### PR TITLE
Restore aligned textbox fill modes and preserve black battle background

### DIFF
--- a/lib/OverworldBattle.lua
+++ b/lib/OverworldBattle.lua
@@ -45,6 +45,7 @@ local BattleScene = V.require("BattleScene")
 local BattleDOF = V.require("BattleDOF")
 local BattleHud = V.require("BattleHud")
 local UiBackplates = V.require("UiBackplates")
+local TextboxStyle = V.require("TextboxStyle")
 local BattlePics = V.require("BattlePics")
 local BattleArt = V.require("BattleArt")
 local AnimatedBattleArt = V.require("AnimatedBattleArt")
@@ -733,41 +734,33 @@ local function withoutBackgroundFill(battle, fn)
   if not ok then error(err, 0) end
 end
 
--- ------- the box, without its paper
+-- ------- the battle box's own paper
 --
--- Font.drawBox is a white fill and then six border glyphs, and the fill is the
--- opaque slab the frosted panel underneath is there to replace. So for the
--- length of one drawTextArea the white fills are dropped and everything else
--- -- the border, the text, the cursor, the down arrow -- draws exactly as it
--- always did, over the glass instead of over paper.
---
--- Every fill drawTextArea issues is one of those: the box's own, and the two
--- eight-pixel cells MoveSelectionMenu wipes back to box white before it writes
--- the border glyphs that hardware would have overwritten. Both are opaque
--- white, both are paper, and both go.
---
--- The same shim shape as withoutBackgroundFill above, and scoped as tightly:
--- installed around a single call, removed on the way out including on error,
--- never live outside a battle frame this mode is drawing.
--- WHITE arena fill: paint the box background (and anything else the engine
--- fills inside the text-area draw) opaque white, so the engine's coloured BG
--- palette -- orange on the intro flash, grey once the mons appear -- cannot
--- show through. The text, border and cursor are drawn as glyphs, not fills,
--- so they survive untouched. (Forcing the palette itself crashed PaletteFX,
--- so we whiten at draw time instead.)
-local function whiteBoxFill(battle, fn)
-  local g = love.graphics
-  local rectangle = g.rectangle
-  g.rectangle = function(mode, ...)
-    if mode == "fill" then
-      g.setColor(1, 1, 1, 1)
-    end
-    return rectangle(mode, ...)
+-- Font.drawBox issues its fill, border and ink into the engine's 160x144 UI
+-- canvas. Styling the opaque-white fills inside that exact draw keeps the
+-- paper and its corners together under both BATTLE SIZE FIXED's integer scale
+-- and FILL's fractional scale. v1.68 drew a second slab into shot.canvas using
+-- shot.scale, which is why HALF only lined up in FIXED.
+local function drawStyledTextArea(battle, draw)
+  local graphics = love.graphics
+  local style = UiBackplates.textboxFillStyle()
+  local whiteInk = UiBackplates.textboxUsesWhiteInk()
+  local drawEngineText = function() draw(battle) end
+
+  -- Preserve the latest build's WHITE rendering, including its black-ink
+  -- treatment. Dark and paperless modes composite their paper separately so
+  -- the white-ink shader cannot mistake a black slab for glyphs.
+  if not whiteInk then
+    return BattleHud.flipGlyphs(BattleScene.GB_W, BattleScene.GB_H, function()
+      TextboxStyle.withFill(graphics, style, drawEngineText)
+    end, true)
   end
-  local ok, err = pcall(fn, battle)
-  g.rectangle = rectangle
-  g.setColor(1, 1, 1, 1)
-  if not ok then error(err, 0) end
+
+  return TextboxStyle.withWhiteInk(graphics, style, drawEngineText,
+    function(drawInk)
+      BattleHud.flipGlyphs(BattleScene.GB_W, BattleScene.GB_H,
+                           drawInk, false)
+    end)
 end
 
 -- ------- the hour's light, on a pic that is not geometry
@@ -1260,15 +1253,7 @@ function OverworldBattle.install()
   function BattleState:drawTextArea()
     if not self.dramaticShapeShot then return innerText(self) end
     if isIOS() then return innerText(self) end
-    local battle = self
-    -- Every battle box -- the dialogue, the FIGHT/ITEM/RUN menu and the
-    -- move-select / type panels -- is drawn as an OPAQUE WHITE panel with
-    -- BLACK ink, the same as the overworld / trainer-intro textbox. Black ink
-    -- sits on white (never white-on-white), so the words always read. This is
-    -- the one predictable backplate, so TEXTBOX FILL was dropped: the box is
-    -- simply always white.
-    BattleHud.flipGlyphs(BattleScene.GB_W, BattleScene.GB_H,
-                         function() whiteBoxFill(battle, innerText) end, true)
+    return drawStyledTextArea(self, innerText)
   end
 
   local innerAnim = BattleState.drawAnimLayer

--- a/lib/TextboxStyle.lua
+++ b/lib/TextboxStyle.lua
@@ -1,0 +1,152 @@
+-- Battle textbox paper replacement.
+--
+-- The engine draws every battle box into its 160x144 UI canvas with an
+-- opaque-white rectangle followed by border and text glyphs. Recolouring that
+-- exact rectangle keeps the paper and its corners in one coordinate space;
+-- Renderer can then present the whole canvas with either BATTLE SIZE FIXED's
+-- integer scale or FILL's fractional scale without the two drifting apart.
+
+local TextboxStyle = {}
+
+local unpackValues = table.unpack or unpack
+
+local function pack(...)
+  return { n = select("#", ...), ... }
+end
+
+local function setBlend(graphics, mode, alphaMode)
+  if alphaMode ~= nil then
+    graphics.setBlendMode(mode, alphaMode)
+  else
+    graphics.setBlendMode(mode)
+  end
+end
+
+local function setCanvas(graphics, canvas)
+  if canvas ~= nil then
+    graphics.setCanvas(canvas)
+  else
+    graphics.setCanvas()
+  end
+end
+
+local function restoreState(graphics, color, blend)
+  graphics.setColor(color[1], color[2], color[3], color[4])
+  setBlend(graphics, blend[1], blend[2])
+end
+
+-- Run draw while replacing only opaque-white fill rectangles.
+--
+-- style = { r, g, b, a } draws the engine-owned rectangle with that colour.
+-- style = nil suppresses the paper while leaving borders, text and coloured
+-- effects alone.
+--
+-- Styled fills use replace blending. Font.drawBox can issue overlapping boxes
+-- for the action menu and TYPE/PP panel; normal alpha blending would stack two
+-- HALF fills into a darker seam, while replace leaves every covered pixel at
+-- the requested opacity.
+function TextboxStyle.withFill(graphics, style, draw, ...)
+  local rectangle = graphics.rectangle
+  local initialColor = pack(graphics.getColor())
+  local initialBlend = pack(graphics.getBlendMode())
+  local args = pack(...)
+
+  graphics.rectangle = function(mode, x, y, w, h, ...)
+    if mode == "fill" then
+      local r, g, b, a = graphics.getColor()
+      if r > 0.99 and g > 0.99 and b > 0.99 and a > 0.99 then
+        if style == nil then return end
+
+        local color = pack(r, g, b, a)
+        local blend = pack(graphics.getBlendMode())
+        setBlend(graphics, "replace")
+        graphics.setColor(style[1], style[2], style[3], style[4])
+        local result = pack(pcall(rectangle, mode, x, y, w, h, ...))
+        restoreState(graphics, color, blend)
+        if not result[1] then error(result[2], 0) end
+        return unpackValues(result, 2, result.n)
+      end
+    end
+    return rectangle(mode, x, y, w, h, ...)
+  end
+
+  local result = pack(pcall(draw, unpackValues(args, 1, args.n)))
+  graphics.rectangle = rectangle
+  if not result[1] then
+    restoreState(graphics, initialColor, initialBlend)
+    error(result[2], 0)
+  end
+  return unpackValues(result, 2, result.n)
+end
+
+-- Draw the stateful engine text area once, into the glyph-flip scratch layer.
+-- Opaque-white paper fills are mirrored to the destination canvas with the
+-- selected style, then replaced by transparency in the scratch layer. The
+-- transparent replacement matters for overlapping Font.drawBox calls and the
+-- move menu's 8x8 tile wipes: those fills intentionally erase border pixels
+-- drawn earlier in the same pass.
+function TextboxStyle.withWhiteInk(graphics, style, draw, flipInk)
+  local rectangle = graphics.rectangle
+  local destination = graphics.getCanvas()
+  local initialColor = pack(graphics.getColor())
+  local initialBlend = pack(graphics.getBlendMode())
+  local initialCanvas = destination
+
+  local function drawInk()
+    graphics.rectangle = function(mode, x, y, w, h, ...)
+      if mode == "fill" then
+        local r, g, b, a = graphics.getColor()
+        if r > 0.99 and g > 0.99 and b > 0.99 and a > 0.99 then
+          local inkCanvas = graphics.getCanvas()
+
+          -- flipGlyphs runs its callback directly when its shader or scratch
+          -- canvas is unavailable. Keep the engine's safe opaque-white box in
+          -- that fallback instead of producing unreadable dark-on-dark ink.
+          if inkCanvas == destination then
+            return rectangle(mode, x, y, w, h, ...)
+          end
+
+          local color = pack(r, g, b, a)
+          local blend = pack(graphics.getBlendMode())
+          local rectangleArgs = pack(...)
+          local result = pack(pcall(function()
+            if style ~= nil then
+              setCanvas(graphics, destination)
+              setBlend(graphics, "replace")
+              graphics.setColor(style[1], style[2], style[3], style[4])
+              rectangle(mode, x, y, w, h,
+                        unpackValues(rectangleArgs, 1, rectangleArgs.n))
+            end
+
+            setCanvas(graphics, inkCanvas)
+            setBlend(graphics, "replace")
+            graphics.setColor(0, 0, 0, 0)
+            return rectangle(mode, x, y, w, h,
+                             unpackValues(rectangleArgs, 1, rectangleArgs.n))
+          end))
+
+          -- Restore the ink target and draw state even if either rectangle
+          -- failed, so the caller can safely unwind its own scratch pass.
+          setCanvas(graphics, inkCanvas)
+          restoreState(graphics, color, blend)
+          if not result[1] then error(result[2], 0) end
+          return unpackValues(result, 2, result.n)
+        end
+      end
+      return rectangle(mode, x, y, w, h, ...)
+    end
+
+    return draw()
+  end
+
+  local result = pack(pcall(flipInk, drawInk))
+  graphics.rectangle = rectangle
+  if not result[1] then
+    setCanvas(graphics, initialCanvas)
+    restoreState(graphics, initialColor, initialBlend)
+    error(result[2], 0)
+  end
+  return unpackValues(result, 2, result.n)
+end
+
+return TextboxStyle

--- a/lib/UiBackplates.lua
+++ b/lib/UiBackplates.lua
@@ -12,10 +12,10 @@
 --      full voxel one. Works with SHADED or UNLIT sprites (UNLIT just keeps
 --      the cards brighter on white).
 --
---   A) TEXTBOX FILL was dropped: the battle box is now ALWAYS an opaque white
---      panel with black ink (the same as the overworld / trainer-intro
---      textbox), so there is no HALF / OFF toggle to manage. See
---      BattleState:drawTextArea in OverworldBattle.lua.
+--   A) TEXTBOX FILL  WHITE / HALF / OFF
+--      Controls the engine's own battle-box paper at draw time. Because the
+--      fill, border and ink stay in the same 160x144 UI canvas, BATTLE SIZE
+--      FIXED and FILL transform them together and the corners stay aligned.
 
 -- Each is a ModSetting: it gets an OPTIONS-menu row and a mod-manager schema
 -- for free, and persists under options.modOptions.BATTLE_ART_VOXEL_FORK like the
@@ -56,11 +56,28 @@ function UiBackplates.arenaWhite()
   return UiBackplates.arenaFill:get() == "WHITE"
 end
 
--- ------- the backplate is applied in OverworldBattle.drawTextArea
---
--- The battle box is ALWAYS drawn as an opaque white panel with black ink by
--- BattleState:drawTextArea (see whiteBoxFill there). TEXTBOX FILL was dropped
--- because the white panel is the one predictable backplate that matches the
--- overworld / trainer-intro textbox and never produces white-on-white.
+-- ------- A) TEXTBOX FILL -------
+
+UiBackplates.textboxFill = ModSetting.new("textboxFill", "TEXTBOX FILL",
+  { "WHITE", "HALF", "OFF" },
+  { "WHITE", "HALF", "OFF" })
+
+-- ARENA FILL: WHITE keeps the latest-build presentation: black ink on opaque
+-- paper. On the 3D arena, the player's explicit textbox choice owns the box.
+function UiBackplates.textboxMode()
+  if UiBackplates.arenaWhite() then return "WHITE" end
+  return UiBackplates.textboxFill:get()
+end
+
+function UiBackplates.textboxFillStyle()
+  local mode = UiBackplates.textboxMode()
+  if mode == "WHITE" then return { 1, 1, 1, 1 } end
+  if mode == "HALF" then return { 0, 0, 0, 0.5 } end
+  return nil
+end
+
+function UiBackplates.textboxUsesWhiteInk()
+  return UiBackplates.textboxMode() ~= "WHITE"
+end
 
 return UiBackplates

--- a/lib/UiBackplates.lua
+++ b/lib/UiBackplates.lua
@@ -12,7 +12,7 @@
 --      full voxel one. Works with SHADED or UNLIT sprites (UNLIT just keeps
 --      the cards brighter on white).
 --
---   A) TEXTBOX FILL  WHITE / HALF / OFF
+--   A) TEXTBOX FILL  WHITE / HALF / BLACK / OFF
 --      Controls the engine's own battle-box paper at draw time. Because the
 --      fill, border and ink stay in the same 160x144 UI canvas, BATTLE SIZE
 --      FIXED and FILL transform them together and the corners stay aligned.
@@ -59,8 +59,8 @@ end
 -- ------- A) TEXTBOX FILL -------
 
 UiBackplates.textboxFill = ModSetting.new("textboxFill", "TEXTBOX FILL",
-  { "WHITE", "HALF", "OFF" },
-  { "WHITE", "HALF", "OFF" })
+  { "WHITE", "HALF", "BLACK", "OFF" },
+  { "WHITE", "HALF", "BLACK", "OFF" })
 
 -- ARENA FILL: WHITE keeps the latest-build presentation: black ink on opaque
 -- paper. On the 3D arena, the player's explicit textbox choice owns the box.
@@ -73,6 +73,7 @@ function UiBackplates.textboxFillStyle()
   local mode = UiBackplates.textboxMode()
   if mode == "WHITE" then return { 1, 1, 1, 1 } end
   if mode == "HALF" then return { 0, 0, 0, 0.5 } end
+  if mode == "BLACK" then return { 0, 0, 0, 1 } end
   return nil
 end
 

--- a/main.lua
+++ b/main.lua
@@ -101,6 +101,18 @@ local FreeMove = V.require("FreeMove")
 -- every other mod's namespace.
 local applyFull
 
+-- WORLD depends on the engine's flat battle compositing the frozen overworld
+-- behind its UI. A staged 3D battle owns that space instead, so WORLD cannot
+-- be represented and falls back to WHITE. BLACK is an ordinary opaque
+-- letterbox and remains a valid explicit choice.
+local function ensureBattleBgCompatible(opts)
+  if opts and opts.battleBg == "world" then
+    opts.battleBg = "white"
+    return true
+  end
+  return false
+end
+
 -- The last VOID FILL the terrain was meshed under; see the update hook.
 -- The scene canvas's size, in FRAMEBUFFER PIXELS.
 --
@@ -167,16 +179,14 @@ mod.content.render_pipelines:register("voxel", {
   -- pump slice -- so stepping out of a door lands on terrain that is
   -- already there instead of a flat flash.
   update = function(dt, level)
-    -- BATTLE BG must be WHITE whenever this mode is on: WORLD is only valid
-    -- for the engine's flat 2D battle and composites as broken dark bars with
-    -- the 3D diorama (there is no "old system" to show through). Force it at
-    -- the top of every update tick -- not gated on FULL -- so a boot that
-    -- starts already at FULL, and the first battle before any transition, are
-    -- both covered. Persists on change only, never every frame.
+    -- WORLD is only valid for the engine's flat 2D battle and composites as
+    -- broken bars with the 3D diorama (there is no frozen overworld to show
+    -- through). Correct that incompatible mode at the top of every update
+    -- tick -- not gated on FULL -- while preserving the valid BLACK option.
+    -- Persists on change only, never every frame.
     local Game = require("src.core.Game")
     local o = Game.save and Game.save.options
-    if o and o.battleBg ~= "white" then
-      o.battleBg = "white"
+    if ensureBattleBgCompatible(o) then
       if Game.writeOptions then pcall(Game.writeOptions, Game) end
     end
     -- FULL is a preset, so it is applied ON THE PRESS rather than held every
@@ -348,9 +358,9 @@ applyFull = function(level)
   -- BATTLE BG: WORLD leaves the frozen overworld showing through a battle and
   -- is only valid for the engine's flat 2D battle; with the 3D diorama there
   -- is no "old system" to show through, so WORLD composites as broken dark
-  -- bars. Force WHITE (the opaque paper field) for every user, since the mode
-  -- cannot render the world-behind-battle path at all.
-  opts.battleBg = "white"
+  -- bars. Correct WORLD to WHITE while preserving BLACK, which is already an
+  -- opaque field and needs no world-behind-battle path.
+  ensureBattleBgCompatible(opts)
   -- and the sky on the clock on the wall: FULL pins DAYTIME to SYNC. Unlike
   -- the rest of the preset this one IS held, not just set -- the row is off
   -- the menu while FULL owns it (the rows hook below), so a value changed

--- a/main.lua
+++ b/main.lua
@@ -488,9 +488,14 @@ local SETTINGS = {
     .. "LIGHT: UNLIT so the sprites stay flat and true-colour with no night "
     .. "tint (as in the traditional games).",
     when = function() return stagedBattles() end, full = true },
-  -- The battle box is ALWAYS an opaque white panel with black ink (see
-  -- BattleState:drawTextArea), so TEXTBOX FILL was dropped -- no option row.
-  -- Marked `full` for the opposite reason the battle rows are: this is not a
+  { UiBackplates.textboxFill,
+    "WHITE keeps the latest build's opaque paper. HALF draws translucent "
+    .. "black, and OFF removes only the paper. "
+    .. "Dark and transparent modes use white ink with a one-pixel shadow. "
+    .. "The fill is drawn with the engine textbox so BATTLE SIZE FIXED and "
+    .. "FILL stay aligned. ARENA FILL: WHITE overrides this row to WHITE.",
+    when = function() return stagedBattles() end, full = true },
+  -- AA is marked `full` for the opposite reason the battle rows are: this is not a
   -- knob on the look at all, it is what the look COSTS. FULL is a preset for
   -- the diorama, not a licence to spend four times the fill rate on the
   -- machine it happens to be running on, so it neither sets this nor takes

--- a/main.lua
+++ b/main.lua
@@ -490,7 +490,7 @@ local SETTINGS = {
     when = function() return stagedBattles() end, full = true },
   { UiBackplates.textboxFill,
     "WHITE keeps the latest build's opaque paper. HALF draws translucent "
-    .. "black, and OFF removes only the paper. "
+    .. "black, BLACK draws opaque black, and OFF removes only the paper. "
     .. "Dark and transparent modes use white ink with a one-pixel shadow. "
     .. "The fill is drawn with the engine textbox so BATTLE SIZE FIXED and "
     .. "FILL stay aligned. ARENA FILL: WHITE overrides this row to WHITE.",

--- a/tests/textbox_battle_state_test.lua
+++ b/tests/textbox_battle_state_test.lua
@@ -1,0 +1,87 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+require("tests.modkit")
+
+local BattleState = require("src.battle.BattleState")
+local modPath = os.getenv("DS_MOD_PATH") or "mods/BATTLE_ART_VOXEL_FORK"
+local TextboxStyle = assert(loadfile(modPath .. "/lib/TextboxStyle.lua"))()
+
+local function eq(actual, expected, label)
+  if actual ~= expected then
+    error(("%s: expected %s, got %s"):format(
+      label, tostring(expected), tostring(actual)), 0)
+  end
+end
+
+local graphics = love.graphics
+local originalRectangle = graphics.rectangle
+
+local function drawStyled(state)
+  local calls = {}
+  graphics.rectangle = function(mode, x, y, w, h)
+    local r, g, b, a = graphics.getColor()
+    local blend = graphics.getBlendMode()
+    calls[#calls + 1] = {
+      mode = mode, x = x, y = y, w = w, h = h,
+      color = { r, g, b, a }, blend = blend,
+      canvas = graphics.getCanvas(),
+    }
+  end
+
+  graphics.setCanvas("ui")
+  graphics.setColor(0, 0, 0, 1)
+  TextboxStyle.withWhiteInk(graphics, { 0, 0, 0, 0.5 }, function()
+    BattleState.drawTextArea(state)
+  end, function(drawInk)
+    local destination = graphics.getCanvas()
+    graphics.setCanvas("ink")
+    drawInk()
+    graphics.setCanvas(destination)
+  end)
+
+  graphics.rectangle = originalRectangle
+  return calls
+end
+
+-- BattleState:drawTextArea mutates scrollPx. The styling wrapper must never
+-- call it twice just to separate paper from ink.
+local messages = {
+  phase = "messages", current = true, scrollPx = 8,
+  shown = {}, frame = 0,
+}
+drawStyled(messages)
+eq(messages.scrollPx, 6, "real BattleState scroll advances once")
+
+-- The real move menu has three overlapping boxes plus two 8x8 white tile
+-- wipes. Every white fill must both paint the UI paper and clear the same
+-- rectangle from the ink layer so old border fragments cannot survive.
+local moveSelect = {
+  phase = "moveSelect", moveIndex = 1,
+  player = { curMoves = {} }, data = { moves = {} },
+}
+local calls = drawStyled(moveSelect)
+local paper, clears = 0, 0
+local wipedLeft, wipedRight = false, false
+for _, call in ipairs(calls) do
+  if call.mode == "fill" and call.canvas == "ui" then
+    paper = paper + 1
+    eq(call.color[4], 0.5, "real move-menu paper keeps HALF alpha")
+    eq(call.blend, "replace", "real overlapping paper uses replace blend")
+  elseif call.mode == "fill" and call.canvas == "ink" then
+    clears = clears + 1
+    eq(call.color[4], 0, "real move-menu paper clears the ink layer")
+    eq(call.blend, "replace", "real ink clear uses replace blend")
+    if call.x == 32 and call.y == 96 and call.w == 8 and call.h == 8 then
+      wipedLeft = true
+    elseif call.x == 80 and call.y == 96 and call.w == 8 and call.h == 8 then
+      wipedRight = true
+    end
+  end
+end
+
+eq(paper, 5, "all real move-menu paper fills reach the UI canvas")
+eq(clears, 5, "all real move-menu paper fills clear the ink canvas")
+eq(wipedLeft, true, "real left 8x8 move-menu wipe is preserved")
+eq(wipedRight, true, "real right 8x8 move-menu wipe is preserved")
+
+print("textbox_battle_state_test: PASS")

--- a/tests/textbox_mod_integration_test.lua
+++ b/tests/textbox_mod_integration_test.lua
@@ -1,0 +1,39 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.modkit")
+local Pipelines = require("src.render.Pipelines")
+local Runtime = require("src.mods.Runtime")
+local Data = T.fixtures.load()
+local modPath = os.getenv("DS_MOD_PATH") or "mods/BATTLE_ART_VOXEL_FORK"
+local run = T.sdk.loadMod(modPath, { data = Data })
+
+local function check(condition, message)
+  if not condition then error(message, 0) end
+end
+
+check(#run.errors == 0,
+  "mod failed to load: " .. table.concat(run.errors, "; "))
+Pipelines.install(Data)
+
+local VoxelState = run.loader.exports.BATTLE_ART_VOXEL_FORK.lib.require("VoxelState")
+Pipelines.setLevel("voxel", VoxelState.FULL_LEVEL)
+
+local rows = Runtime.call("ui.options.rows", function(_, offered) return offered end,
+  { data = Data },
+  { { id = "pipeline:voxel" }, { id = "pipeline:tiltshift" } })
+
+local textboxRow
+for _, row in ipairs(rows) do
+  if row.id == "BATTLE_ART_VOXEL_FORK:textboxFill" then
+    textboxRow = row
+    break
+  end
+end
+
+check(textboxRow ~= nil,
+  "TEXTBOX FILL must remain exposed while VOXEL is FULL")
+check(textboxRow.value() == "WHITE",
+  "TEXTBOX FILL must preserve the latest build's WHITE default")
+
+run.release()
+print("textbox_mod_integration_test: PASS")

--- a/tests/textbox_mod_integration_test.lua
+++ b/tests/textbox_mod_integration_test.lua
@@ -3,6 +3,7 @@ package.path = "./?.lua;./?/init.lua;" .. package.path
 local T = require("tests.modkit")
 local Pipelines = require("src.render.Pipelines")
 local Runtime = require("src.mods.Runtime")
+local Game = require("src.core.Game")
 local Data = T.fixtures.load()
 local modPath = os.getenv("DS_MOD_PATH") or "mods/BATTLE_ART_VOXEL_FORK"
 local run = T.sdk.loadMod(modPath, { data = Data })
@@ -34,6 +35,40 @@ check(textboxRow ~= nil,
   "TEXTBOX FILL must remain exposed while VOXEL is FULL")
 check(textboxRow.value() == "WHITE",
   "TEXTBOX FILL must preserve the latest build's WHITE default")
+
+-- The 3D battle cannot composite WORLD's frozen-overworld path, but BLACK is
+-- an ordinary opaque letterbox and remains valid. The voxel update must not
+-- rewrite a deliberate BLACK choice on every frame.
+local previousSave = Game.save
+local previousWriteOptions = Game.writeOptions
+local writes = 0
+Game.save = { options = { battleBg = "black" } }
+Game.writeOptions = function() writes = writes + 1 end
+
+Pipelines.setLevel("voxel", 3)
+Pipelines.update(0)
+check(Game.save.options.battleBg == "black",
+  "voxel update must preserve BATTLE BG BLACK")
+check(writes == 0,
+  "preserving BATTLE BG BLACK must not rewrite options")
+
+Pipelines.setLevel("voxel", VoxelState.FULL_LEVEL)
+Pipelines.update(0)
+check(Game.save.options.battleBg == "black",
+  "entering VOXEL FULL must preserve BATTLE BG BLACK")
+
+-- Ignore the writes made by the rest of the FULL preset; this assertion is
+-- specifically about the compatibility correction on subsequent frames.
+writes = 0
+Game.save.options.battleBg = "world"
+Pipelines.update(0)
+check(Game.save.options.battleBg == "white",
+  "voxel update must replace incompatible BATTLE BG WORLD with WHITE")
+check(writes == 1,
+  "replacing BATTLE BG WORLD must persist exactly once")
+
+Game.save = previousSave
+Game.writeOptions = previousWriteOptions
 
 run.release()
 print("textbox_mod_integration_test: PASS")

--- a/tests/textbox_options_test.lua
+++ b/tests/textbox_options_test.lua
@@ -1,0 +1,52 @@
+local settings = {}
+
+local ModSetting = {}
+function ModSetting.new(key, label, values, labels, defaultIndex)
+  local setting = {
+    key = key,
+    label = label,
+    values = values,
+    labels = labels,
+    value = values[defaultIndex or 1],
+  }
+  function setting:get() return self.value end
+  function setting:sync(value) self.value = value end
+  settings[key] = setting
+  return setting
+end
+
+local V = {
+  require = function(name)
+    if name == "ModSetting" then return ModSetting end
+    error("unexpected module " .. tostring(name))
+  end,
+}
+
+local root = MOD_ROOT or "."
+local UiBackplates = assert(loadfile(root .. "/lib/UiBackplates.lua"))(V)
+
+local function eq(actual, expected, label)
+  if actual ~= expected then
+    error(("%s: expected %s, got %s"):format(
+      label, tostring(expected), tostring(actual)), 0)
+  end
+end
+
+eq(settings.textboxFill ~= nil, true, "TEXTBOX FILL setting exists")
+eq(UiBackplates.textboxMode(), "WHITE", "latest-compatible default is WHITE")
+
+settings.textboxFill:sync("HALF")
+eq(UiBackplates.textboxMode(), "HALF", "HALF is selectable")
+local half = UiBackplates.textboxFillStyle()
+eq(half[1], 0, "HALF is black")
+eq(half[4], 0.5, "HALF matches v1.68 translucency")
+
+settings.textboxFill:sync("OFF")
+eq(UiBackplates.textboxFillStyle(), nil, "OFF has no paper fill")
+
+settings.textboxFill:sync("HALF")
+settings.arenaFill:sync("WHITE")
+eq(UiBackplates.textboxMode(), "WHITE",
+  "ARENA FILL WHITE preserves the official readable white textbox")
+
+print("textbox_options_test: PASS")

--- a/tests/textbox_options_test.lua
+++ b/tests/textbox_options_test.lua
@@ -41,6 +41,11 @@ local half = UiBackplates.textboxFillStyle()
 eq(half[1], 0, "HALF is black")
 eq(half[4], 0.5, "HALF matches v1.68 translucency")
 
+settings.textboxFill:sync("BLACK")
+local black = UiBackplates.textboxFillStyle()
+eq(black[1], 0, "BLACK is black")
+eq(black[4], 1, "BLACK is opaque")
+
 settings.textboxFill:sync("OFF")
 eq(UiBackplates.textboxFillStyle(), nil, "OFF has no paper fill")
 

--- a/tests/textbox_style_test.lua
+++ b/tests/textbox_style_test.lua
@@ -1,0 +1,130 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local TextboxStyle = require("lib.TextboxStyle")
+
+local function eq(actual, expected, label)
+  if actual ~= expected then
+    error(("%s: expected %s, got %s"):format(
+      label, tostring(expected), tostring(actual)), 0)
+  end
+end
+
+local function graphicsStub()
+  local color = { 1, 1, 1, 1 }
+  local blend = { "alpha", "alphamultiply" }
+  local canvas = "ui"
+  local calls = {}
+  local g = {}
+
+  function g.getColor() return color[1], color[2], color[3], color[4] end
+  function g.setColor(r, gr, b, a) color = { r, gr, b, a or 1 } end
+  function g.getBlendMode() return blend[1], blend[2] end
+  function g.setBlendMode(mode, alphaMode) blend = { mode, alphaMode } end
+  function g.getCanvas() return canvas end
+  function g.setCanvas(nextCanvas) canvas = nextCanvas or "screen" end
+  function g.rectangle(mode, x, y, w, h)
+    calls[#calls + 1] = {
+      mode = mode, x = x, y = y, w = w, h = h,
+      color = { color[1], color[2], color[3], color[4] },
+      blend = { blend[1], blend[2] },
+      canvas = canvas,
+    }
+  end
+
+  return g, calls
+end
+
+-- The engine owns the textbox coordinates. Recolouring its white paper in
+-- place means BATTLE SIZE FIXED and FILL transform the paper, corners and ink
+-- together rather than scaling a second window-space rectangle differently.
+do
+  local g, calls = graphicsStub()
+  local original = g.rectangle
+
+  TextboxStyle.withFill(g, { 0, 0, 0, 0.5 }, function()
+    g.setColor(1, 1, 1, 1)
+    g.rectangle("fill", 0, 96, 160, 48)
+    g.setColor(0.2, 0.3, 0.4, 1)
+    g.rectangle("fill", 9, 10, 11, 12)
+  end)
+
+  eq(#calls, 2, "both engine rectangles survive")
+  eq(calls[1].x, 0, "paper keeps the engine x")
+  eq(calls[1].y, 96, "paper keeps the engine y")
+  eq(calls[1].w, 160, "paper keeps the engine width")
+  eq(calls[1].h, 48, "paper keeps the engine height")
+  eq(calls[1].color[1], 0, "HALF paper is black")
+  eq(calls[1].color[4], 0.5, "HALF matches v1.68 opacity")
+  eq(calls[1].blend[1], "replace", "nested paper cannot stack darker")
+  eq(calls[2].color[1], 0.2, "non-paper fills pass through")
+  eq(g.rectangle, original, "rectangle hook is restored")
+end
+
+-- Black paper cannot enter the white-ink shader: the shader would recognise
+-- the whole slab as ink and brighten it. The stateful engine draw must run
+-- exactly once in the ink layer; white paper fills are mirrored to the UI
+-- canvas and become transparent-replace clears in the ink layer. Those clears
+-- preserve nested Font.drawBox and MoveSelectionMenu's two 8x8 border wipes.
+do
+  local g, calls = graphicsStub()
+  local draws, flips = 0, 0
+  local battle = { scrollPx = 8 }
+
+  TextboxStyle.withWhiteInk(g, { 0, 0, 0, 0.5 }, function()
+    draws = draws + 1
+    battle.scrollPx = battle.scrollPx - 2
+    g.setColor(1, 1, 1, 1)
+    g.rectangle("fill", 0, 96, 160, 48)
+    g.setColor(0, 0, 0, 1)
+    g.rectangle("line", 0, 96, 160, 48)
+    g.setColor(1, 1, 1, 1)
+    g.rectangle("fill", 0, 64, 88, 40)
+    g.setColor(0, 0, 0, 1)
+    g.rectangle("line", 0, 64, 88, 40)
+    g.setColor(1, 1, 1, 1)
+    g.rectangle("fill", 32, 96, 8, 8)
+    g.rectangle("fill", 80, 96, 8, 8)
+    g.setColor(0, 0, 0, 1)
+    g.rectangle("line", 32, 96, 8, 8)
+    g.rectangle("line", 80, 96, 8, 8)
+  end, function(drawInk)
+    flips = flips + 1
+    local destination = g.getCanvas()
+    g.setCanvas("ink")
+    drawInk()
+    g.setCanvas(destination)
+  end)
+
+  eq(draws, 1, "stateful engine text area draws once")
+  eq(battle.scrollPx, 6, "scroll advances once per frame")
+  eq(flips, 1, "the single ink pass is flipped")
+
+  local paper, clears, inkLines, uiLines = 0, 0, 0, 0
+  local wipedLeft, wipedRight = false, false
+  for _, call in ipairs(calls) do
+    if call.canvas == "ui" and call.mode == "fill" then
+      paper = paper + 1
+      eq(call.color[4], 0.5, "every paper replacement keeps HALF alpha")
+      eq(call.blend[1], "replace", "overlapping paper does not stack")
+    elseif call.canvas == "ink" and call.mode == "fill" then
+      clears = clears + 1
+      eq(call.color[4], 0, "paper is a transparent clear in the ink layer")
+      eq(call.blend[1], "replace", "ink paper clear replaces prior borders")
+      if call.x == 32 and call.w == 8 then wipedLeft = true end
+      if call.x == 80 and call.w == 8 then wipedRight = true end
+    elseif call.canvas == "ink" and call.mode == "line" then
+      inkLines = inkLines + 1
+    elseif call.canvas == "ui" and call.mode == "line" then
+      uiLines = uiLines + 1
+    end
+  end
+
+  eq(paper, 4, "outer, nested and wipe paper reaches the UI canvas")
+  eq(clears, 4, "every paper draw clears the same ink-layer rectangle")
+  eq(inkLines, 4, "borders draw only in the ink layer")
+  eq(uiLines, 0, "no black border leaks into the UI paper pass")
+  eq(wipedLeft, true, "left 8x8 MoveSelectionMenu wipe is preserved")
+  eq(wipedRight, true, "right 8x8 MoveSelectionMenu wipe is preserved")
+end
+
+print("textbox_style_test: PASS")


### PR DESCRIPTION
## What changed

Restores the `TEXTBOX FILL` setting with `WHITE`, `HALF`, `BLACK`, and `OFF` modes while keeping the 1.7.6 opaque-white presentation as the default.

The optional `BLACK` mode is isolated in the second commit, so it can be dropped independently if only the restored v1.68 modes are wanted.

Also preserves the engine's valid `BATTLE BG: BLACK` option while voxel mode is active. `BATTLE BG: WORLD` still falls back to `WHITE` because the staged 3D battle cannot composite the frozen-overworld path.

## Why

While recreating the v1.68 transparent battle UI, I found that `TEXTBOX FILL: HALF` aligns correctly when `BATTLE SIZE` is `FIXED`, but its backplate drifts away from the textbox corners when `BATTLE SIZE` is `FILL`.

The old path painted a second backplate into the window-resolution battle shot using `shot.scale`. The textbox border and ink are drawn separately in the engine's 160x144 UI canvas, and `FILL` presents that canvas with a fractional scale. The two coordinate paths therefore agree under integer-scaled `FIXED` but diverge under `FILL`.

This change styles the opaque-white paper rectangles issued by `BattleState:drawTextArea` instead. Paper, border, and ink now remain in the same UI canvas and receive the same final transform.

Dark paper and white ink are composited separately so the glyph-inversion shader cannot mistake the black backplate for text. `BattleState:drawTextArea` still runs only once per frame (it mutates the message-scroll offset), while each white paper fill is mirrored to the UI canvas and replaced by transparency in the ink layer. That transparent replacement also preserves the move menu's overlapping box borders and two 8x8 tile wipes. Translucent paper uses replace blending so overlapping action and TYPE/PP boxes do not accumulate darker seams.

`ARENA FILL: WHITE` still forces the current opaque-white textbox, the default remains `WHITE`, and the existing iOS fallback is unchanged.

The prior voxel update rewrote every non-white `BATTLE BG` value to `WHITE` on every frame, although its compatibility comment only identified `WORLD` as unsupported. The compatibility guard now corrects only `WORLD`; an explicit opaque `BLACK` choice survives ordinary updates, entering `VOXEL: FULL`, and a restart.

## Validation

- Reproduced the original mismatch with `BATTLE SIZE: FILL` and confirmed alignment with `FIXED` on macOS/gen1recomp 0.1.75.
- Confirmed the patched build visually under both `FIXED` and `FILL`.
- `luajit tests/textbox_style_test.lua`
- `luajit tests/textbox_options_test.lua`
- `textbox_mod_integration_test.lua` through gen1recomp's modkit loader, including availability under `VOXEL: FULL`.
- `textbox_battle_state_test.lua` against the engine's real `BattleState:drawTextArea`, covering one-step scrolling and the overlapping move-menu wipes.
