### PR TITLE
Add StadiumBattleFX voxel arena provider

### DIFF
--- a/lib/BattleScene.lua
+++ b/lib/BattleScene.lua
@@ -363,7 +363,7 @@ local function tickTiles()
   pcall(require("src.render.TileRenderer").tick)
 end
 
-function BattleScene.render(state, arena, textures, token, battle)
+function BattleScene.render(state, arena, textures, token, battle, drawActors)
   if not (state and state.map and arena) then return nil end
   if not Voxel3D.available() then return nil end
   tickTiles()
@@ -438,7 +438,10 @@ function BattleScene.render(state, arena, textures, token, battle)
   -- and the real one is rebuilt inside the scene below.
   Voxel3D.camera = cam
   Voxel3D.viewProjection(cx, cy, vw, vh)
-  local cards = monCards(arena, groundY, textures)
+  -- A Battle Presentation host supplies its independently selected actor
+  -- renderer here. In that mode the native cards must not also enter either
+  -- the shadow map or the colour pass.
+  local cards = drawActors and {} or monCards(arena, groundY, textures)
   Voxel3D.camera = nil
   if flatFill then
     -- WHITE is a genuinely flat stage: there is no visible world receiver,
@@ -448,7 +451,8 @@ function BattleScene.render(state, arena, textures, token, battle)
     ShadowMap.discard()
   else
     castShadows(state, arena, terrain, nbMesh, cx, cy, vw, vh, atlasFor,
-                cards, token, host, neighbors, water, nbWater)
+                cards, drawActors and nil or token,
+                host, neighbors, water, nbWater)
   end
 
   -- An opaque void either way. Outdoors the camera is low enough that the
@@ -544,7 +548,7 @@ function BattleScene.render(state, arena, textures, token, battle)
     -- and no glass either: the cards wear the battle screen, not the
     -- tileset atlas, so the mask's coordinates mean nothing on them
     Voxel3D.glass(false)
-    for _, card in ipairs(monCards(arena, groundY, textures)) do
+    for _, card in ipairs(cards) do
       -- Static front illustrations retain their authored brightness instead
       -- of being dimmed or colour-cast by the clock. Only the hour tint is
       -- neutral here; depth and alpha-shaped lighting/shadows stay active.
@@ -598,6 +602,18 @@ function BattleScene.render(state, arena, textures, token, battle)
                    Mat4.translate(nb.ox, 0, nb.oy), fpull,
                    ShadowMap.snug(Mat4.translate(nb.ox, 0, nb.oy)))
     end
+    end
+    if drawActors then
+      -- Enter the selected model provider while this arena's depth target and
+      -- camera are live. The host owns actor shader/state cleanup. Logical
+      -- dimensions describe the resolved surface, so projected attachments
+      -- remain correct when this pass is supersampled.
+      drawActors({
+        vp = Voxel3D.vp,
+        groundY = groundY,
+        width = pw,
+        height = ph,
+      })
     end
     local canvas = AntiAlias.resolve(Voxel3D.endScene(), pw, ph, "battle")
     if not canvas then return end

--- a/lib/OverworldBattle.lua
+++ b/lib/OverworldBattle.lua
@@ -579,6 +579,50 @@ function OverworldBattle.arena()
   return session and session.arena or nil
 end
 
+-- Battle Presentation API bridge. While hosted, the normal BattleState draw
+-- wrapper must stay dormant: SBFX presents the arena canvas and independently
+-- selected actors through its own composition pass.
+function OverworldBattle.providerAvailable(expectedBattle)
+  return session ~= nil and session.arena ~= nil
+    and (expectedBattle == nil or session.battle == nil
+      or session.battle == expectedBattle)
+end
+
+function OverworldBattle.providerBegin(expectedBattle)
+  if not OverworldBattle.providerAvailable(expectedBattle) then return false end
+  session.apiHosted = true
+  session.shot = nil
+  session.snapped = false
+  return true
+end
+
+function OverworldBattle.providerRender(expectedBattle, drawActors)
+  if not (session and session.apiHosted and type(drawActors) == "function") then
+    return nil
+  end
+  if expectedBattle ~= nil and session.battle ~= nil
+      and session.battle ~= expectedBattle then return nil end
+  session.battle = session.battle or expectedBattle
+  session.token = (session.token or 0) + 1
+  local ok, shot = pcall(BattleScene.render, session.state, session.arena,
+    nil, session.token, session.battle, drawActors)
+  if not (ok and shot and shot.canvas) then return nil end
+  local y1 = shot.ly + shot.player[2] * shot.scale
+  local y2 = shot.ly + shot.enemy[2] * shot.scale
+  local focusY, band, range = BattleDOF.bandFor(y1, y2, shot.ph)
+  local okDof, blurred = pcall(BattleDOF.apply, shot.canvas,
+    focusY, band, range)
+  if okDof and blurred then shot.canvas = blurred end
+  return shot.canvas
+end
+
+function OverworldBattle.providerFinish()
+  if not session then return end
+  session.apiHosted = false
+  session.shot = nil
+  session.snapped = false
+end
+
 function OverworldBattle.finish()
   if not session then return end
   AnimatedBattleArt.finish(session.battle)
@@ -643,6 +687,12 @@ function OverworldBattle.update(dt)
   -- the world pass is hidden behind the battle, so mesh builds get the wide
   -- slice: nothing visible can hitch on them
   ChunkMesher.pump(true)
+
+  if session.apiHosted then
+    session.shot = nil
+    session.snapped = false
+    return
+  end
 
   -- The mons' textures are rendered HERE, with no canvas bound, for the same
   -- reason the scene is: the pics layer binds its own targets, and doing that

--- a/lib/StadiumBattleFxProvider.lua
+++ b/lib/StadiumBattleFxProvider.lua
@@ -1,0 +1,69 @@
+-- Optional StadiumBattleFX Battle Presentation API v1 arena provider.
+-- Registration is inert when SBFX is absent. The player explicitly selects
+-- this arena independently from models, effects, camera, HUD, and audio.
+
+local V = ...
+local OverworldBattle = V.require("OverworldBattle")
+
+local Provider = { registered = false, fallback = nil }
+
+local function findMod(id)
+  local finder = V.mod and V.mod.find
+  if type(finder) ~= "function" then return nil end
+  local ok, handle = pcall(finder, id)
+  if ok and handle then return handle end
+  ok, handle = pcall(finder, V.mod, id)
+  return ok and handle or nil
+end
+
+function Provider:arena(context)
+  if not OverworldBattle.providerAvailable(context and context.battle) then
+    return self.fallback
+  end
+  return OverworldBattle.arena()
+end
+
+function Provider:begin(context)
+  return OverworldBattle.providerBegin(context and context.battle)
+    or self.fallback
+end
+
+function Provider:render(context, arena, drawActors)
+  local canvas = OverworldBattle.providerRender(
+    context and context.battle, drawActors)
+  return canvas or self.fallback
+end
+
+function Provider:finish()
+  OverworldBattle.providerFinish()
+end
+
+function Provider.register()
+  if Provider.registered then return true end
+  local handle = findMod("STADIUM_BATTLE_FX")
+  local api = handle and handle.exports and handle.exports.battles
+  if not (api and api.version == 1
+      and type(api.registerComponent) == "function") then return false end
+  Provider.fallback = api.FALLBACK
+  local ok, id = pcall(api.registerComponent, api, V.mod.id, "arena",
+    "voxel-map", {
+      label = "BATTLE ART VOXEL MAP",
+      description = "Battle Art's staged voxel-map arena; models and other "
+        .. "features remain independently selectable.",
+      provider = Provider,
+      available = function(context)
+        return OverworldBattle.providerAvailable(context and context.battle)
+      end,
+    })
+  if not ok then
+    if V.mod.log and V.mod.log.warn then
+      V.mod.log:warn("StadiumBattleFX arena registration failed: %s", tostring(id))
+    end
+    return false
+  end
+  Provider.registered = true
+  Provider.id = id
+  return true
+end
+
+return Provider

--- a/main.lua
+++ b/main.lua
@@ -95,6 +95,7 @@ local WorldUnderlay = V.require("WorldUnderlay")
 local OverworldBattle = V.require("OverworldBattle")
 local BattlePresentation = V.require("BattlePresentation")
 local BattleStage = V.require("BattleStage")
+local StadiumBattleFxProvider = V.require("StadiumBattleFxProvider")
 local BattleArt = V.require("BattleArt")
 local UiBackplates = V.require("UiBackplates")
 local BattleExit = V.require("BattleExit")
@@ -118,6 +119,7 @@ mod.events:on("mods.loaded", function(payload)
   -- Reassert BATTLE ART ownership outside the completed chain so ordinary and
   -- shiny opponent fronts cannot alternate after those providers advance.
   OverworldBattle.refreshSpriteOwnershipHook()
+  StadiumBattleFxProvider.register()
 end)
 
 -- Forward declaration: the voxel pipeline's update hook (registered below)

--- a/tests/stadium_battle_fx_provider_test.lua
+++ b/tests/stadium_battle_fx_provider_test.lua
@@ -1,0 +1,75 @@
+-- Standalone contract test for optional StadiumBattleFX arena registration.
+local expectedOwner = "BATTLE_ART_VOXEL_FORK"
+local fallback = {}
+local registered
+local calls = {}
+local OverworldBattle = {
+  providerAvailable = function(battle)
+    calls.available = battle
+    return battle == "battle"
+  end,
+  arena = function() return { id = "map-arena" } end,
+  providerBegin = function(battle)
+    calls.begin = battle
+    return battle == "battle"
+  end,
+  providerRender = function(battle, drawActors)
+    calls.render = battle
+    drawActors({ vp = {}, groundY = 7, width = 160, height = 144 })
+    return "canvas"
+  end,
+  providerFinish = function() calls.finished = true end,
+}
+local api = {
+  version = 1,
+  FALLBACK = fallback,
+  registerComponent = function(_, owner, slot, id, definition)
+    registered = { owner, slot, id, definition }
+    return owner .. ":" .. id
+  end,
+}
+local V = {
+  mod = {
+    id = expectedOwner,
+    find = function(id)
+      if id == "STADIUM_BATTLE_FX" then
+        return { exports = { battles = api } }
+      end
+    end,
+    log = { warn = function() error("registration should not warn") end },
+  },
+  require = function(name)
+    assert(name == "OverworldBattle")
+    return OverworldBattle
+  end,
+}
+
+for _, path in ipairs({
+  "lib/BattleScene.lua",
+  "lib/OverworldBattle.lua",
+  "lib/StadiumBattleFxProvider.lua",
+  "main.lua",
+}) do
+  assert(loadfile(path), path .. " must compile")
+end
+
+local Provider = assert(loadfile("lib/StadiumBattleFxProvider.lua"))(V)
+assert(Provider.register() == true)
+assert(Provider.register() == true, "registration must be idempotent")
+assert(registered[1] == expectedOwner and registered[2] == "arena"
+  and registered[3] == "voxel-map")
+local definition = registered[4]
+assert(definition.available({ battle = "battle" }) == true)
+assert(definition.available({ battle = "other" }) == false)
+assert(definition.provider == Provider)
+assert(Provider:arena({ battle = "other" }) == fallback)
+assert(Provider:arena({ battle = "battle" }).id == "map-arena")
+assert(Provider:begin({ battle = "battle" }) == true)
+local drew
+assert(Provider:render({ battle = "battle" }, {}, function(world)
+  drew = world.groundY == 7 and world.width == 160 and world.height == 144
+end) == "canvas")
+assert(drew == true and calls.render == "battle")
+Provider:finish()
+assert(calls.finished == true)
+print("ok StadiumBattleFX voxel-map arena provider " .. expectedOwner)


### PR DESCRIPTION
## What changed

Adds an optional StadiumBattleFX Battle Presentation API v1 arena provider for Battle Art 1.8.8.

When the player selects **BATTLE ART VOXEL MAP** under SBFX's **BTL ARENA**, Battle Art renders its staged voxel-map environment and calls the host's `drawActors(world)` callback inside the live depth pass. Battle Art's native cards are omitted only in this API-hosted path.

## Compatibility impact

This is specifically designed for compatibility and mix-and-match configuration:

- Battle Art supplies only the arena.
- The player can independently select Stadium 1, Stadium 2, another compatible model provider, or OFF under **BTL MODELS**.
- SBFX effects, camera, HUD, announcer, overlays, and transitions remain independently selectable.
- No provider wins through load order.
- Without StadiumBattleFX, registration is inert and Battle Art behaves exactly as before.
- If Battle Art cannot stage the encounter, SBFX safely falls back to its selected/default arena.

This complements the already merged read-only `exports.battleStage` compatibility API without replacing it.

## Validation

- Added a standalone provider registration/lifecycle contract test.
- Verified changed Lua files compile under LÖVE.
- Gen1Recomp mod lint passes with no ROM-derived content.