### PR TITLE
Remove stale wild_skies conflict

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,8 +16,7 @@
   "conflicts": [
     "DRAMATIC_SHAPE",
     "DRAMALESS_SHAPE",
-    "potato_voxel",
-	"wild_skies"
+    "potato_voxel"
   ],
   "permissions": [
     "engine_internals"


### PR DESCRIPTION
The `wild_skies` entry in `conflicts` predates wild_skies 1.10.2, which fixed the crash that made the pairing genuinely break: the resident-sky ghost rows wild_skies injects for neighbour maps were born without cell coordinates, so the voxel capture threw on its ground lookup and newer voxel builds latched to 2D after one failed frame. Fixed in [shanehudson-gen1recomp-mods PR #14](https://github.com/shanehudson-gen1recomp-mods/monorepo/pull/14) (wild_skies 1.10.2, thanks to ProwainK for pinpointing the injection site). Nothing else in Battle Art references wild_skies.

Verified against Battle Art 1.9.3 + wild_skies 1.12.0: both load and run together cleanly with the conflict removed. 