### PR TITLE
Expose staged battle compatibility API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 - `BATTLE ART` now retains every selected normal and shiny frame outside the
   completed sprite-provider update chain. Later provider animation updates can
   no longer alternate a second opponent front over Battle Art's chosen image.
+- Added a versioned, read-only staged-battle compatibility API. Other mods can
+  detect the active Battle Art session, inspect presentation ownership, and
+  align effects to copied live projection anchors without depending on Battle
+  Art's internal module layout.
 
 ## 1.8.3 — Illustrated battle arenas
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,22 @@ when the consumer will draw that complete surface. The descriptor is exported
 as `mod.find("BATTLE_ART_VOXEL_FORK").exports.battlePresentation`; absent,
 throwing or false consumers fail open to Battle Art's native presentation.
 
+### Staged-battle compatibility API
+
+Effects and presentation mods can read the versioned, read-only descriptor at
+`mod.find("BATTLE_ART_VOXEL_FORK").exports.battleStage`. Its `state(battle)`
+function returns `nil` unless that exact battle is staged. A staged session is
+reported immediately with `staged=true`; `ready` becomes true once the first
+projected shot exists.
+
+Ready state includes copied authored and projected player/enemy anchors,
+back-sprite pinning, the animation scale and complete layer transform. It also
+declares Battle Art's arena, battler, trainer, camera, HUD, transition and
+animation-projection ownership. Consumers can therefore align their effects
+or yield competing presentation without importing Battle Art's internal
+modules, retaining live tables, or changing either mod's settings. API version
+1 is observational only.
+
 ## Bring your own battle art
 
 `BATTLE ART: STATIC` is the default. Drop a front PNG named for the species

--- a/lib/BattleStage.lua
+++ b/lib/BattleStage.lua
@@ -1,0 +1,110 @@
+-- Read-only compatibility contract for mods that compose effects with Battle
+-- Art's staged battle. Consumers receive copies of projection coordinates and
+-- ownership metadata; no setting or live Battle Art table is exposed.
+
+local BattleStage = {}
+
+BattleStage.API_VERSION = 1
+BattleStage.SOURCE_MOD_ID = "BATTLE_ART_VOXEL_FORK"
+
+local OWNERSHIP = {
+  arena = true,
+  battlers = true,
+  trainers = true,
+  camera = true,
+  hud = true,
+  transition = true,
+  animationProjection = true,
+}
+
+local function copyPoint(value, fallback)
+  if type(value) == "table" and type(value[1]) == "number"
+      and type(value[2]) == "number" then
+    return { value[1], value[2] }
+  end
+  return { fallback[1], fallback[2] }
+end
+
+local function copyOwnership()
+  local out = {}
+  for name, claimed in pairs(OWNERSHIP) do out[name] = claimed end
+  return out
+end
+
+local function call(object, name, ...)
+  local fn = object and object[name]
+  if type(fn) ~= "function" then return nil end
+  local ok, value = pcall(fn, ...)
+  return ok and value or nil
+end
+
+function BattleStage.export(battles)
+  local anchors = battles and battles.ANCHOR or {}
+  local authoredPlayer = copyPoint(anchors.player, { 26, 96 })
+  local authoredEnemy = copyPoint(anchors.enemy, { 124, 56 })
+
+  local function state(expectedBattle)
+    local battle = call(battles, "battle")
+    if battle == nil or (expectedBattle ~= nil and battle ~= expectedBattle) then
+      return nil
+    end
+
+    local out = {
+      apiVersion = BattleStage.API_VERSION,
+      sourceModId = BattleStage.SOURCE_MOD_ID,
+      battle = battle,
+      staged = true,
+      ready = false,
+      ownership = copyOwnership(),
+      surfaceOwned = true,
+      externalCamera = true,
+      layerOwnsProjection = true,
+    }
+
+    local shot = call(battles, "shot")
+    if type(shot) ~= "table" then return out end
+
+    local player = copyPoint(shot.player, authoredPlayer)
+    local enemy = copyPoint(shot.enemy, authoredEnemy)
+    local backPinned = call(battles, "backPinned") == true
+    if backPinned then player = copyPoint(authoredPlayer, authoredPlayer) end
+
+    local scale = tonumber(call(battles, "animScale", shot,
+      player[1], player[2])) or 1
+    if not (scale > 0) or scale ~= scale then scale = 1 end
+
+    local authoredCenter = {
+      (authoredPlayer[1] + authoredEnemy[1]) / 2,
+      (authoredPlayer[2] + authoredEnemy[2]) / 2,
+    }
+    local projectedCenter = {
+      (player[1] + enemy[1]) / 2,
+      (player[2] + enemy[2]) / 2,
+    }
+
+    out.ready = true
+    out.backPinned = backPinned
+    out.animationScale = scale
+    out.authoredAnchors = {
+      player = copyPoint(authoredPlayer, authoredPlayer),
+      enemy = copyPoint(authoredEnemy, authoredEnemy),
+    }
+    out.projectedAnchors = { player = player, enemy = enemy }
+    out.layerTransform = {
+      authoredCenter = authoredCenter,
+      projectedCenter = projectedCenter,
+      scale = scale,
+    }
+    return out
+  end
+
+  return {
+    apiVersion = BattleStage.API_VERSION,
+    sourceModId = BattleStage.SOURCE_MOD_ID,
+    ownership = copyOwnership(),
+    enabled = function() return call(battles, "enabled") == true end,
+    state = state,
+  }
+end
+
+return BattleStage

--- a/main.lua
+++ b/main.lua
@@ -94,6 +94,7 @@ local WorldCurve = V.require("WorldCurve")
 local WorldUnderlay = V.require("WorldUnderlay")
 local OverworldBattle = V.require("OverworldBattle")
 local BattlePresentation = V.require("BattlePresentation")
+local BattleStage = V.require("BattleStage")
 local BattleArt = V.require("BattleArt")
 local UiBackplates = V.require("UiBackplates")
 local BattleExit = V.require("BattleExit")
@@ -1307,6 +1308,7 @@ end)
 
 mod.exports.version = "1.8.8"
 mod.exports.battlePresentation = BattlePresentation.export()
+mod.exports.battleStage = BattleStage.export(OverworldBattle)
 -- exposed so a companion mod can pin its own tiles' shapes or read the
 -- camera without reaching into this mod's file layout
 mod.exports.lib = V

--- a/tests/battle_art_voxel_fork_test.lua
+++ b/tests/battle_art_voxel_fork_test.lua
@@ -56,6 +56,43 @@ T.eq(BattlePresentation.suppressed("hud"), false,
   "a broken replacement presenter leaves the native HUD visible")
 removeBroken()
 
+-- Presentation companions get a stable, read-only staged-battle descriptor
+-- instead of reaching through the exported module loader for implementation
+-- details. Its coordinates are copies, so consumers cannot move Battle Art's
+-- live shot by retaining or mutating them.
+local BattleStage = modExports.lib.require("BattleStage")
+local expectedBattle = {}
+local liveShot = { player = { 40, 90 }, enemy = { 130, 50 } }
+local stageExport = BattleStage.export({
+  ANCHOR = { player = { 26, 96 }, enemy = { 124, 56 } },
+  enabled = function() return true end,
+  battle = function() return expectedBattle end,
+  shot = function() return liveShot end,
+  backPinned = function() return true end,
+  animScale = function() return 1.25 end,
+})
+T.eq(stageExport.apiVersion, 1,
+  "the public staged-battle descriptor is versioned")
+T.eq(stageExport.enabled(), true,
+  "the staged-battle descriptor reports the feature setting")
+T.eq(stageExport.state({}), nil,
+  "a consumer cannot claim projection from a different battle")
+local stage = stageExport.state(expectedBattle)
+T.check(stage and stage.staged and stage.ready,
+  "the active staged battle publishes a ready projection")
+T.eq(stage.projectedAnchors.player[1], 26,
+  "a pinned player reports its authored UI anchor")
+T.eq(stage.projectedAnchors.enemy[1], 130,
+  "the enemy reports its live projected anchor")
+T.eq(stage.animationScale, 1.25,
+  "the animation transform reports Battle Art's live scale")
+T.check(stage.ownership.arena and stage.ownership.battlers
+    and stage.ownership.camera and stage.ownership.animationProjection,
+  "the descriptor declares the staged surfaces Battle Art owns")
+stage.projectedAnchors.enemy[1] = -1
+T.eq(liveShot.enemy[1], 130,
+  "published projection coordinates cannot mutate the live shot")
+
 -- The mod removes only the presentation flag created by field poison. The
 -- poison routine itself remains the engine's routine (wrapped in main.lua),
 -- so damage, timing, sound and faint handling are not reimplemented here.


### PR DESCRIPTION
## Summary

- export a versioned `battleStage` compatibility descriptor
- report whether a specific battle is staged before the first projected frame
- expose copied authored/projected anchors, back-sprite pinning, animation scale, and the complete layer transform once ready
- declare Battle Art's presentation ownership so companion mods can yield conflicting arena, battler, trainer, camera, HUD, transition, and projection systems
- document and test the observational API

## Why

StadiumBattleFX can already cooperate with Battle Art by reaching through the generic exported module loader and reproducing Battle Art's animation projection math. That depends on internal module layout and duplicates behavior that Battle Art owns.

This API provides a stable, read-only boundary. Consumers can align effects or yield competing presentation without retaining Battle Art's live shot tables, modifying either mod's settings, or taking control of Battle Art's arena.

## API behavior

`mod.find("BATTLE_ART_VOXEL_FORK").exports.battleStage` exposes API version 1, source identity, ownership metadata, `enabled()`, and `state(battle)`.

`state(battle)` returns `nil` for a different or inactive battle. It reports a staged-but-not-ready session before the first projected shot, then returns copied projection coordinates and transform metadata when ready.

## Validation

- focused LÖVE API behavior checks pass
- modified Lua files parse successfully
- `git diff --check` passes
- headless regression coverage added to `tests/battle_art_voxel_fork_test.lua`
