### PR TITLE
Expose a generic battle presentation compatibility hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **Renderer-neutral battle presentation contract.** Replacement UI mods can
+  claim Battle Art's native `hud`, `text`, or `panels` surfaces through the
+  versioned `battle.presentation.suppress_native.v1` hook. Claims are granular,
+  compose across consumers, and fail open so missing or broken consumers leave
+  native battle rendering intact.
 - **Zero-configuration bring-your-own battle PNGs.** `BATTLE ART: STATIC`
   looks in `front-static` and the selected `back-static/gen1` through `gen5`,
   uses native image dimensions,

--- a/README.md
+++ b/README.md
@@ -81,6 +81,54 @@ menu.
 **3D-BTL** is on by default and is independent of **VOXEL**: battles draw
 on the world whether or not the free-roam camera is pitched over.
 
+## Battle presentation compatibility
+
+Battle Art publishes a renderer-neutral suppression contract for mods that
+replace part of the battle presentation. Consumers wrap the public
+`battle.presentation.suppress_native.v1` hook and may claim only the native
+surface they actually replace:
+
+| surface | Battle Art-owned rendering |
+| --- | --- |
+| `hud` | native battle status HUD glyphs and bars |
+| `text` | native battle dialogue and command/menu layer |
+| `panels` | Battle Art's frosted native HUD backplates |
+
+Each request has this shape:
+
+```lua
+{
+  apiVersion = 1,
+  sourceModId = "BATTLE_ART_VOXEL_FORK",
+  surface = "hud", -- or "text" / "panels"
+}
+```
+
+A consumer returns exactly `true` to suppress that one surface for that draw.
+It must call `next(request)` first and preserve an existing `true` so multiple
+replacement mods compose monotonically:
+
+```lua
+local HOOK = "battle.presentation.suppress_native.v1"
+
+mod.hooks:wrap(HOOK, function(next, request)
+  local claimed = next(request)
+  if claimed == true then return true end
+  if type(request) ~= "table" or request.apiVersion ~= 1 then return false end
+
+  return myBattlePresenterIsActive()
+    and request.sourceModId == "BATTLE_ART_VOXEL_FORK"
+    and request.surface == "hud"
+end)
+```
+
+The source descriptor is available at
+`mod.find("BATTLE_ART_VOXEL_FORK").exports.battlePresentation`. Missing hooks,
+unknown versions or surfaces, disabled consumers, and throwing consumers all
+fail open to Battle Art's native rendering. This contract suppresses drawing
+only; Battle Art remains responsible for battle state and animations, and no
+third-party draw callback is executed.
+
 ## Bring your own battle art
 
 `BATTLE ART: STATIC` is the default. Drop a front PNG named for the species

--- a/lib/BattleHud.lua
+++ b/lib/BattleHud.lua
@@ -255,6 +255,12 @@ end
 -- used, so the contrast is guaranteed rather than hoped for: a dark panel
 -- gets darker under white text, a bright one brighter under black text.
 function BattleHud.panel(rect, box, dark, world)
+  -- FIX: Check if Modern UI Battle mode is active. If yes, abort drawing the frosted glass!
+  local Game = require("src.core.Game")
+  if Game and Game.save and Game.save.options and Game.save.options.modOptions then
+      local mOpts = Game.save.options.modOptions["gen1_modern_ui"]
+      if mOpts and mOpts.battleUiWip == true then return true end
+  end
   -- Fully transparent means absent, not a zero-alpha draw. Avoid touching the
   -- destination canvas or blend state at all; premultiplied driver paths can
   -- otherwise retain RGB from a transparent sample as a dim veil.
@@ -445,6 +451,23 @@ end
 local hudLayer = nil
 
 function BattleHud.layerTexture(w, h, dark, fn, inverted)
+  -- FIX: Check if Modern UI Battle mode is active. If yes, abort drawing classic text!
+  local Game = require("src.core.Game")
+  if Game and Game.save and Game.save.options and Game.save.options.modOptions then
+      local mOpts = Game.save.options.modOptions["gen1_modern_ui"]
+      if mOpts and mOpts.battleUiWip == true then
+          if not hudLayer or hudLayer:getWidth() ~= w or hudLayer:getHeight() ~= h then
+              hudLayer = canvasOf(w, h, "nearest")
+          end
+          local g = love.graphics
+          local prev = g.getCanvas()
+          g.setCanvas(hudLayer)
+          g.clear(0, 0, 0, 0)
+          if prev then g.setCanvas(prev) else g.setCanvas() end
+          return hudLayer
+      end
+  end
+
   if not hudLayer or hudLayer:getWidth() ~= w or hudLayer:getHeight() ~= h then
     hudLayer = canvasOf(w, h, "nearest")
     if not hudLayer then return nil end

--- a/lib/BattleHud.lua
+++ b/lib/BattleHud.lua
@@ -25,6 +25,8 @@
 -- the mod namespace (see main.lua): V.require loads a sibling module
 local V = ...
 
+local BattlePresentation = V.require("BattlePresentation")
+
 local BattleHud = {}
 
 -- How solid the frost is over the world behind it, and how far the tint
@@ -255,12 +257,7 @@ end
 -- used, so the contrast is guaranteed rather than hoped for: a dark panel
 -- gets darker under white text, a bright one brighter under black text.
 function BattleHud.panel(rect, box, dark, world)
-  -- FIX: Check if Modern UI Battle mode is active. If yes, abort drawing the frosted glass!
-  local Game = require("src.core.Game")
-  if Game and Game.save and Game.save.options and Game.save.options.modOptions then
-      local mOpts = Game.save.options.modOptions["gen1_modern_ui"]
-      if mOpts and mOpts.battleUiWip == true then return true end
-  end
+  if BattlePresentation.suppressed("panels") then return true end
   -- Fully transparent means absent, not a zero-alpha draw. Avoid touching the
   -- destination canvas or blend state at all; premultiplied driver paths can
   -- otherwise retain RGB from a transparent sample as a dim veil.
@@ -451,27 +448,11 @@ end
 local hudLayer = nil
 
 function BattleHud.layerTexture(w, h, dark, fn, inverted)
-  -- FIX: Check if Modern UI Battle mode is active. If yes, abort drawing classic text!
-  local Game = require("src.core.Game")
-  if Game and Game.save and Game.save.options and Game.save.options.modOptions then
-      local mOpts = Game.save.options.modOptions["gen1_modern_ui"]
-      if mOpts and mOpts.battleUiWip == true then
-          if not hudLayer or hudLayer:getWidth() ~= w or hudLayer:getHeight() ~= h then
-              hudLayer = canvasOf(w, h, "nearest")
-          end
-          local g = love.graphics
-          local prev = g.getCanvas()
-          g.setCanvas(hudLayer)
-          g.clear(0, 0, 0, 0)
-          if prev then g.setCanvas(prev) else g.setCanvas() end
-          return hudLayer
-      end
-  end
-
   if not hudLayer or hudLayer:getWidth() ~= w or hudLayer:getHeight() ~= h then
     hudLayer = canvasOf(w, h, "nearest")
     if not hudLayer then return nil end
   end
+  local suppressHud = BattlePresentation.suppressed("hud")
   local g = love.graphics
   local prevCanvas = g.getCanvas()
   local prevBlend, prevAlpha = g.getBlendMode()
@@ -483,7 +464,9 @@ function BattleHud.layerTexture(w, h, dark, fn, inverted)
     -- flipGlyphs renders fn into its own scratch layer and composites the
     -- whitened result into whatever is bound, which is this canvas. `inverted`
     -- (the WHITE arena fill) keeps the glyphs black with a white drop-shadow.
-    if dark then BattleHud.flipGlyphs(w, h, fn, inverted) else fn() end
+    if not suppressHud then
+      if dark then BattleHud.flipGlyphs(w, h, fn, inverted) else fn() end
+    end
   end)
   if prevCanvas then g.setCanvas(prevCanvas) else g.setCanvas() end
   g.setBlendMode(prevBlend or "alpha", prevAlpha)

--- a/lib/BattlePresentation.lua
+++ b/lib/BattlePresentation.lua
@@ -1,0 +1,61 @@
+-- Public, renderer-neutral compatibility seam for battle UI replacements.
+--
+-- A replacement UI may claim one native presentation surface at a time by
+-- wrapping SUPPRESS_HOOK and returning exactly true.  Battle Art keeps all
+-- gameplay, animation, and unclaimed rendering paths intact.
+
+local Runtime = require("src.mods.Runtime")
+
+local BattlePresentation = {}
+
+BattlePresentation.API_VERSION = 1
+BattlePresentation.SUPPRESS_HOOK = "battle.presentation.suppress_native.v1"
+BattlePresentation.SOURCE_MOD_ID = "BATTLE_ART_VOXEL_FORK"
+BattlePresentation.SURFACES = {
+  hud = "hud",
+  text = "text",
+  panels = "panels",
+}
+
+local validSurface = {
+  hud = true,
+  text = true,
+  panels = true,
+}
+
+local function unclaimed()
+  return false
+end
+
+function BattlePresentation.suppressed(surface)
+  if not validSurface[surface] then return false end
+  if not Runtime.wantsHook(BattlePresentation.SUPPRESS_HOOK) then return false end
+
+  local request = {
+    apiVersion = BattlePresentation.API_VERSION,
+    sourceModId = BattlePresentation.SOURCE_MOD_ID,
+    surface = surface,
+  }
+  local ok, claimed = pcall(
+    Runtime.call,
+    BattlePresentation.SUPPRESS_HOOK,
+    unclaimed,
+    request
+  )
+  return ok and claimed == true
+end
+
+function BattlePresentation.export()
+  return {
+    apiVersion = BattlePresentation.API_VERSION,
+    suppressHook = BattlePresentation.SUPPRESS_HOOK,
+    sourceModId = BattlePresentation.SOURCE_MOD_ID,
+    surfaces = {
+      hud = BattlePresentation.SURFACES.hud,
+      text = BattlePresentation.SURFACES.text,
+      panels = BattlePresentation.SURFACES.panels,
+    },
+  }
+end
+
+return BattlePresentation

--- a/lib/OverworldBattle.lua
+++ b/lib/OverworldBattle.lua
@@ -44,6 +44,7 @@ local BattleCam = V.require("BattleCam")
 local BattleScene = V.require("BattleScene")
 local BattleDOF = V.require("BattleDOF")
 local BattleHud = V.require("BattleHud")
+local BattlePresentation = V.require("BattlePresentation")
 local UiBackplates = V.require("UiBackplates")
 local BattlePics = V.require("BattlePics")
 local BattleArt = V.require("BattleArt")
@@ -1259,6 +1260,7 @@ function OverworldBattle.install()
   local innerText = BattleState.drawTextArea
   function BattleState:drawTextArea()
     if not self.dramaticShapeShot then return innerText(self) end
+    if BattlePresentation.suppressed("text") then return end
     if isIOS() then return innerText(self) end
     local battle = self
     -- Every battle box -- the dialogue, the FIGHT/ITEM/RUN menu and the
@@ -1367,6 +1369,7 @@ function OverworldBattle.install()
   -- only an exactly-black set is remapped.
   innerHUDs = BattleState.drawHUDs
   function BattleState:drawHUDs(slide)
+    if self.dramaticShapeShot and BattlePresentation.suppressed("hud") then return end
     -- Normally the HUDs have already been drawn this frame, snapped out to the
     -- window's edges and composited into the world image (snapHUDs). Drawing
     -- them here as well would show each block twice, once in each place.

--- a/main.lua
+++ b/main.lua
@@ -1049,3 +1049,27 @@ mod.exports.version = "1.7.6"
 -- exposed so a companion mod can pin its own tiles' shapes or read the
 -- camera without reaching into this mod's file layout
 mod.exports.lib = V
+
+-- =====================================================================
+-- FIX: SILENCE VOXEL HUD WHEN MODERN UI BATTLE PRESENTER IS ACTIVE
+-- This wraps the Voxel Mod's own HUD hooks to prevent them from drawing
+-- the classic floating lifebars when Modern UI is handling the battle.
+-- =====================================================================
+local okBS, BattleState = pcall(require, "src.battle.BattleState")
+if okBS and BattleState then
+    local orig_drawHUDs = BattleState.drawHUDs
+    BattleState.drawHUDs = function(self, ...)
+        local modernMod = mod.find and mod.find("gen1_modern_ui")
+        local wipOn = modernMod and modernMod.options and modernMod.options:get("battleUiWip")
+        if wipOn then return end
+        if orig_drawHUDs then return orig_drawHUDs(self, ...) end
+    end
+
+    local orig_drawTextArea = BattleState.drawTextArea
+    BattleState.drawTextArea = function(self, ...)
+        local modernMod = mod.find and mod.find("gen1_modern_ui")
+        local wipOn = modernMod and modernMod.options and modernMod.options:get("battleUiWip")
+        if wipOn then return end
+        if orig_drawTextArea then return orig_drawTextArea(self, ...) end
+    end
+end

--- a/main.lua
+++ b/main.lua
@@ -85,6 +85,7 @@ local ChunkMesher = V.require("ChunkMesher")
 local VoxelGrid = V.require("VoxelGrid")
 local WorldCurve = V.require("WorldCurve")
 local OverworldBattle = V.require("OverworldBattle")
+local BattlePresentation = V.require("BattlePresentation")
 local BattleArt = V.require("BattleArt")
 local UiBackplates = V.require("UiBackplates")
 local BattleExit = V.require("BattleExit")
@@ -1046,30 +1047,7 @@ mod.hooks:wrap("world.tod", function(next, tod, ctx)
 end)
 
 mod.exports.version = "1.7.6"
+mod.exports.battlePresentation = BattlePresentation.export()
 -- exposed so a companion mod can pin its own tiles' shapes or read the
 -- camera without reaching into this mod's file layout
 mod.exports.lib = V
-
--- =====================================================================
--- FIX: SILENCE VOXEL HUD WHEN MODERN UI BATTLE PRESENTER IS ACTIVE
--- This wraps the Voxel Mod's own HUD hooks to prevent them from drawing
--- the classic floating lifebars when Modern UI is handling the battle.
--- =====================================================================
-local okBS, BattleState = pcall(require, "src.battle.BattleState")
-if okBS and BattleState then
-    local orig_drawHUDs = BattleState.drawHUDs
-    BattleState.drawHUDs = function(self, ...)
-        local modernMod = mod.find and mod.find("gen1_modern_ui")
-        local wipOn = modernMod and modernMod.options and modernMod.options:get("battleUiWip")
-        if wipOn then return end
-        if orig_drawHUDs then return orig_drawHUDs(self, ...) end
-    end
-
-    local orig_drawTextArea = BattleState.drawTextArea
-    BattleState.drawTextArea = function(self, ...)
-        local modernMod = mod.find and mod.find("gen1_modern_ui")
-        local wipOn = modernMod and modernMod.options and modernMod.options:get("battleUiWip")
-        if wipOn then return end
-        if orig_drawTextArea then return orig_drawTextArea(self, ...) end
-    end
-end


### PR DESCRIPTION
## Summary

- Add the provider-neutral `battle.presentation.suppress_native.v1` hook.
- Expose `mod.exports.battlePresentation` for feature discovery.
- Remove the hardcoded Gen1 Modern UI monkey patch and direct option reads.
- Fail open so native battle surfaces remain visible when hooks are absent or error.

## Verification

- Focused contract test passed locally.
- Relevant Lua syntax checks passed.
- Staged whitespace checks passed.

The local test changes used for verification are intentionally not included in this pull request.