### PR TITLE
feat(VoxelGrid): add BTL-OFF rung to V-GRID setting

### DIFF
--- a/lib/BattleScene.lua
+++ b/lib/BattleScene.lua
@@ -379,7 +379,9 @@ function BattleScene.render(state, arena, textures, token)
   -- the seams are what make it read as built rather than photographed. Forced
   -- through the override so the player's own row is never written to.
   local gridWas = VoxelGrid.override
-  VoxelGrid.override = true
+  if VoxelGrid.battleForced() then
+    VoxelGrid.override = true
+  end
   local out = nil
   local ok, err = pcall(function()
     -- its own canvas slot: this renders at the window's pixel size and the

--- a/lib/VoxelGrid.lua
+++ b/lib/VoxelGrid.lua
@@ -46,7 +46,7 @@ VoxelGrid.WIDTH = 1.0
 
 -- where it persists and the rows that cycle it (see ModSetting)
 VoxelGrid.setting = ModSetting.new(VoxelGrid.KEY, VoxelGrid.LABEL,
-                                   { false, true }, { "OFF", "ON" })
+                                   { false, true, "btloff" }, { "OFF", "ON", "BTL-OFF" })
 
 -- A pass that needs the wireframe whatever the player left the row on sets
 -- this for the length of its own draw and puts it back after. nil means
@@ -61,7 +61,13 @@ VoxelGrid.override = nil
 
 function VoxelGrid.enabled()
   if VoxelGrid.override ~= nil then return VoxelGrid.override end
-  return VoxelGrid.setting:get() and true or false
+  local v = VoxelGrid.setting:get()
+  if v == "btloff" then return false end
+  return v and true or false
+end
+
+function VoxelGrid.battleForced()
+  return VoxelGrid.setting:get() ~= "btloff"
 end
 
 function VoxelGrid.set(enabled, game)
@@ -73,7 +79,7 @@ function VoxelGrid.toggle(game)
 end
 
 function VoxelGrid.sync(value)
-  VoxelGrid.setting:sync(value and true or false)
+  VoxelGrid.setting:sync(value)
 end
 
 function VoxelGrid.row()

--- a/main.lua
+++ b/main.lua
@@ -329,7 +329,7 @@ local function stagedBattles()
 end
 
 local SETTINGS = {
-  { VoxelGrid.setting, "One-pixel wireframe along every voxel edge." },
+  { VoxelGrid.setting, "One-pixel wireframe along every voxel edge. BTL-OFF disables it during battles." },
   { WorldCurve.setting,
     "Bend the world down over the horizon, Animal Crossing style." },
   -- `full` marks a row FULL does not take away. FULL owns the diorama's own


### PR DESCRIPTION
Adds a third V-GRID setting option: BTL-OFF.

- OFF keeps the grid disabled, but remains enabled on battles.
- ON forces the grid in the overworld and battles.
- BTL-OFF forces the grid to be OFF in both the overworld and battles.