### PR TITLE
Add Voxel Companion API v1 for Kanto First Person 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- **Exact KFP world semantics.** The companion snapshot now separates verified
+  OVERWORLD tree supports from boulder-tree candidates, rejects walkable and
+  unknown cylinder ghosts, and marks mountain seeds and their bounded support
+  cells with explicit normalized tags. Generic cylinders and cliffs no longer
+  become trees or mountains by class-name guesswork.
+
 - **StadiumBattleFX API-1 providers.** Battle Art now registers its voxel-map
   arena, native battle cards, placed camera, projected HUD, and exit fade as
   independent SBFX selections. The projected HUD respects Battle Art's

--- a/data/voxel_heights.lua
+++ b/data/voxel_heights.lua
@@ -192,11 +192,13 @@ return {
       -- as one continuous lip, and the mound loses nothing: its foot
       -- row simply reads as the talus it is drawn as.
       ledge = { 13, 29, 39, 52, 54, 55 },
-      -- trees are drawn ROUND -- the lone canopy (42/43/58/59) and the
-      -- border tree wall (64/65/80/81, blockset $0F). Boxes and per-pixel
-      -- cutouts both read wrong for them; the cylinder archetype carves
-      -- one voxel ball per 16x16 cell from the canopy's darkest-pixel
-      -- outline, round in depth, so tree rows become rows of real canopies
+      -- round scenery uses one geometry pool but has two semantic roles:
+      -- the lone grey boulder (42/43/58/59) and the green border-tree wall
+      -- (64/65/80/81, blockset $0F). Boxes and per-pixel cutouts both read
+      -- wrong for them; the cylinder archetype carves one voxel ball per
+      -- 16x16 cell from the drawing's darkest-pixel outline. The companion
+      -- adapter keeps their semantic identities separate; `cylinder` alone
+      -- is never evidence that a cell is a tree.
       cylinder = { 42, 43, 58, 59, 64, 65, 80, 81 },
       -- the town sign (blockset 8's SE cell): a standing per-pixel slab
       -- 2 voxels thin, transparency respected -- never a solid box

--- a/docs/VOXEL_COMPANION_API_V1_HOST.md
+++ b/docs/VOXEL_COMPANION_API_V1_HOST.md
@@ -1,0 +1,147 @@
+# Voxel Companion API v1 host integration
+
+## Pinned sources
+
+- Host: `BATTLE_ART_VOXEL_FORK` 1.9.7 at
+  `fcbe541676cd7f245fa73df3d01dcbabec37a1fe`, dated
+  2026-08-21T07:49:50+02:00.
+- Host source: <https://github.com/absol89/DramaticShapeVoxelMod/commit/fcbe541676cd7f245fa73df3d01dcbabec37a1fe>
+- Gen1recomp compatibility audit: commit
+  `06e06e305bbcefe97c216a31bb25265ffb5e6b18`, dated
+  2026-08-21T14:38:54-04:00.
+- Gen1recomp source: <https://github.com/bryanthaboi/gen1recomp/commit/06e06e305bbcefe97c216a31bb25265ffb5e6b18>
+- Voxel Companion API reference dispatcher: normalized SHA-256
+  `7ACB41E52757898038454D2EA673AAE5AC1ED66768DBA38E4FD8104702FD569B`.
+
+The integration does not change the upstream mod identifier, manifest version,
+load priority, permissions, conflicts, or package layout. The existing package
+scripts include all files under `lib`, so they include the adapter and vendored
+dispatcher without a packaging rule change.
+
+## Honest capability descriptor
+
+The exported `mod.exports.voxel_companion` provider advertises only these v1
+capabilities:
+
+- `world_snapshot`
+- `camera_delta`
+- `render_phases`
+- `quality_tier`
+- `integrity_status`
+
+It does not advertise `terrain_patch`, `shadow_pass`, or `battle_pass`. It also
+does not advertise `materials` or `draw`; those names are borrowed facades, not
+wire capabilities. A descriptor that supplies `shadow_casters` or
+`battle_opaque` is refused because this host does not run companion work in
+those passes.
+
+## Host seams
+
+The adapter uses only existing host-owned seams:
+
+1. `update(frame)` runs from the voxel pipeline update. It also runs while the
+   voxel display level is off, so extension compilation can finish before the
+   player selects the mode.
+2. `worldChanged(snapshot)` runs after a real world identity change. Multiple
+   block edits before one update coalesce into one snapshot revision.
+3. `modifyCamera(camera)` runs after the first-person rig is built and before
+   projection. The host applies finite additive values only. Position is
+   limited to 32 world units per axis, rotation to 0.5 radians per axis, and
+   FOV to the host range of 20 to 120 degrees. API input remains radians.
+4. `background` runs after the host opens its 3D scene and before terrain.
+5. `opaque_after_terrain` runs after host terrain and distant fill props and
+   before water and actors.
+6. `translucent_after_actors` runs after host actors, water, grass, and flowers
+   and before the scene resolves.
+
+The adapter does not enter `ShadowMap` or `BattleScene`. It does not suppress,
+replace, or mutate base terrain.
+
+## World snapshot
+
+The snapshot is copied from the current Gen1recomp overworld and map APIs. It
+contains the game identity, map and tileset revisions, display mode, map tags,
+player pose, bounded actor and neighbor lists, and normalized cells. Cell tags
+come from the host tile shape plus Gen1recomp walk, water, grass, and warp
+queries.
+
+Hard limits are:
+
+- 262,144 cells
+- 2,048 actors
+- 8 neighbors
+
+The public facade returns defensive plain-data copies. Snapshot construction is
+protected by one outer fault boundary. It does not use a protected call for
+each cell query. This keeps map-change work bounded without adding several
+protected calls per cell. Player movement does not rebuild the full map.
+
+## Draw adapter and safety
+
+The draw facade implements the three v1 draw methods:
+
+- `mesh` for a box, plane, and centered world apron
+- `instances` for bounded prototype batches
+- `billboards` for bounded camera-facing batches
+
+One phase accepts at most 2,048 items per packet and 4,096 draws per frame.
+Geometry positions and primitive sizes are finite and limited to 65,536 host
+world units at the adapter boundary.
+Unsupported mesh primitives fail only the requesting extension. The host base
+scene continues.
+
+Every companion render phase uses `love.graphics.push("all")` and a matching
+`pop`. The adapter also restores the host `Voxel3D.glass` shader selector after
+each draw, including a failed draw. The reference dispatcher isolates callback
+faults, records a bounded diagnostic, disposes the failed extension once, and
+continues later extensions in deterministic order.
+
+The adapter does not replace a global LÖVE callback. It does not retain borrowed
+callback contexts or service leases. Disposal releases adapter GPU resources
+and drops world and activation references.
+
+## Legacy splice refusal
+
+The adapter reads only known upstream host targets. It scans for exact literals
+written by the old KFP patcher in:
+
+- `main.lua`
+- `lib/VoxelScene.lua`
+- `lib/FirstPerson.lua`
+- `lib/Structures.lua`
+- `lib/ChunkMesher.lua`
+- `lib/Ceiling.lua`
+- `lib/Backdrop.lua`
+- `lib/SkyLayer.lua`
+- `lib/Flora.lua`
+- `lib/Jump.lua`
+
+If a marker is present, `register` returns a diagnostic that names the first
+contaminated target and tells the user to reinstall a clean voxel host. The
+scan and refusal do not write, restore, remove, or rename any file.
+
+## Verification
+
+Run the focused host test from the repository root:
+
+```text
+luajit tests\voxel_companion_api_v1_test.lua
+```
+
+It covers descriptor truthfulness, canonical flat callbacks, optional
+capabilities, late registration, direct world/update/camera payloads, defensive
+snapshots, edit coalescing, radian camera input, graphics restoration, draw
+fault isolation, deterministic continuation, disposal, legacy refusal, and the
+no-write rule.
+
+The canonical KFP dispatcher conformance command is:
+
+```text
+luajit tools\run_tests.lua companion
+```
+
+At integration time, the focused host test passed 76 checks and the canonical
+KFP suite passed 32 tests. All changed Lua files also compiled with LuaJIT. The
+large upstream `tests/battle_art_voxel_fork_test.lua` cannot compile as one
+LuaJIT chunk because its main function already exceeds LuaJIT's 200-local
+limit. This is an upstream test-harness limit, not a companion adapter failure.

--- a/docs/VOXEL_COMPANION_API_V1_HOST.md
+++ b/docs/VOXEL_COMPANION_API_V1_HOST.md
@@ -6,10 +6,14 @@
   `fcbe541676cd7f245fa73df3d01dcbabec37a1fe`, dated
   2026-08-21T07:49:50+02:00.
 - Host source: <https://github.com/absol89/DramaticShapeVoxelMod/commit/fcbe541676cd7f245fa73df3d01dcbabec37a1fe>
-- Gen1recomp compatibility audit: commit
-  `06e06e305bbcefe97c216a31bb25265ffb5e6b18`, dated
-  2026-08-21T14:38:54-04:00.
-- Gen1recomp source: <https://github.com/bryanthaboi/gen1recomp/commit/06e06e305bbcefe97c216a31bb25265ffb5e6b18>
+- Gen1recomp stable audit: v0.2.18 commit
+  `70d7b6383e2c005857013dc897fd096886b08f0b`, dated
+  2026-08-21T17:10:00-04:00.
+- Stable source: <https://github.com/bryanthaboi/gen1recomp/commit/70d7b6383e2c005857013dc897fd096886b08f0b>
+- Gen1recomp development audit: commit
+  `087a2751895899ad6e79800599ae27a8f40cf1e3`, dated
+  2026-08-21T16:36:55-04:00.
+- Development source: <https://github.com/bryanthaboi/gen1recomp/commit/087a2751895899ad6e79800599ae27a8f40cf1e3>
 - Frozen Voxel Companion API reference dispatcher: byte-exact SHA-256
   `6150DA890F36666AFA88C7EE2E48D57F6C77D1C9678B7B34C988C24997ADA3A3`.
 
@@ -80,11 +84,13 @@ protected calls per cell. Player movement does not rebuild the full map.
 
 The draw facade implements the three v1 draw methods:
 
-- `mesh` for a box, plane, and centered world apron
+- `mesh` for box, plane, centered world apron, panorama, cloud layer, and
+  rainbow geometry
 - `instances` for bounded batches of box, plane, door frame, window, poster,
   rail, fixture, sconce, cave roof, grass clump, canopy, vine, umbrella,
   mountain, and hood prototypes
-- `billboards` for bounded explicit camera-facing items
+- `billboards` for bounded explicit camera-facing items and deterministic
+  procedural stars
 
 Extensions call each method with the canonical dot-call form
 `draw.<kind>(command, context)`. A draw returns exactly `true` when the host
@@ -104,6 +110,17 @@ command tables, texture handles, or derived command geometry.
 draw callback. A string path is refused. The adapter can pass the borrowed
 texture to `Voxel3D.draw`, then unbinds it before returning. It never stores,
 releases, or substitutes ownership of that texture.
+
+Panorama uses a fixed 32-segment host-owned cylinder and its callback-borrowed
+texture. Cloud layers use one fixed eight-quad host mesh. Rainbow uses one fixed
+24-segment ribbon. Required declarative fields select bounded transforms,
+density, parallax, and deterministic placement. These are conservative API
+baseline visuals. They do not claim rich parity with KFP 1.x sky art or weather.
+
+Procedural stars expand to at most 2,048 temporary camera-facing items with a
+local Park-Miller stream. The stream is seeded only from the command. It does
+not call or reseed the global random generator. Generated items and resource
+handles are not retained.
 
 One phase accepts at most 2,048 items per packet and 4,096 draws per frame.
 Geometry positions and primitive sizes are finite and limited to 65,536 host
@@ -163,10 +180,10 @@ The canonical KFP dispatcher conformance command is:
 luajit tools\run_tests.lua companion
 ```
 
-At integration time, the focused host test passed 263 checks, the canonical
-companion selector passed 38 tests, and the complete KFP suite passed 191
-tests. The shared ROM-free draw fixture has SHA-256
-`A817618D9BAD3C3849B71DF02C255ECA53CBC74B0660A38031EC8399D22FE6A5`.
+At integration time, the focused host test passed 577 checks, the canonical
+companion selector passed 40 tests, and the complete KFP suite passed 196
+tests. The complete 23-command ROM-free draw fixture has SHA-256
+`4CD7A8C9D258B247CB9AE0A9730E56DE3E9541B63358149A2AD09513F655A113`.
 All changed Lua files also compiled with LuaJIT. The large upstream
 `tests/battle_art_voxel_fork_test.lua` cannot compile as one LuaJIT chunk
 because its main function already exceeds LuaJIT's 200-local limit. This is an

--- a/docs/VOXEL_COMPANION_API_V1_HOST.md
+++ b/docs/VOXEL_COMPANION_API_V1_HOST.md
@@ -128,8 +128,11 @@ Panorama uses a fixed 32-segment host-owned cylinder and its callback-borrowed
 texture. The physical cylinder keeps the released radius of 900 world units,
 top at 300, normal bottom at -120, and deep-skirt bottom at -1400.
 `sourceWidth` and `targetWidth` are texture quality metadata and never scale
-world geometry. Distance haze changes RGB only; texture alpha stays the only
-coverage source, which avoids the host shader's ordered-alpha bands.
+world geometry. The authored texture spans only -120 through 300. A separate
+deep-skirt ring samples its bottom texture row from -1400 through -120, so the
+painted skyline is never stretched into the closure. Distance haze changes RGB
+only; texture alpha stays the only coverage source, which avoids the host
+shader's ordered-alpha bands.
 
 Cloud layers require a callback-borrowed KFP texture and use one fixed
 eight-quad host mesh, a maximum 192-world-unit span, opaque material coverage,
@@ -221,7 +224,7 @@ luajit tools\run_tests.lua companion
 ```
 
 At integration time, the lifecycle test passed 11 checks, the focused host
-test passed 725 checks, the canonical
+test passed 1,112 checks, the canonical
 companion selector passed 54 tests, and the complete KFP suite passed 215
 tests. The complete 23-command ROM-free draw fixture has canonical LF SHA-256
 `DE1DCA98A04AD9446B0AF4C13523DAB7F365BC7A76E70BC44B24F323D98A9BFA`.

--- a/docs/VOXEL_COMPANION_API_V1_HOST.md
+++ b/docs/VOXEL_COMPANION_API_V1_HOST.md
@@ -15,7 +15,7 @@
   2026-08-21T16:36:55-04:00.
 - Development source: <https://github.com/bryanthaboi/gen1recomp/commit/087a2751895899ad6e79800599ae27a8f40cf1e3>
 - Frozen Voxel Companion API reference dispatcher: byte-exact SHA-256
-  `864DA19493F773A52FB2111EFC02D79E9882B87C5A762AF5B124326A74A32B33`.
+  `6FDED9C804298AB064DB61B908382BE7C9A74AD29D611444C33E1BCC53A33D26`.
 
 The integration does not change the upstream mod identifier, manifest version,
 load priority, permissions, conflicts, or package layout. The existing package
@@ -102,16 +102,18 @@ cache key made only from `[A-Za-z0-9._:-]`. This generic host rule does not
 require a producer prefix. KFP-produced commands use the stricter profile
 `kfp1:<scene8>:<generation>:<phaseId>:<sequence>:<content16>`.
 
-For KFP instances, `cutaway = true` has one narrow host meaning. When the
-public callback value `context.camera.mode` is `first_person`, the adapter
-omits `role = "ceiling"`, `role = "wall"`, and `primitive = "canopy"` items
-within four cells of the player. The radius boundary is included. Released
-canopy packets have normalized cell-center positions but no explicit cell
-coordinates, so the adapter derives their cell from the defensive public
-world snapshot and its `cellSize`. Items outside the radius, other semantic
-roles, and all items in third-person or diorama mode remain visible.
-`cutaway = false` always preserves the item. The adapter reads the frame-local
-public camera context and does not retain it.
+For KFP instances, `cutaway = true` applies the declared interior intent in
+first-person, third-person, and diorama modes. The adapter omits nearby
+`role = "ceiling"` items within four cells of the player. For `role = "wall"`,
+it omits only the nearby shell between the public camera eye and player; far
+and side walls remain as a readable room cross-section. If the public eye is
+unavailable, the wall remains. `primitive = "canopy"` uses the same inclusive
+radius only in first person. Released canopy packets without explicit cell
+coordinates remain compatible: the adapter derives their cell from normalized
+cell-center positions and the defensive world snapshot's `cellSize`. Other
+missing player or item coordinates fail open and keep the geometry visible.
+`cutaway = false`, items outside the radius, and other roles remain visible.
+The adapter does not retain the frame-local camera context.
 
 The adapter copies each accepted cache key and stores an independent bounded
 digest of declarative command content. Reuse with the same content is valid.
@@ -122,7 +124,10 @@ command tables, texture handles, or derived command geometry.
 `command.texture` is an optional opaque resource borrowed only for the active
 draw callback. A string path is refused. The adapter can pass the borrowed
 texture to `Voxel3D.draw`, then unbinds it before returning. It never stores,
-releases, or substitutes ownership of that texture.
+releases, or substitutes ownership of that texture. The shared validator also
+refuses a direct opaque `command.mesh` or `command.resource` combined with a
+texture. That unsafe combination would require the host to mutate one borrowed
+resource to attach another.
 
 Panorama uses a fixed 32-segment host-owned cylinder and its callback-borrowed
 texture. The physical cylinder keeps the released radius of 900 world units,
@@ -135,14 +140,18 @@ only; texture alpha stays the only coverage source, which avoids the host
 shader's ordered-alpha bands.
 
 Cloud layers require a callback-borrowed KFP texture and use one fixed
-eight-quad host mesh, a maximum 192-world-unit span, opaque material coverage,
-and no depth writes. A missing texture fails closed at the shared validator.
-The adapter unbinds a cloud texture after each draw and never retains or
-releases it. This keeps the layers high and non-occluding without the former
-screen-covering translucent fallback planes. Rainbow uses one fixed
-24-segment ribbon. Required declarative fields select bounded transforms,
-density, parallax, and deterministic placement. These are conservative API
-baseline visuals. They do not claim rich parity with KFP 1.x sky art or weather.
+continuous 32-triangle circular host deck, a maximum 192-world-unit diameter,
+opaque material coverage, and no depth writes. Shared vertices and continuous
+UVs remove detached patch edges. The circular half-unit local radius keeps the
+transformed diameter bounded even when the deck rotates. A missing texture
+fails closed at the shared validator. The adapter unbinds a cloud texture after
+each draw and never retains or releases it. If unbinding fails, it evicts and
+releases only the host-owned mesh before it reports the failed draw. This keeps
+the layers high and non-occluding without the former screen-covering
+translucent fallback planes. Rainbow uses one fixed 24-segment ribbon.
+Required declarative fields select bounded transforms, density, parallax, and
+deterministic placement. These are conservative API baseline visuals. They do
+not claim rich parity with KFP 1.x sky art or weather.
 
 Procedural stars expand to at most 2,048 temporary camera-facing items with a
 local Park-Miller stream. The stream is seeded only from the command. It does
@@ -210,12 +219,15 @@ optional capabilities, late registration, guarded hot attach, hot start, and
 handle-invalidate fault cleanup, direct world/update/camera payloads,
 transactional finite camera aggregation, defensive snapshots, edit coalescing,
 radian camera input, graphics restoration, exact draw results, generic safe
-keys, untrusted-key formatting, KFP producer keys, schema rejection, borrowed
-panorama and cloud texture ownership, missing-cloud-texture refusal,
+keys, untrusted-key formatting, KFP producer keys, schema rejection, unsafe
+direct-resource texture refusal, borrowed panorama and cloud texture ownership,
+detach-failure mesh eviction, missing-cloud-texture refusal,
 key-content collision refusal, all shared baseline
-primitives, mode-aware KFP ceiling, wall, and canopy cutaways, cutaway radius boundaries,
-fail-open cell metadata, draw fault isolation, dispatch recovery, deterministic
-continuation, disposal, legacy refusal, and the no-write rule.
+primitives, producer-declared ceiling intent in every camera mode,
+far-shell-preserving wall cross-sections, first-person-only canopy cutaways,
+cutaway radius boundaries, fail-open cell metadata, draw fault isolation,
+dispatch recovery, deterministic continuation, disposal, legacy refusal, and
+the no-write rule.
 
 The canonical KFP dispatcher conformance command is:
 
@@ -224,8 +236,8 @@ luajit tools\run_tests.lua companion
 ```
 
 At integration time, the lifecycle test passed 11 checks, the focused host
-test passed 1,112 checks, the canonical
-companion selector passed 54 tests, and the complete KFP suite passed 215
+test passed 1,301 checks, the canonical
+companion selector passed 54 tests, and the complete KFP suite passed 227
 tests. The complete 23-command ROM-free draw fixture has canonical LF SHA-256
 `DE1DCA98A04AD9446B0AF4C13523DAB7F365BC7A76E70BC44B24F323D98A9BFA`.
 All changed Lua files also compiled with LuaJIT. The large upstream

--- a/docs/VOXEL_COMPANION_API_V1_HOST.md
+++ b/docs/VOXEL_COMPANION_API_V1_HOST.md
@@ -139,16 +139,20 @@ painted skyline is never stretched into the closure. Distance haze changes RGB
 only; texture alpha stays the only coverage source, which avoids the host
 shader's ordered-alpha bands.
 
-Cloud layers require a callback-borrowed KFP texture and use one fixed
-continuous 32-triangle circular host deck, a maximum 192-world-unit diameter,
-opaque material coverage, and no depth writes. Shared vertices and continuous
-UVs remove detached patch edges. The circular half-unit local radius keeps the
-transformed diameter bounded even when the deck rotates. A missing texture
-fails closed at the shared validator. The adapter unbinds a cloud texture after
-each draw and never retains or releases it. If unbinding fails, it evicts and
-releases only the host-owned mesh before it reports the failed draw. This keeps
-the layers high and non-occluding without the former screen-covering
-translucent fallback planes. Rainbow uses one fixed 24-segment ribbon.
+Cloud layers require a callback-borrowed KFP texture and use one fixed closed
+32-by-16 host shell with a maximum 192-world-unit horizontal diameter and a
+maximum 736-world-unit vertical diameter. The shell remains centered on and
+strictly encloses the public camera eye; its upper pole retains the high cloud
+deck position and its lower half closes below the world. Every geometric edge
+has two faces, so opaque mask pixels have no mesh perimeter at which to clip.
+Shared vertices and planar X/Z UV projection also remove longitude seams and
+detached facets. Material coverage is opaque and depth writes remain off. A
+missing texture fails closed at the shared validator. The adapter unbinds a
+cloud texture after each draw and never retains or releases it. If unbinding
+fails, it evicts and releases only the host-owned mesh before it reports the
+failed draw. This keeps the layers high and non-occluding without the former
+screen-covering translucent fallback planes. Rainbow uses one fixed
+24-segment ribbon.
 Required declarative fields select bounded transforms, density, parallax, and
 deterministic placement. These are conservative API baseline visuals. They do
 not claim rich parity with KFP 1.x sky art or weather.
@@ -221,7 +225,8 @@ transactional finite camera aggregation, defensive snapshots, edit coalescing,
 radian camera input, graphics restoration, exact draw results, generic safe
 keys, untrusted-key formatting, KFP producer keys, schema rejection, unsafe
 direct-resource texture refusal, borrowed panorama and cloud texture ownership,
-detach-failure mesh eviction, missing-cloud-texture refusal,
+detach-failure mesh eviction, closed-manifold cloud geometry, camera
+containment, transformed cloud bounds, missing-cloud-texture refusal,
 key-content collision refusal, all shared baseline
 primitives, producer-declared ceiling intent in every camera mode,
 far-shell-preserving wall cross-sections, first-person-only canopy cutaways,
@@ -236,7 +241,7 @@ luajit tools\run_tests.lua companion
 ```
 
 At integration time, the lifecycle test passed 11 checks, the focused host
-test passed 1,301 checks, the canonical
+test passed 2,610 checks, the canonical
 companion selector passed 54 tests, and the complete KFP suite passed 227
 tests. The complete 23-command ROM-free draw fixture has canonical LF SHA-256
 `DE1DCA98A04AD9446B0AF4C13523DAB7F365BC7A76E70BC44B24F323D98A9BFA`.

--- a/docs/VOXEL_COMPANION_API_V1_HOST.md
+++ b/docs/VOXEL_COMPANION_API_V1_HOST.md
@@ -82,6 +82,41 @@ protected by one outer fault boundary. It does not use a protected call for
 each cell query. This keeps map-change work bounded without adding several
 protected calls per cell. Player movement does not rebuild the full map.
 
+### Semantic density-tag contract
+
+Density roles are Boolean values in each normalized cell's existing `tags`
+table. They are host facts, not guesses from broad geometry classes:
+
+| Tag | Battle Art meaning |
+|---|---|
+| `tree_support` | Verified solid, non-walkable OVERWORLD cylinder tile 64, 65, 80, or 81 |
+| `boulder_tree` | Verified solid, non-walkable OVERWORLD cylinder tile 42, 43, 58, or 59; eligible for KFP's optional boulder-tree conversion |
+| `mountain_seed` | Authored OVERWORLD rock tile 2 or 36 that passes the mountain-context gates |
+| `mountain_support` | A seed, or an eligible upright rock cell reached within two four-neighbor steps of a seed |
+
+Water and walkable cells never receive a density role. Thus a connection
+overlay that exposes a walkable cylinder remains a raw `cylinder` record and
+does not become a tree or boulder. An unknown cylinder also keeps only its raw
+shape facts. Broad `tree` is added only for a verified tree (or a solid host
+class that is itself explicitly `tree` or `canopy`). Broad `mountain` is added
+only with `mountain_support`; generic `wall`, `cliff`, `rock`, and `cylinder`
+names do not imply it.
+
+Mountain candidates must be outdoors, solid, non-walkable, non-water,
+`wall` or `cliff` cells, and outside active two-cell connection bands. A roof
+in the surrounding 5-by-5 cell neighborhood rejects both a seed and a support
+candidate. A door in that neighborhood rejects only non-seed support, so an
+authored cliff can still form the shoulders of a cave mouth. Seeds also carry
+`mountain_support`. The bounded four-neighbor flood never promotes an unrelated
+wall more than two cells from an accepted seed.
+
+The tile identities and mountain gates are taken from the public KFP 1.60
+`payload_flora.lua` in [Kanto in First Person 1.60.0](https://github.com/mrmushrooms11/kanto-first-person/releases/tag/firstperson1.60.0).
+The audited release ZIP SHA-256 is
+`b54b28271918aaab9a11ced66247898e51cff5e5f03d3530ff3b81bb3b25af29`.
+The host remains the only layer that interprets its tile ids and classes. KFP
+consumes these normalized roles and does not inspect host or engine internals.
+
 ## Draw adapter and safety
 
 The draw facade implements the three v1 draw methods:
@@ -231,8 +266,10 @@ key-content collision refusal, all shared baseline
 primitives, producer-declared ceiling intent in every camera mode,
 far-shell-preserving wall cross-sections, first-person-only canopy cutaways,
 cutaway radius boundaries, fail-open cell metadata, draw fault isolation,
-dispatch recovery, deterministic continuation, disposal, legacy refusal, and
-the no-write rule.
+dispatch recovery, deterministic continuation, disposal, legacy refusal, the
+no-write rule, exact tree and boulder roles, walkable and unknown cylinder
+rejection, and bounded mountain seed, support, roof, door, and connection
+policies.
 
 The canonical KFP dispatcher conformance command is:
 
@@ -241,7 +278,7 @@ luajit tools\run_tests.lua companion
 ```
 
 At integration time, the lifecycle test passed 11 checks, the focused host
-test passed 2,610 checks, the canonical
+test passed 2,636 checks, the canonical
 companion selector passed 54 tests, and the complete KFP suite passed 227
 tests. The complete 23-command ROM-free draw fixture has canonical LF SHA-256
 `DE1DCA98A04AD9446B0AF4C13523DAB7F365BC7A76E70BC44B24F323D98A9BFA`.

--- a/docs/VOXEL_COMPANION_API_V1_HOST.md
+++ b/docs/VOXEL_COMPANION_API_V1_HOST.md
@@ -15,7 +15,7 @@
   2026-08-21T16:36:55-04:00.
 - Development source: <https://github.com/bryanthaboi/gen1recomp/commit/087a2751895899ad6e79800599ae27a8f40cf1e3>
 - Frozen Voxel Companion API reference dispatcher: byte-exact SHA-256
-  `7860E9A628F65B0252250F5EE564DB99E7D2C34415BBA82BB4380A6C6588E58C`.
+  `864DA19493F773A52FB2111EFC02D79E9882B87C5A762AF5B124326A74A32B33`.
 
 The integration does not change the upstream mod identifier, manifest version,
 load priority, permissions, conflicts, or package layout. The existing package
@@ -140,7 +140,9 @@ registration. Later descriptor changes cannot replace cleanup behavior.
 Validation failures always clear dispatch state, so a bad callback payload does
 not block the next frame. Camera merging is transactional: if finite inputs
 would make an aggregate non-finite, only that contribution is faulted and later
-extensions continue from the last finite aggregate.
+extensions continue from the last finite aggregate. The dispatcher keeps its
+reentrancy guard active through fault cleanup. A failed extension's cleanup
+cannot reenter dispatch, register another extension, or dispose the dispatcher.
 
 The adapter does not replace a global LÖVE callback. It does not retain borrowed
 callback contexts or service leases. Disposal releases adapter GPU resources
@@ -175,7 +177,8 @@ luajit tests\voxel_companion_api_v1_test.lua
 ```
 
 It covers descriptor truthfulness, canonical flat callbacks, callback snapshots,
-optional capabilities, late registration, direct world/update/camera payloads,
+optional capabilities, late registration, guarded hot attach, hot start, and
+handle-invalidate fault cleanup, direct world/update/camera payloads,
 transactional finite camera aggregation, defensive snapshots, edit coalescing,
 radian camera input, graphics restoration, exact draw results, generic safe
 keys, untrusted-key formatting, KFP producer keys, schema rejection, borrowed
@@ -189,8 +192,8 @@ The canonical KFP dispatcher conformance command is:
 luajit tools\run_tests.lua companion
 ```
 
-At integration time, the focused host test passed 622 checks, the canonical
-companion selector passed 51 tests, and the complete KFP suite passed 212
+At integration time, the focused host test passed 660 checks, the canonical
+companion selector passed 54 tests, and the complete KFP suite passed 215
 tests. The complete 23-command ROM-free draw fixture has SHA-256
 `4CD7A8C9D258B247CB9AE0A9730E56DE3E9541B63358149A2AD09513F655A113`.
 All changed Lua files also compiled with LuaJIT. The large upstream

--- a/docs/VOXEL_COMPANION_API_V1_HOST.md
+++ b/docs/VOXEL_COMPANION_API_V1_HOST.md
@@ -15,7 +15,7 @@
   2026-08-21T16:36:55-04:00.
 - Development source: <https://github.com/bryanthaboi/gen1recomp/commit/087a2751895899ad6e79800599ae27a8f40cf1e3>
 - Frozen Voxel Companion API reference dispatcher: byte-exact SHA-256
-  `6150DA890F36666AFA88C7EE2E48D57F6C77D1C9678B7B34C988C24997ADA3A3`.
+  `7860E9A628F65B0252250F5EE564DB99E7D2C34415BBA82BB4380A6C6588E58C`.
 
 The integration does not change the upstream mod identifier, manifest version,
 load priority, permissions, conflicts, or package layout. The existing package
@@ -134,6 +134,14 @@ each draw, including a failed draw. The reference dispatcher isolates callback
 faults, records a bounded diagnostic, disposes the failed extension once, and
 continues later extensions in deterministic order.
 
+The dispatcher never calls conversion callbacks while it labels an untrusted
+table key. It copies validated flat lifecycle callback references during
+registration. Later descriptor changes cannot replace cleanup behavior.
+Validation failures always clear dispatch state, so a bad callback payload does
+not block the next frame. Camera merging is transactional: if finite inputs
+would make an aggregate non-finite, only that contribution is faulted and later
+extensions continue from the last finite aggregate.
+
 The adapter does not replace a global LÖVE callback. It does not retain borrowed
 callback contexts or service leases. Disposal releases adapter GPU resources
 and drops world and activation references.
@@ -166,13 +174,14 @@ Run the focused host test from the repository root:
 luajit tests\voxel_companion_api_v1_test.lua
 ```
 
-It covers descriptor truthfulness, canonical flat callbacks, optional
-capabilities, late registration, direct world/update/camera payloads, defensive
-snapshots, edit coalescing, radian camera input, graphics restoration, exact
-draw results, generic safe keys, KFP producer keys, schema rejection, borrowed
+It covers descriptor truthfulness, canonical flat callbacks, callback snapshots,
+optional capabilities, late registration, direct world/update/camera payloads,
+transactional finite camera aggregation, defensive snapshots, edit coalescing,
+radian camera input, graphics restoration, exact draw results, generic safe
+keys, untrusted-key formatting, KFP producer keys, schema rejection, borrowed
 texture ownership, key-content collision refusal, all shared baseline
-primitives, draw fault isolation, deterministic continuation, disposal, legacy
-refusal, and the no-write rule.
+primitives, draw fault isolation, dispatch recovery, deterministic continuation,
+disposal, legacy refusal, and the no-write rule.
 
 The canonical KFP dispatcher conformance command is:
 
@@ -180,8 +189,8 @@ The canonical KFP dispatcher conformance command is:
 luajit tools\run_tests.lua companion
 ```
 
-At integration time, the focused host test passed 577 checks, the canonical
-companion selector passed 40 tests, and the complete KFP suite passed 196
+At integration time, the focused host test passed 622 checks, the canonical
+companion selector passed 51 tests, and the complete KFP suite passed 212
 tests. The complete 23-command ROM-free draw fixture has SHA-256
 `4CD7A8C9D258B247CB9AE0A9730E56DE3E9541B63358149A2AD09513F655A113`.
 All changed Lua files also compiled with LuaJIT. The large upstream

--- a/docs/VOXEL_COMPANION_API_V1_HOST.md
+++ b/docs/VOXEL_COMPANION_API_V1_HOST.md
@@ -43,11 +43,13 @@ those passes.
 
 The adapter uses only existing host-owned seams:
 
-1. `update(frame)` runs from the voxel pipeline update. It also runs while the
-   voxel display level is off, so extension compilation can finish before the
-   player selects the mode.
-2. `worldChanged(snapshot)` runs after a real world identity change. Multiple
-   block edits before one update coalesce into one snapshot revision.
+1. The public `core.update` hook runs the engine update first, then observes
+   `game.overworld` and sends `update(frame)`. It also runs while the voxel
+   display level is off, so extension compilation can finish before the player
+   selects the mode.
+2. Startup can have no map. The adapter keeps one snapshot pending and sends
+   `worldChanged(snapshot)` when the real overworld becomes ready. Later map
+   identities and coalesced block edits send one newer revision.
 3. `modifyCamera(camera)` runs after the first-person rig is built and before
    projection. The host applies finite additive values only. Position is
    limited to 32 world units per axis, rotation to 0.5 radians per axis, and
@@ -181,10 +183,12 @@ scan and refusal do not write, restore, remove, or rename any file.
 Run the focused host test from the repository root:
 
 ```text
+luajit tests\companion_lifecycle_test.lua
 luajit tests\voxel_companion_api_v1_test.lua
 ```
 
-It covers descriptor truthfulness, canonical flat callbacks, callback snapshots,
+They cover delayed overworld readiness through the public core hook, descriptor
+truthfulness, canonical flat callbacks, callback snapshots,
 optional capabilities, late registration, guarded hot attach, hot start, and
 handle-invalidate fault cleanup, direct world/update/camera payloads,
 transactional finite camera aggregation, defensive snapshots, edit coalescing,
@@ -201,7 +205,8 @@ The canonical KFP dispatcher conformance command is:
 luajit tools\run_tests.lua companion
 ```
 
-At integration time, the focused host test passed 684 checks, the canonical
+At integration time, the lifecycle test passed 11 checks, the focused host
+test passed 702 checks, the canonical
 companion selector passed 54 tests, and the complete KFP suite passed 215
 tests. The complete 23-command ROM-free draw fixture has SHA-256
 `4CD7A8C9D258B247CB9AE0A9730E56DE3E9541B63358149A2AD09513F655A113`.

--- a/docs/VOXEL_COMPANION_API_V1_HOST.md
+++ b/docs/VOXEL_COMPANION_API_V1_HOST.md
@@ -102,13 +102,16 @@ cache key made only from `[A-Za-z0-9._:-]`. This generic host rule does not
 require a producer prefix. KFP-produced commands use the stricter profile
 `kfp1:<scene8>:<generation>:<phaseId>:<sequence>:<content16>`.
 
-For KFP box instances, `cutaway = true` has one narrow host meaning. When the
+For KFP instances, `cutaway = true` has one narrow host meaning. When the
 public callback value `context.camera.mode` is `first_person`, the adapter
-omits `role = "ceiling"` and `role = "wall"` items within four cells of the
-player. The radius boundary is included. Items outside that radius, other
-semantic roles, items without cell coordinates, and all items in third-person
-or diorama mode remain visible. `cutaway = false` always preserves the item.
-The adapter reads the frame-local public camera context and does not retain it.
+omits `role = "ceiling"`, `role = "wall"`, and `primitive = "canopy"` items
+within four cells of the player. The radius boundary is included. Released
+canopy packets have normalized cell-center positions but no explicit cell
+coordinates, so the adapter derives their cell from the defensive public
+world snapshot and its `cellSize`. Items outside the radius, other semantic
+roles, and all items in third-person or diorama mode remain visible.
+`cutaway = false` always preserves the item. The adapter reads the frame-local
+public camera context and does not retain it.
 
 The adapter copies each accepted cache key and stores an independent bounded
 digest of declarative command content. Reuse with the same content is valid.
@@ -122,7 +125,16 @@ texture to `Voxel3D.draw`, then unbinds it before returning. It never stores,
 releases, or substitutes ownership of that texture.
 
 Panorama uses a fixed 32-segment host-owned cylinder and its callback-borrowed
-texture. Cloud layers use one fixed eight-quad host mesh. Rainbow uses one fixed
+texture. The physical cylinder keeps the released radius of 900 world units,
+top at 300, normal bottom at -120, and deep-skirt bottom at -1400.
+`sourceWidth` and `targetWidth` are texture quality metadata and never scale
+world geometry. Distance haze changes RGB only; texture alpha stays the only
+coverage source, which avoids the host shader's ordered-alpha bands.
+
+Cloud layers use one fixed eight-quad host mesh, a bounded host-owned 32 by 32
+binary alpha mask, a maximum 192-world-unit span, and no depth writes. This
+keeps the texture-free portable baseline high and non-occluding without the
+screen-covering translucent fallback planes. Rainbow uses one fixed
 24-segment ribbon. Required declarative fields select bounded transforms,
 density, parallax, and deterministic placement. These are conservative API
 baseline visuals. They do not claim rich parity with KFP 1.x sky art or weather.
@@ -195,7 +207,7 @@ transactional finite camera aggregation, defensive snapshots, edit coalescing,
 radian camera input, graphics restoration, exact draw results, generic safe
 keys, untrusted-key formatting, KFP producer keys, schema rejection, borrowed
 texture ownership, key-content collision refusal, all shared baseline
-primitives, mode-aware KFP ceiling and wall cutaways, cutaway radius boundaries,
+primitives, mode-aware KFP ceiling, wall, and canopy cutaways, cutaway radius boundaries,
 fail-open cell metadata, draw fault isolation, dispatch recovery, deterministic
 continuation, disposal, legacy refusal, and the no-write rule.
 
@@ -206,7 +218,7 @@ luajit tools\run_tests.lua companion
 ```
 
 At integration time, the lifecycle test passed 11 checks, the focused host
-test passed 702 checks, the canonical
+test passed 725 checks, the canonical
 companion selector passed 54 tests, and the complete KFP suite passed 215
 tests. The complete 23-command ROM-free draw fixture has SHA-256
 `4CD7A8C9D258B247CB9AE0A9730E56DE3E9541B63358149A2AD09513F655A113`.

--- a/docs/VOXEL_COMPANION_API_V1_HOST.md
+++ b/docs/VOXEL_COMPANION_API_V1_HOST.md
@@ -10,8 +10,8 @@
   `06e06e305bbcefe97c216a31bb25265ffb5e6b18`, dated
   2026-08-21T14:38:54-04:00.
 - Gen1recomp source: <https://github.com/bryanthaboi/gen1recomp/commit/06e06e305bbcefe97c216a31bb25265ffb5e6b18>
-- Voxel Companion API reference dispatcher: normalized SHA-256
-  `7ACB41E52757898038454D2EA673AAE5AC1ED66768DBA38E4FD8104702FD569B`.
+- Frozen Voxel Companion API reference dispatcher: byte-exact SHA-256
+  `6150DA890F36666AFA88C7EE2E48D57F6C77D1C9678B7B34C988C24997ADA3A3`.
 
 The integration does not change the upstream mod identifier, manifest version,
 load priority, permissions, conflicts, or package layout. The existing package
@@ -81,8 +81,29 @@ protected calls per cell. Player movement does not rebuild the full map.
 The draw facade implements the three v1 draw methods:
 
 - `mesh` for a box, plane, and centered world apron
-- `instances` for bounded prototype batches
-- `billboards` for bounded camera-facing batches
+- `instances` for bounded batches of box, plane, door frame, window, poster,
+  rail, fixture, sconce, cave roof, grass clump, canopy, vine, umbrella,
+  mountain, and hood prototypes
+- `billboards` for bounded explicit camera-facing items
+
+Extensions call each method with the canonical dot-call form
+`draw.<kind>(command, context)`. A draw returns exactly `true` when the host
+accepts it. A rejection returns `false, error`; it does not throw across the
+facade boundary. Every command must use `schemaVersion = 1` and a 1 to 64 byte
+cache key made only from `[A-Za-z0-9._:-]`. This generic host rule does not
+require a producer prefix. KFP-produced commands use the stricter profile
+`kfp1:<scene8>:<generation>:<phaseId>:<sequence>:<content16>`.
+
+The adapter copies each accepted cache key and stores an independent bounded
+digest of declarative command content. Reuse with the same content is valid.
+Reuse with different content fails closed. The registry holds at most 4,096
+entries and is cleared on invalidation. It does not retain commands, nested
+command tables, texture handles, or derived command geometry.
+
+`command.texture` is an optional opaque resource borrowed only for the active
+draw callback. A string path is refused. The adapter can pass the borrowed
+texture to `Voxel3D.draw`, then unbinds it before returning. It never stores,
+releases, or substitutes ownership of that texture.
 
 One phase accepts at most 2,048 items per packet and 4,096 draws per frame.
 Geometry positions and primitive sizes are finite and limited to 65,536 host
@@ -130,9 +151,11 @@ luajit tests\voxel_companion_api_v1_test.lua
 
 It covers descriptor truthfulness, canonical flat callbacks, optional
 capabilities, late registration, direct world/update/camera payloads, defensive
-snapshots, edit coalescing, radian camera input, graphics restoration, draw
-fault isolation, deterministic continuation, disposal, legacy refusal, and the
-no-write rule.
+snapshots, edit coalescing, radian camera input, graphics restoration, exact
+draw results, generic safe keys, KFP producer keys, schema rejection, borrowed
+texture ownership, key-content collision refusal, all shared baseline
+primitives, draw fault isolation, deterministic continuation, disposal, legacy
+refusal, and the no-write rule.
 
 The canonical KFP dispatcher conformance command is:
 
@@ -140,8 +163,11 @@ The canonical KFP dispatcher conformance command is:
 luajit tools\run_tests.lua companion
 ```
 
-At integration time, the focused host test passed 76 checks and the canonical
-KFP suite passed 32 tests. All changed Lua files also compiled with LuaJIT. The
-large upstream `tests/battle_art_voxel_fork_test.lua` cannot compile as one
-LuaJIT chunk because its main function already exceeds LuaJIT's 200-local
-limit. This is an upstream test-harness limit, not a companion adapter failure.
+At integration time, the focused host test passed 263 checks, the canonical
+companion selector passed 38 tests, and the complete KFP suite passed 191
+tests. The shared ROM-free draw fixture has SHA-256
+`A817618D9BAD3C3849B71DF02C255ECA53CBC74B0660A38031EC8399D22FE6A5`.
+All changed Lua files also compiled with LuaJIT. The large upstream
+`tests/battle_art_voxel_fork_test.lua` cannot compile as one LuaJIT chunk
+because its main function already exceeds LuaJIT's 200-local limit. This is an
+upstream test-harness limit, not a companion adapter failure.

--- a/docs/VOXEL_COMPANION_API_V1_HOST.md
+++ b/docs/VOXEL_COMPANION_API_V1_HOST.md
@@ -131,9 +131,11 @@ top at 300, normal bottom at -120, and deep-skirt bottom at -1400.
 world geometry. Distance haze changes RGB only; texture alpha stays the only
 coverage source, which avoids the host shader's ordered-alpha bands.
 
-Cloud layers use one fixed eight-quad host mesh, a bounded host-owned 32 by 32
-binary alpha mask, a maximum 192-world-unit span, and no depth writes. This
-keeps the texture-free portable baseline high and non-occluding without the
+Cloud layers require a callback-borrowed KFP texture and use one fixed
+eight-quad host mesh, a maximum 192-world-unit span, opaque material coverage,
+and no depth writes. A missing texture fails closed at the shared validator.
+The adapter unbinds a cloud texture after each draw and never retains or
+releases it. This keeps the layers high and non-occluding without the former
 screen-covering translucent fallback planes. Rainbow uses one fixed
 24-segment ribbon. Required declarative fields select bounded transforms,
 density, parallax, and deterministic placement. These are conservative API
@@ -206,7 +208,8 @@ handle-invalidate fault cleanup, direct world/update/camera payloads,
 transactional finite camera aggregation, defensive snapshots, edit coalescing,
 radian camera input, graphics restoration, exact draw results, generic safe
 keys, untrusted-key formatting, KFP producer keys, schema rejection, borrowed
-texture ownership, key-content collision refusal, all shared baseline
+panorama and cloud texture ownership, missing-cloud-texture refusal,
+key-content collision refusal, all shared baseline
 primitives, mode-aware KFP ceiling, wall, and canopy cutaways, cutaway radius boundaries,
 fail-open cell metadata, draw fault isolation, dispatch recovery, deterministic
 continuation, disposal, legacy refusal, and the no-write rule.
@@ -220,8 +223,8 @@ luajit tools\run_tests.lua companion
 At integration time, the lifecycle test passed 11 checks, the focused host
 test passed 725 checks, the canonical
 companion selector passed 54 tests, and the complete KFP suite passed 215
-tests. The complete 23-command ROM-free draw fixture has SHA-256
-`4CD7A8C9D258B247CB9AE0A9730E56DE3E9541B63358149A2AD09513F655A113`.
+tests. The complete 23-command ROM-free draw fixture has canonical LF SHA-256
+`DE1DCA98A04AD9446B0AF4C13523DAB7F365BC7A76E70BC44B24F323D98A9BFA`.
 All changed Lua files also compiled with LuaJIT. The large upstream
 `tests/battle_art_voxel_fork_test.lua` cannot compile as one LuaJIT chunk
 because its main function already exceeds LuaJIT's 200-local limit. This is an

--- a/docs/VOXEL_COMPANION_API_V1_HOST.md
+++ b/docs/VOXEL_COMPANION_API_V1_HOST.md
@@ -100,6 +100,14 @@ cache key made only from `[A-Za-z0-9._:-]`. This generic host rule does not
 require a producer prefix. KFP-produced commands use the stricter profile
 `kfp1:<scene8>:<generation>:<phaseId>:<sequence>:<content16>`.
 
+For KFP box instances, `cutaway = true` has one narrow host meaning. When the
+public callback value `context.camera.mode` is `first_person`, the adapter
+omits `role = "ceiling"` and `role = "wall"` items within four cells of the
+player. The radius boundary is included. Items outside that radius, other
+semantic roles, items without cell coordinates, and all items in third-person
+or diorama mode remain visible. `cutaway = false` always preserves the item.
+The adapter reads the frame-local public camera context and does not retain it.
+
 The adapter copies each accepted cache key and stores an independent bounded
 digest of declarative command content. Reuse with the same content is valid.
 Reuse with different content fails closed. The registry holds at most 4,096
@@ -183,8 +191,9 @@ transactional finite camera aggregation, defensive snapshots, edit coalescing,
 radian camera input, graphics restoration, exact draw results, generic safe
 keys, untrusted-key formatting, KFP producer keys, schema rejection, borrowed
 texture ownership, key-content collision refusal, all shared baseline
-primitives, draw fault isolation, dispatch recovery, deterministic continuation,
-disposal, legacy refusal, and the no-write rule.
+primitives, mode-aware KFP ceiling and wall cutaways, cutaway radius boundaries,
+fail-open cell metadata, draw fault isolation, dispatch recovery, deterministic
+continuation, disposal, legacy refusal, and the no-write rule.
 
 The canonical KFP dispatcher conformance command is:
 
@@ -192,7 +201,7 @@ The canonical KFP dispatcher conformance command is:
 luajit tools\run_tests.lua companion
 ```
 
-At integration time, the focused host test passed 660 checks, the canonical
+At integration time, the focused host test passed 684 checks, the canonical
 companion selector passed 54 tests, and the complete KFP suite passed 215
 tests. The complete 23-command ROM-free draw fixture has SHA-256
 `4CD7A8C9D258B247CB9AE0A9730E56DE3E9541B63358149A2AD09513F655A113`.

--- a/lib/CompanionLifecycle.lua
+++ b/lib/CompanionLifecycle.lua
@@ -1,0 +1,33 @@
+-- Public engine lifecycle binding for the Voxel Companion host.
+
+local CompanionLifecycle = {}
+
+local unpack = table.unpack or unpack
+
+local function pack(...)
+  return { n = select("#", ...), ... }
+end
+
+function CompanionLifecycle.install(mod, companion)
+  assert(type(mod) == "table" and type(mod.hooks) == "table"
+      and type(mod.hooks.wrap) == "function",
+    "CompanionLifecycle needs the public mod hook facade")
+  assert(type(companion) == "table"
+      and type(companion.updateFromGame) == "function",
+    "CompanionLifecycle needs a companion adapter")
+
+  local reportedFault = false
+  return mod.hooks:wrap("core.update", function(next, game, dt)
+    local results = pack(next(game, dt))
+    local ok, err = pcall(companion.updateFromGame, companion, dt, game)
+    if not ok and not reportedFault then
+      reportedFault = true
+      if mod.log and type(mod.log.error) == "function" then
+        mod.log:error("Voxel Companion update failed: %s", tostring(err))
+      end
+    end
+    return unpack(results, 1, results.n)
+  end)
+end
+
+return CompanionLifecycle

--- a/lib/Voxel3D.lua
+++ b/lib/Voxel3D.lua
@@ -573,6 +573,101 @@ end
 -- way either way.
 Voxel3D.camera = nil
 
+-- One-frame additive camera input from a Voxel Companion extension. The
+-- host retains the base rig and applies only finite, bounded deltas. A fresh
+-- value is supplied for every rendered frame, including a zero result.
+Voxel3D.companionCameraDelta = nil
+
+local function finiteDelta(value)
+  value = tonumber(value)
+  if not value or value ~= value or value == math.huge or value == -math.huge then
+    return 0
+  end
+  return value
+end
+
+function Voxel3D.setCompanionCameraDelta(delta)
+  if type(delta) ~= "table" then
+    Voxel3D.companionCameraDelta = nil
+    return
+  end
+  local position = type(delta.positionDelta) == "table" and delta.positionDelta or {}
+  local rotation = type(delta.rotationDelta) == "table" and delta.rotationDelta or {}
+  Voxel3D.companionCameraDelta = {
+    positionDelta = {
+      x = math.max(-32, math.min(32, finiteDelta(position.x))),
+      y = math.max(-32, math.min(32, finiteDelta(position.y))),
+      z = math.max(-32, math.min(32, finiteDelta(position.z))),
+    },
+    rotationDelta = {
+      yaw = math.max(-0.5, math.min(0.5, finiteDelta(rotation.yaw))),
+      pitch = math.max(-0.5, math.min(0.5, finiteDelta(rotation.pitch))),
+      roll = math.max(-0.5, math.min(0.5, finiteDelta(rotation.roll))),
+    },
+    fovDelta = finiteDelta(delta.fovDelta),
+  }
+end
+
+local function normalize3(value, fallback)
+  local x, y, z = value[1] or 0, value[2] or 0, value[3] or 0
+  local length = math.sqrt(x * x + y * y + z * z)
+  if length < 1e-6 then return fallback[1], fallback[2], fallback[3] end
+  return x / length, y / length, z / length
+end
+
+local function cross3(ax, ay, az, bx, by, bz)
+  return ay * bz - az * by, az * bx - ax * bz, ax * by - ay * bx
+end
+
+local function rotateAxis(x, y, z, ax, ay, az, angle)
+  if math.abs(angle) < 1e-9 then return x, y, z end
+  local c, s = math.cos(angle), math.sin(angle)
+  local dot = x * ax + y * ay + z * az
+  local cx, cy, cz = cross3(ax, ay, az, x, y, z)
+  return x * c + cx * s + ax * dot * (1 - c),
+         y * c + cy * s + ay * dot * (1 - c),
+         z * c + cz * s + az * dot * (1 - c)
+end
+
+local function cameraWithDelta(camera)
+  local delta = Voxel3D.companionCameraDelta
+  if not delta then return camera end
+  local eye, focus = camera.eye, camera.focus
+  if not (type(eye) == "table" and type(focus) == "table") then return camera end
+  local px, py, pz = delta.positionDelta.x, delta.positionDelta.y,
+    delta.positionDelta.z
+  local ex, ey, ez = eye[1] + px, eye[2] + py, eye[3] + pz
+  local dx, dy, dz = focus[1] - eye[1], focus[2] - eye[2], focus[3] - eye[3]
+  local distance = math.max(1e-3, math.sqrt(dx * dx + dy * dy + dz * dz))
+  dx, dy, dz = dx / distance, dy / distance, dz / distance
+
+  local rotation = delta.rotationDelta
+  dx, dy, dz = rotateAxis(dx, dy, dz, 0, 1, 0, rotation.yaw)
+  local rx, ry, rz = cross3(dx, dy, dz, 0, 1, 0)
+  rx, ry, rz = normalize3({ rx, ry, rz }, { 1, 0, 0 })
+  local baseUp = camera.up or { 0, 1, 0 }
+  local ux, uy, uz = normalize3(baseUp, { 0, 1, 0 })
+  dx, dy, dz = rotateAxis(dx, dy, dz, rx, ry, rz, rotation.pitch)
+  ux, uy, uz = rotateAxis(ux, uy, uz, rx, ry, rz, rotation.pitch)
+
+  ux, uy, uz = rotateAxis(ux, uy, uz, dx, dy, dz, rotation.roll)
+
+  -- Voxel Companion API v1 defines both base FOV and additive FOV in radians.
+  local baseFov = finiteDelta(camera.fov)
+  if baseFov <= 0 then baseFov = math.rad(65) end
+  local fovDelta = delta.fovDelta
+  local fov = math.max(math.rad(20), math.min(math.rad(120),
+    baseFov + math.max(-math.rad(30),
+      math.min(math.rad(30), fovDelta))))
+  return {
+    eye = { ex, ey, ez },
+    focus = { ex + dx * distance, ey + dy * distance, ez + dz * distance },
+    up = { ux, uy, uz },
+    fov = fov,
+    curve = camera.curve,
+  }
+end
+
 -- ------- which way, and how steeply, this camera looks
 --
 -- Two facts about the view direction, set alongside the eye and the focus
@@ -613,6 +708,7 @@ end
 function Voxel3D.viewProjection(cx, cy, vw, vh)
   local cam = Voxel3D.camera
   if cam then
+    cam = cameraWithDelta(cam)
     local eye, focus = cam.eye, cam.focus
     Voxel3D.eye = eye
     -- kept beside the eye for horizonY: where the sky's pale end goes is a
@@ -1419,6 +1515,7 @@ end
 
 -- Drop the GPU objects (window resize, hot reload).
 function Voxel3D.invalidate()
+  Voxel3D.companionCameraDelta = nil
   for name, slotHeld in pairs(slots) do
     releaseSlot(slotHeld)
     slots[name] = nil

--- a/lib/VoxelCompanion.lua
+++ b/lib/VoxelCompanion.lua
@@ -44,7 +44,8 @@ local MAX_SIGNATURE_NODES = 32768
 local MAX_SIGNATURE_BYTES = 256 * 1024
 local MAX_SKY_LAYER = 16
 local PANORAMA_SEGMENTS = 32
-local CLOUD_SEGMENTS = 32
+local CLOUD_LONGITUDE_SEGMENTS = 32
+local CLOUD_LATITUDE_SEGMENTS = 16
 local RAINBOW_SEGMENTS = 24
 local PANORAMA_RADIUS = 900
 local PANORAMA_TOP = 300
@@ -342,20 +343,54 @@ local function buildPanorama(deepSkirt)
 end
 
 local function buildCloudLayer()
-  -- One planar fan keeps the texture continuous across the full cloud deck.
-  -- Its circular perimeter has a fixed radius, so rotation cannot expand the
-  -- declared span or expose the clipped edges of detached square patches.
-  local vertices = { { 0, 0, 0, 0.5, 0.5, 1 } }
-  local indices = {}
-  for segment = 0, CLOUD_SEGMENTS - 1 do
-    local angle = segment * math.pi * 2 / CLOUD_SEGMENTS
-    local x, z = math.cos(angle) * 0.5, math.sin(angle) * 0.5
-    vertices[#vertices + 1] = { x, 0, z, x + 0.5, z + 0.5, 1 }
+  -- A closed inward-facing shell has no perimeter at which an opaque cloud
+  -- texel can be clipped. Planar X/Z projection keeps UVs continuous across
+  -- every shared edge without a longitude seam or detached mesh facets.
+  local vertices, indices = {}, {}
+  vertices[1] = { 0, 0.5, 0, 0.5, 0.5, 1 }
+  for latitude = 1, CLOUD_LATITUDE_SEGMENTS - 1 do
+    local polar = latitude * math.pi / CLOUD_LATITUDE_SEGMENTS
+    local ringRadius = math.sin(polar) * 0.5
+    local y = math.cos(polar) * 0.5
+    for longitude = 0, CLOUD_LONGITUDE_SEGMENTS - 1 do
+      local azimuth = longitude * math.pi * 2 / CLOUD_LONGITUDE_SEGMENTS
+      local x = math.cos(azimuth) * ringRadius
+      local z = math.sin(azimuth) * ringRadius
+      vertices[#vertices + 1] = { x, y, z, x + 0.5, z + 0.5, 1 }
+    end
   end
-  for segment = 0, CLOUD_SEGMENTS - 1 do
+  local south = #vertices + 1
+  vertices[south] = { 0, -0.5, 0, 0.5, 0.5, 1 }
+
+  local function ringVertex(latitude, longitude)
+    return 2 + (latitude - 1) * CLOUD_LONGITUDE_SEGMENTS
+      + longitude % CLOUD_LONGITUDE_SEGMENTS
+  end
+
+  for longitude = 0, CLOUD_LONGITUDE_SEGMENTS - 1 do
     indices[#indices + 1] = 1
-    indices[#indices + 1] = segment + 2
-    indices[#indices + 1] = ((segment + 1) % CLOUD_SEGMENTS) + 2
+    indices[#indices + 1] = ringVertex(1, longitude)
+    indices[#indices + 1] = ringVertex(1, longitude + 1)
+  end
+  for latitude = 1, CLOUD_LATITUDE_SEGMENTS - 2 do
+    for longitude = 0, CLOUD_LONGITUDE_SEGMENTS - 1 do
+      local upper = ringVertex(latitude, longitude)
+      local upperNext = ringVertex(latitude, longitude + 1)
+      local lower = ringVertex(latitude + 1, longitude)
+      local lowerNext = ringVertex(latitude + 1, longitude + 1)
+      indices[#indices + 1] = upper
+      indices[#indices + 1] = lower
+      indices[#indices + 1] = lowerNext
+      indices[#indices + 1] = upper
+      indices[#indices + 1] = lowerNext
+      indices[#indices + 1] = upperNext
+    end
+  end
+  local lastRing = CLOUD_LATITUDE_SEGMENTS - 1
+  for longitude = 0, CLOUD_LONGITUDE_SEGMENTS - 1 do
+    indices[#indices + 1] = ringVertex(lastRing, longitude)
+    indices[#indices + 1] = south
+    indices[#indices + 1] = ringVertex(lastRing, longitude + 1)
   end
   return Voxel3D.newMesh(vertices, indices)
 end
@@ -694,19 +729,20 @@ local function skyPrimitive(self, prototype)
     local parallax = clamp(prototype.parallax, -2, 2, 0)
     local density = clamp(prototype.density, 0, 1, 0.5)
     local state = localSeed(prototype.seed) or 1
-    local offsetX, offsetZ, angle
-    state, offsetX = nextUnit(state)
-    state, offsetZ = nextUnit(state)
+    local angle
     state, angle = nextUnit(state)
-    local span = 128 + density * 64
-    local x = eyeX * (1 - parallax) + (offsetX - 0.5) * 48
-    local z = eyeZ * (1 - parallax) + (offsetZ - 0.5) * 48
+    local visualLayer = math.min(layer, 3)
+    local span = 112 + density * 56 + visualLayer * 8
+    local verticalSpan = 448 + visualLayer * 96
+    angle = math.fmod(angle * math.pi * 2
+      + (eyeX + eyeZ) * parallax / math.max(span, 1), math.pi * 2)
     local model = Mat4.mul(Mat4.translate(
-      clamp(x, -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0),
-      clamp(eyeY + 160 + layer * 48,
+      eyeX,
+      clamp(eyeY - 64,
         -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0),
-      clamp(z, -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0)),
-      Mat4.mul(Mat4.rotateY(angle * math.pi * 2), Mat4.scale(span, 1, span)))
+      eyeZ),
+      Mat4.mul(Mat4.rotateY(angle),
+        Mat4.scale(span, verticalSpan, span)))
     return ensureMesh(self, "cloud_layer"), model,
       { 0.93, 0.96, 1.00, 1.00 }
   end

--- a/lib/VoxelCompanion.lua
+++ b/lib/VoxelCompanion.lua
@@ -146,7 +146,8 @@ end
 
 local function integer(value, fallback)
   value = finite(value, fallback)
-  return value == nil and nil or math.floor(value)
+  if value == nil then return nil end
+  return math.floor(value)
 end
 
 local function clamp(value, minimum, maximum, fallback)
@@ -467,10 +468,16 @@ local function playerCell(state)
   return integer(player.cellX, nil), integer(player.cellY, nil)
 end
 
-local function shouldCutaway(self, prototype, item)
-  if not (prototype and prototype.cutaway and prototype.role == "ceiling") then
+local function shouldCutaway(self, prototype, item, context)
+  if not (prototype and prototype.cutaway) then
     return false
   end
+  local role = prototype.role
+  if role ~= "ceiling" and role ~= "wall" then return false end
+  -- The callback context is the public, frame-local source of camera mode.
+  -- Do not infer it from extension data or retain the borrowed context.
+  local camera = type(context) == "table" and context.camera or nil
+  if type(camera) ~= "table" or camera.mode ~= "first_person" then return false end
   local px, pz = playerCell(self.state)
   local cx, cz = integer(item.cellX, nil), integer(item.cellZ, nil)
   if not (px and pz and cx and cz) then return false end
@@ -640,8 +647,8 @@ local function skyPrimitive(self, prototype)
   end
 end
 
-local function drawItem(self, prototype, item, material, borrowedTexture)
-  if shouldCutaway(self, prototype, item) then return false end
+local function drawItem(self, prototype, item, material, borrowedTexture, context)
+  if shouldCutaway(self, prototype, item, context) then return false end
   local primitive, width, height, depth = primitiveDimensions(prototype, item)
   -- An extension-owned texture is borrowed for this call only. Never place it
   -- on the adapter, a mesh cache, or any cleanup list.
@@ -903,7 +910,7 @@ local function makeDrawFacade(self)
           geometry.y = finite(geometry.y, -0.5)
           geometry.z = finite(geometry.z, baseDepth * 0.5)
         end
-        drawItem(self, geometry, geometry, packet.material, packet.texture)
+        drawItem(self, geometry, geometry, packet.material, packet.texture, context)
         return true
       end)
     end,
@@ -930,7 +937,8 @@ local function makeDrawFacade(self)
       if not budgeted then return false, budgetError end
       return runDraw(function()
         for _, item in ipairs(packet.items) do
-          drawItem(self, packet.prototype, item, packet.material, packet.texture)
+          drawItem(self, packet.prototype, item, packet.material, packet.texture,
+            context)
         end
         return true
       end)
@@ -968,7 +976,7 @@ local function makeDrawFacade(self)
             width = finite(item.width, baseWidth),
             height = finite(item.height, baseHeight),
           }
-          drawItem(self, prototype, item, packet.material, packet.texture)
+          drawItem(self, prototype, item, packet.material, packet.texture, context)
         end
         return true
       end)

--- a/lib/VoxelCompanion.lua
+++ b/lib/VoxelCompanion.lua
@@ -1377,6 +1377,15 @@ function VoxelCompanion:update(dt, state)
   return self.dispatcher:update(self.frame)
 end
 
+-- Pump the adapter from the engine's public core.update hook. The companion
+-- starts during mods.loaded, before Game.overworld necessarily has a map, so
+-- the first calls can legitimately have no state. A later call observes the
+-- live overworld and dispatches the pending normalized snapshot.
+function VoxelCompanion:updateFromGame(dt, game)
+  local state = type(game) == "table" and game.overworld or nil
+  return self:update(dt, state)
+end
+
 function VoxelCompanion:cameraDelta(state)
   self:_observeState(state)
   if not self.started then return nil end

--- a/lib/VoxelCompanion.lua
+++ b/lib/VoxelCompanion.lua
@@ -42,11 +42,18 @@ local MAX_PRIMITIVE_SIZE = 65536
 local MAX_COMMAND_SIGNATURES = 4096
 local MAX_SIGNATURE_NODES = 32768
 local MAX_SIGNATURE_BYTES = 256 * 1024
+local MAX_SKY_LAYER = 16
+local PANORAMA_SEGMENTS = 32
+local CLOUD_PATCHES = 8
+local RAINBOW_SEGMENTS = 24
 
 local MESH_PRIMITIVES = {
   box = true,
   plane = true,
   world_apron = true,
+  panorama = true,
+  cloud_layer = true,
+  rainbow = true,
 }
 
 local INSTANCE_PRIMITIVES = {
@@ -118,6 +125,10 @@ local COLORS = {
   water = { 0.26, 0.55, 0.78, 0.64 },
   puddle = { 0.35, 0.62, 0.80, 0.50 },
   rain = { 0.70, 0.84, 0.96, 0.70 },
+  panorama = { 1.00, 1.00, 1.00, 1.00 },
+  cloud = { 0.93, 0.96, 1.00, 0.22 },
+  rainbow = { 0.96, 0.62, 0.84, 0.48 },
+  star = { 1.00, 0.98, 0.78, 0.90 },
   shadow = { 0.04, 0.05, 0.07, 0.28 },
   light = { 1.00, 0.88, 0.55, 0.72 },
   firefly = { 0.90, 1.00, 0.45, 0.88 },
@@ -290,6 +301,73 @@ local function buildBillboard()
   return Voxel3D.newMesh(vertices, indices)
 end
 
+-- These conservative host-owned sky meshes implement the API v1 baseline.
+-- They are bounded visual proxies, not a claim of legacy panorama or weather
+-- parity. Declarative commands and callback-borrowed textures stay outside all
+-- host caches; only these fixed meshes are retained by the adapter.
+local function buildPanorama()
+  local vertices, indices = {}, {}
+  for segment = 0, PANORAMA_SEGMENTS - 1 do
+    local a0 = segment * math.pi * 2 / PANORAMA_SEGMENTS
+    local a1 = (segment + 1) * math.pi * 2 / PANORAMA_SEGMENTS
+    local x0, z0 = math.cos(a0) * 0.5, math.sin(a0) * 0.5
+    local x1, z1 = math.cos(a1) * 0.5, math.sin(a1) * 0.5
+    local u0, u1 = segment / PANORAMA_SEGMENTS,
+      (segment + 1) / PANORAMA_SEGMENTS
+    local quad = #vertices / 4
+    vertices[#vertices + 1] = { x0, -0.5, z0, u0, 1, 1 }
+    vertices[#vertices + 1] = { x1, -0.5, z1, u1, 1, 1 }
+    vertices[#vertices + 1] = { x1,  0.5, z1, u1, 0, 1 }
+    vertices[#vertices + 1] = { x0,  0.5, z0, u0, 0, 1 }
+    Voxel3D.pushQuad(indices, quad)
+  end
+  return Voxel3D.newMesh(vertices, indices)
+end
+
+local function buildCloudLayer()
+  local patches = {
+    { -0.38, -0.25, 0.24 }, { -0.08, -0.34, 0.20 },
+    {  0.25, -0.24, 0.27 }, {  0.39,  0.03, 0.19 },
+    {  0.16,  0.31, 0.25 }, { -0.18,  0.34, 0.22 },
+    { -0.40,  0.17, 0.18 }, {  0.02,  0.02, 0.30 },
+  }
+  local vertices, indices = {}, {}
+  for index = 1, math.min(CLOUD_PATCHES, #patches) do
+    local x, z, radius = patches[index][1], patches[index][2], patches[index][3]
+    local quad = #vertices / 4
+    vertices[#vertices + 1] = { x - radius, 0, z - radius, 0, 0, 1 }
+    vertices[#vertices + 1] = { x + radius, 0, z - radius, 1, 0, 1 }
+    vertices[#vertices + 1] = { x + radius, 0, z + radius, 1, 1, 1 }
+    vertices[#vertices + 1] = { x - radius, 0, z + radius, 0, 1, 1 }
+    Voxel3D.pushQuad(indices, quad)
+  end
+  return Voxel3D.newMesh(vertices, indices)
+end
+
+local function buildRainbow()
+  local vertices, indices = {}, {}
+  for segment = 0, RAINBOW_SEGMENTS - 1 do
+    local a0 = segment * math.pi / RAINBOW_SEGMENTS
+    local a1 = (segment + 1) * math.pi / RAINBOW_SEGMENTS
+    local outer, inner = 0.5, 0.39
+    local quad = #vertices / 4
+    vertices[#vertices + 1] = {
+      math.cos(a0) * outer, math.sin(a0) * outer, 0, 0, 0, 1,
+    }
+    vertices[#vertices + 1] = {
+      math.cos(a0) * inner, math.sin(a0) * inner, 0, 0, 1, 1,
+    }
+    vertices[#vertices + 1] = {
+      math.cos(a1) * inner, math.sin(a1) * inner, 0, 1, 1, 1,
+    }
+    vertices[#vertices + 1] = {
+      math.cos(a1) * outer, math.sin(a1) * outer, 0, 1, 0, 1,
+    }
+    Voxel3D.pushQuad(indices, quad)
+  end
+  return Voxel3D.newMesh(vertices, indices)
+end
+
 local function colorFor(material)
   local text = tostring(material or ""):lower()
   for key, color in pairs(COLORS) do
@@ -311,6 +389,76 @@ local function billboardTransform(item, width, height)
   local yaw = math.atan2((eye[1] or x) - x, (eye[3] or z + 1) - z)
   return Mat4.mul(Mat4.mul(Mat4.translate(x, y, z), Mat4.rotateY(yaw)),
                   Mat4.scale(width, height, 1))
+end
+
+local function eyePosition()
+  local eye = Voxel3D.eye
+  if type(eye) ~= "table" and type(Voxel3D.camera) == "table" then
+    eye = Voxel3D.camera.eye
+  end
+  eye = type(eye) == "table" and eye or {}
+  return clamp(eye[1], -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0),
+    clamp(eye[2], -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0),
+    clamp(eye[3], -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0)
+end
+
+local RANDOM_MODULUS = 2147483647
+local function localSeed(value)
+  local number = finite(value, nil)
+  if number == nil then return nil end
+  local folded = math.fmod(math.abs(number), RANDOM_MODULUS - 1)
+  return math.floor(folded * 1000 + 0.5) % (RANDOM_MODULUS - 1) + 1
+end
+
+local function nextUnit(state)
+  state = state * 48271 % RANDOM_MODULUS
+  return state, state / RANDOM_MODULUS
+end
+
+local function starItems(procedural)
+  if type(procedural) ~= "table" or procedural.kind ~= "stars" then
+    return nil, "billboard procedural kind must be stars"
+  end
+  local count = integer(procedural.count, nil)
+  local state = localSeed(procedural.seed)
+  if not count or count < 1 or count > MAX_PACKET_ITEMS or not state then
+    return nil, "star procedure needs a bounded count and finite seed"
+  end
+  for _, key in ipairs({ "twinkle", "nebula", "shootingStars" }) do
+    if procedural[key] ~= nil and type(procedural[key]) ~= "boolean" then
+      return nil, "star procedure " .. key .. " must be Boolean"
+    end
+  end
+
+  local eyeX, eyeY, eyeZ = eyePosition()
+  local items = {}
+  for index = 1, count do
+    local azimuth, elevation, radial, sizeNoise
+    state, azimuth = nextUnit(state)
+    state, elevation = nextUnit(state)
+    state, radial = nextUnit(state)
+    state, sizeNoise = nextUnit(state)
+    local angle = azimuth * math.pi * 2
+    local lift = 0.22 + elevation * 0.58
+    local radius = 96 + radial * 160
+    local size = procedural.twinkle and (0.55 + sizeNoise * 1.25) or 1
+    if procedural.nebula and index % 11 == 0 then size = size * 1.5 end
+    local width, height = size, size
+    if procedural.shootingStars and index % 19 == 0 then
+      width, height = size * 3.5, math.max(0.25, size * 0.45)
+    end
+    items[index] = {
+      x = clamp(eyeX + math.cos(angle) * radius,
+        -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0),
+      y = clamp(eyeY + 32 + math.sin(lift) * radius,
+        -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0),
+      z = clamp(eyeZ + math.sin(angle) * radius,
+        -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0),
+      width = clamp(width, 0.25, 8, 1),
+      height = clamp(height, 0.25, 8, 1),
+    }
+  end
+  return items
 end
 
 local function playerCell(state)
@@ -391,6 +539,9 @@ local function ensureMesh(self, kind)
   local mesh
   if kind == "plane" then mesh = buildPlane()
   elseif kind == "billboard" then mesh = buildBillboard()
+  elseif kind == "panorama" then mesh = buildPanorama()
+  elseif kind == "cloud_layer" then mesh = buildCloudLayer()
+  elseif kind == "rainbow" then mesh = buildRainbow()
   else mesh = buildBox() end
   self.meshes[kind] = mesh or false
   return mesh
@@ -423,6 +574,72 @@ local function drawVoxel(mesh, texture, model, borrowed)
   if not ok then error(err, 3) end
 end
 
+local function skyPrimitive(self, prototype)
+  local primitive = prototype.primitive
+  local eyeX, eyeY, eyeZ = eyePosition()
+  if primitive == "panorama" then
+    local sourceWidth = clamp(prototype.sourceWidth, 1,
+      MAX_PRIMITIVE_SIZE * 64, 4096)
+    local targetWidth = clamp(prototype.targetWidth, 16,
+      MAX_PRIMITIVE_SIZE, 1024)
+    local resample = clamp(targetWidth / sourceWidth, 0.125, 4, 1)
+    local height = clamp(targetWidth * (0.16 + resample * 0.08),
+      16, MAX_PRIMITIVE_SIZE, 128)
+    if prototype.deepSkirt == true then height = math.min(height * 1.35,
+      MAX_PRIMITIVE_SIZE) end
+    local y = clamp(
+      eyeY - height * (prototype.deepSkirt == true and 0.32 or 0.18),
+      -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0)
+    local color = prototype.distanceHaze == true
+      and { 0.92, 0.94, 0.98, 0.94 } or COLORS.panorama
+    return ensureMesh(self, "panorama"),
+      transform(eyeX, y, eyeZ, targetWidth, height, targetWidth), color
+  end
+
+  if primitive == "cloud_layer" then
+    local layer = clamp(integer(prototype.layer, 1), 1, MAX_SKY_LAYER, 1)
+    local parallax = clamp(prototype.parallax, -2, 2, 0)
+    local density = clamp(prototype.density, 0, 1, 0.5)
+    local state = localSeed(prototype.seed) or 1
+    local offsetX, offsetZ, angle
+    state, offsetX = nextUnit(state)
+    state, offsetZ = nextUnit(state)
+    state, angle = nextUnit(state)
+    local span = 128 + density * 512
+    local x = eyeX * (1 - parallax) + (offsetX - 0.5) * 48
+    local z = eyeZ * (1 - parallax) + (offsetZ - 0.5) * 48
+    local model = Mat4.mul(Mat4.translate(
+      clamp(x, -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0),
+      clamp(eyeY + 48 + layer * 24,
+        -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0),
+      clamp(z, -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0)),
+      Mat4.mul(Mat4.rotateY(angle * math.pi * 2), Mat4.scale(span, 1, span)))
+    return ensureMesh(self, "cloud_layer"), model,
+      { 0.93, 0.96, 1.00, 0.04 + density * 0.22 }
+  end
+
+  if primitive == "rainbow" then
+    local state = localSeed(prototype.seed) or 1
+    local angle, distanceNoise, sizeNoise
+    state, angle = nextUnit(state)
+    state, distanceNoise = nextUnit(state)
+    state, sizeNoise = nextUnit(state)
+    local radians = angle * math.pi * 2
+    local distance = 96 + distanceNoise * 96
+    local item = {
+      x = clamp(eyeX + math.cos(radians) * distance,
+        -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0),
+      y = clamp(eyeY + 12 + sizeNoise * 24,
+        -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0),
+      z = clamp(eyeZ + math.sin(radians) * distance,
+        -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0),
+    }
+    return ensureMesh(self, "rainbow"),
+      billboardTransform(item, 96 + sizeNoise * 64, 72 + sizeNoise * 32),
+      COLORS.rainbow
+  end
+end
+
 local function drawItem(self, prototype, item, material, borrowedTexture)
   if shouldCutaway(self, prototype, item) then return false end
   local primitive, width, height, depth = primitiveDimensions(prototype, item)
@@ -432,14 +649,21 @@ local function drawItem(self, prototype, item, material, borrowedTexture)
   if not texture then error("companion material texture is unavailable", 3) end
   local color = colorFor(material)
   local ok, err = xpcall(function()
-    setMaterial(color)
     Voxel3D.glass(false)
-    if primitive == "billboard" then
+    if primitive == "panorama" or primitive == "cloud_layer"
+        or primitive == "rainbow" then
+      local mesh, model, skyColor = skyPrimitive(self, prototype)
+      if not mesh then error("companion sky mesh is unavailable", 0) end
+      setMaterial(skyColor or color)
+      drawVoxel(mesh, texture, model, borrowedTexture ~= nil)
+    elseif primitive == "billboard" then
+      setMaterial(color)
       local mesh = ensureMesh(self, "billboard")
       if not mesh then error("companion billboard mesh is unavailable", 0) end
       drawVoxel(mesh, texture, billboardTransform(item, width, height),
         borrowedTexture ~= nil)
     else
+      setMaterial(color)
       local meshKind = primitive == "plane" and "plane" or "box"
       local mesh = ensureMesh(self, meshKind)
       if not mesh then error("companion primitive mesh is unavailable", 0) end
@@ -590,9 +814,26 @@ local function validateMeshGeometry(geometry)
     if not (positive(geometry.width) and positive(geometry.depth)) then
       return false, "plane geometry needs positive width and depth"
     end
-  elseif not (positive(geometry.width) and positive(geometry.depth)
-      and positive(geometry.skirtDepth)) then
-    return false, "world_apron geometry needs positive width, depth, and skirtDepth"
+  elseif primitive == "world_apron" then
+    if not (positive(geometry.width) and positive(geometry.depth)
+        and positive(geometry.skirtDepth)) then
+      return false, "world_apron geometry needs positive width, depth, and skirtDepth"
+    end
+  elseif primitive == "panorama" then
+    if not (positive(geometry.sourceWidth) and positive(geometry.targetWidth)) then
+      return false, "panorama geometry needs positive sourceWidth and targetWidth"
+    end
+  elseif primitive == "cloud_layer" then
+    local layer = finite(geometry.layer, nil)
+    local density = finite(geometry.density, nil)
+    if not (layer and layer >= 1 and layer == math.floor(layer)
+        and finite(geometry.parallax, nil) ~= nil
+        and density and density >= 0 and density <= 1
+        and finite(geometry.seed, nil) ~= nil) then
+      return false, "cloud_layer geometry needs an integer layer, finite parallax/seed, and unit density"
+    end
+  elseif finite(geometry.seed, nil) == nil then
+    return false, "rainbow geometry needs a finite seed"
   end
   return true
 end
@@ -697,18 +938,22 @@ local function makeDrawFacade(self)
     billboards = function(packet, context)
       local valid, validationError = validateDrawCommand(packet, "billboards", context)
       if not valid then return false, validationError end
-      if type(packet) ~= "table" or type(packet.items) ~= "table" then
-        return false, "billboard command needs explicit items"
+      local items = packet.items
+      if packet.procedural ~= nil then
+        items, validationError = starItems(packet.procedural)
+        if not items then return false, validationError end
+      elseif type(items) ~= "table" then
+        return false, "billboard command needs explicit items or procedural stars"
       end
-      if #packet.items < 1 or #packet.items > MAX_PACKET_ITEMS then
+      if #items < 1 or #items > MAX_PACKET_ITEMS then
         return false, "billboard command item count must be 1.." .. MAX_PACKET_ITEMS
       end
-      for _, item in ipairs(packet.items) do
+      for _, item in ipairs(items) do
         if type(item) ~= "table" then return false, "billboard item must be a table" end
       end
       valid, validationError = validateCommandSignature(self, packet)
       if not valid then return false, validationError end
-      local budgeted, budgetError = useDrawBudget(self, #packet.items)
+      local budgeted, budgetError = useDrawBudget(self, #items)
       if not budgeted then return false, budgetError end
       local baseWidth, baseHeight = 3, 5
       local material = tostring(packet.material or "")
@@ -717,7 +962,7 @@ local function makeDrawFacade(self)
       if material:find("rain", 1, true) then baseWidth, baseHeight = 0.6, 8 end
       if material:find("sun_shaft", 1, true) then baseWidth = 8 end
       return runDraw(function()
-        for _, item in ipairs(packet.items) do
+        for _, item in ipairs(items) do
           local prototype = {
             primitive = "billboard",
             width = finite(item.width, baseWidth),

--- a/lib/VoxelCompanion.lua
+++ b/lib/VoxelCompanion.lua
@@ -46,6 +46,11 @@ local MAX_SKY_LAYER = 16
 local PANORAMA_SEGMENTS = 32
 local CLOUD_PATCHES = 8
 local RAINBOW_SEGMENTS = 24
+local PANORAMA_RADIUS = 900
+local PANORAMA_TOP = 300
+local PANORAMA_BOTTOM = -120
+local PANORAMA_DEEP_BOTTOM = -1400
+local CLOUD_TEXTURE_SIZE = 32
 
 local MESH_PRIMITIVES = {
   box = true,
@@ -472,14 +477,27 @@ local function shouldCutaway(self, prototype, item, context)
   if not (prototype and prototype.cutaway) then
     return false
   end
-  local role = prototype.role
-  if role ~= "ceiling" and role ~= "wall" then return false end
+  local primitive, role = prototype.primitive, prototype.role
+  if role ~= "ceiling" and role ~= "wall" and primitive ~= "canopy" then
+    return false
+  end
   -- The callback context is the public, frame-local source of camera mode.
   -- Do not infer it from extension data or retain the borrowed context.
   local camera = type(context) == "table" and context.camera or nil
   if type(camera) ~= "table" or camera.mode ~= "first_person" then return false end
   local px, pz = playerCell(self.state)
   local cx, cz = integer(item.cellX, nil), integer(item.cellZ, nil)
+  -- Released KFP canopy packets predate explicit cell coordinates. Their
+  -- positions are normalized cell centres, so derive the same public cell
+  -- identity from the retained defensive snapshot instead of reaching into
+  -- producer or engine-private state.
+  if primitive == "canopy" and (cx == nil or cz == nil) then
+    local size = self.snapshot and finite(self.snapshot.cellSize, nil)
+    if size and size > 0 then
+      cx = math.floor(finite(item.x, -1) / size)
+      cz = math.floor(finite(item.z, -1) / size)
+    end
+  end
   if not (px and pz and cx and cz) then return false end
   return math.abs(px - cx) <= 4 and math.abs(pz - cz) <= 4
 end
@@ -541,6 +559,36 @@ local function ensureTexture(self)
   return self.texture or nil
 end
 
+local function ensureCloudTexture(self)
+  if self.cloudTexture ~= nil then return self.cloudTexture or nil end
+  if not (love and love.image and love.image.newImageData
+      and love.graphics and love.graphics.newImage) then
+    self.cloudTexture = false
+    return nil
+  end
+  local ok, texture = pcall(function()
+    local data = love.image.newImageData(CLOUD_TEXTURE_SIZE, CLOUD_TEXTURE_SIZE)
+    local half = (CLOUD_TEXTURE_SIZE - 1) * 0.5
+    for y = 0, CLOUD_TEXTURE_SIZE - 1 do
+      for x = 0, CLOUD_TEXTURE_SIZE - 1 do
+        local dx, dy = (x - half) / half, (y - half) / half
+        local r = math.sqrt(dx * dx + dy * dy)
+        -- The scene shader uses an alpha cutout. A bounded radial mask
+        -- removes the opaque quad corners that made the old white fallback
+        -- read as giant translucent polygons.
+        local alpha = r <= 0.88 and 1 or 0
+        data:setPixel(x, y, 1, 1, 1, alpha)
+      end
+    end
+    local image = love.graphics.newImage(data)
+    image:setFilter("linear", "linear")
+    image:setWrap("clamp", "clamp")
+    return image
+  end)
+  self.cloudTexture = ok and texture or false
+  return self.cloudTexture or nil
+end
+
 local function ensureMesh(self, kind)
   if self.meshes[kind] ~= nil then return self.meshes[kind] or nil end
   local mesh
@@ -585,22 +633,20 @@ local function skyPrimitive(self, prototype)
   local primitive = prototype.primitive
   local eyeX, eyeY, eyeZ = eyePosition()
   if primitive == "panorama" then
-    local sourceWidth = clamp(prototype.sourceWidth, 1,
-      MAX_PRIMITIVE_SIZE * 64, 4096)
-    local targetWidth = clamp(prototype.targetWidth, 16,
-      MAX_PRIMITIVE_SIZE, 1024)
-    local resample = clamp(targetWidth / sourceWidth, 0.125, 4, 1)
-    local height = clamp(targetWidth * (0.16 + resample * 0.08),
-      16, MAX_PRIMITIVE_SIZE, 128)
-    if prototype.deepSkirt == true then height = math.min(height * 1.35,
-      MAX_PRIMITIVE_SIZE) end
-    local y = clamp(
-      eyeY - height * (prototype.deepSkirt == true and 0.32 or 0.18),
-      -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0)
+    -- sourceWidth and targetWidth describe texture quality, not world scale.
+    -- Keep the released physical panorama bounds at every quality tier.
+    local bottom = prototype.deepSkirt == true
+      and PANORAMA_DEEP_BOTTOM or PANORAMA_BOTTOM
+    local height = PANORAMA_TOP - bottom
+    local y = bottom + height * 0.5
+    -- Battle's scene shader converts partial material alpha to ordered
+    -- coverage. Keep the material opaque so only the panorama texture's
+    -- authored alpha controls its silhouette.
     local color = prototype.distanceHaze == true
-      and { 0.92, 0.94, 0.98, 0.94 } or COLORS.panorama
+      and { 0.92, 0.94, 0.98, 1.00 } or COLORS.panorama
     return ensureMesh(self, "panorama"),
-      transform(eyeX, y, eyeZ, targetWidth, height, targetWidth), color
+      transform(eyeX, y, eyeZ, PANORAMA_RADIUS * 2, height,
+        PANORAMA_RADIUS * 2), color
   end
 
   if primitive == "cloud_layer" then
@@ -612,17 +658,17 @@ local function skyPrimitive(self, prototype)
     state, offsetX = nextUnit(state)
     state, offsetZ = nextUnit(state)
     state, angle = nextUnit(state)
-    local span = 128 + density * 512
+    local span = 128 + density * 64
     local x = eyeX * (1 - parallax) + (offsetX - 0.5) * 48
     local z = eyeZ * (1 - parallax) + (offsetZ - 0.5) * 48
     local model = Mat4.mul(Mat4.translate(
       clamp(x, -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0),
-      clamp(eyeY + 48 + layer * 24,
+      clamp(eyeY + 160 + layer * 48,
         -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0),
       clamp(z, -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0)),
       Mat4.mul(Mat4.rotateY(angle * math.pi * 2), Mat4.scale(span, 1, span)))
     return ensureMesh(self, "cloud_layer"), model,
-      { 0.93, 0.96, 1.00, 0.04 + density * 0.22 }
+      { 0.93, 0.96, 1.00, 1.00 }
   end
 
   if primitive == "rainbow" then
@@ -652,7 +698,9 @@ local function drawItem(self, prototype, item, material, borrowedTexture, contex
   local primitive, width, height, depth = primitiveDimensions(prototype, item)
   -- An extension-owned texture is borrowed for this call only. Never place it
   -- on the adapter, a mesh cache, or any cleanup list.
-  local texture = borrowedTexture or ensureTexture(self)
+  local texture = borrowedTexture
+    or (primitive == "cloud_layer" and ensureCloudTexture(self))
+    or ensureTexture(self)
   if not texture then error("companion material texture is unavailable", 3) end
   local color = colorFor(material)
   local ok, err = xpcall(function()
@@ -662,6 +710,11 @@ local function drawItem(self, prototype, item, material, borrowedTexture, contex
       local mesh, model, skyColor = skyPrimitive(self, prototype)
       if not mesh then error("companion sky mesh is unavailable", 0) end
       setMaterial(skyColor or color)
+      if primitive == "panorama" or primitive == "cloud_layer" then
+        -- Sky coverage must not reserve depth in front of terrain or actors
+        -- drawn later in the frame.
+        love.graphics.setDepthMode("lequal", false)
+      end
       drawVoxel(mesh, texture, model, borrowedTexture ~= nil)
     elseif primitive == "billboard" then
       setMaterial(color)
@@ -1205,6 +1258,7 @@ function VoxelCompanion.new(options)
     frameDraws = 0,
     meshes = {},
     texture = nil,
+    cloudTexture = nil,
     commandSignatures = {},
     commandSignatureOrder = {},
     commandSignatureCount = 0,
@@ -1423,6 +1477,10 @@ function VoxelCompanion:invalidate(reason)
   end
   if self.texture and self.texture.release then pcall(self.texture.release, self.texture) end
   self.texture = nil
+  if self.cloudTexture and self.cloudTexture.release then
+    pcall(self.cloudTexture.release, self.cloudTexture)
+  end
+  self.cloudTexture = nil
   self.commandSignatures = {}
   self.commandSignatureOrder = {}
   self.commandSignatureCount = 0

--- a/lib/VoxelCompanion.lua
+++ b/lib/VoxelCompanion.lua
@@ -44,7 +44,7 @@ local MAX_SIGNATURE_NODES = 32768
 local MAX_SIGNATURE_BYTES = 256 * 1024
 local MAX_SKY_LAYER = 16
 local PANORAMA_SEGMENTS = 32
-local CLOUD_PATCHES = 8
+local CLOUD_SEGMENTS = 32
 local RAINBOW_SEGMENTS = 24
 local PANORAMA_RADIUS = 900
 local PANORAMA_TOP = 300
@@ -342,21 +342,20 @@ local function buildPanorama(deepSkirt)
 end
 
 local function buildCloudLayer()
-  local patches = {
-    { -0.38, -0.25, 0.24 }, { -0.08, -0.34, 0.20 },
-    {  0.25, -0.24, 0.27 }, {  0.39,  0.03, 0.19 },
-    {  0.16,  0.31, 0.25 }, { -0.18,  0.34, 0.22 },
-    { -0.40,  0.17, 0.18 }, {  0.02,  0.02, 0.30 },
-  }
-  local vertices, indices = {}, {}
-  for index = 1, math.min(CLOUD_PATCHES, #patches) do
-    local x, z, radius = patches[index][1], patches[index][2], patches[index][3]
-    local quad = #vertices / 4
-    vertices[#vertices + 1] = { x - radius, 0, z - radius, 0, 0, 1 }
-    vertices[#vertices + 1] = { x + radius, 0, z - radius, 1, 0, 1 }
-    vertices[#vertices + 1] = { x + radius, 0, z + radius, 1, 1, 1 }
-    vertices[#vertices + 1] = { x - radius, 0, z + radius, 0, 1, 1 }
-    Voxel3D.pushQuad(indices, quad)
+  -- One planar fan keeps the texture continuous across the full cloud deck.
+  -- Its circular perimeter has a fixed radius, so rotation cannot expand the
+  -- declared span or expose the clipped edges of detached square patches.
+  local vertices = { { 0, 0, 0, 0.5, 0.5, 1 } }
+  local indices = {}
+  for segment = 0, CLOUD_SEGMENTS - 1 do
+    local angle = segment * math.pi * 2 / CLOUD_SEGMENTS
+    local x, z = math.cos(angle) * 0.5, math.sin(angle) * 0.5
+    vertices[#vertices + 1] = { x, 0, z, x + 0.5, z + 0.5, 1 }
+  end
+  for segment = 0, CLOUD_SEGMENTS - 1 do
+    indices[#indices + 1] = 1
+    indices[#indices + 1] = segment + 2
+    indices[#indices + 1] = ((segment + 1) % CLOUD_SEGMENTS) + 2
   end
   return Voxel3D.newMesh(vertices, indices)
 end
@@ -484,6 +483,36 @@ local function playerCell(state)
   return integer(player.cellX, nil), integer(player.cellY, nil)
 end
 
+local function playerWorldPosition(self, cellX, cellZ)
+  local player = self.state and self.state.player
+  local size = self.snapshot and finite(self.snapshot.cellSize, nil) or 16
+  if type(player) == "table" then
+    local x = finite(player.px, finite(player.x, nil))
+    local z = finite(player.py, finite(player.y, nil))
+    if x ~= nil and z ~= nil then return x + size * 0.5, z + size * 0.5 end
+  end
+  if cellX ~= nil and cellZ ~= nil then
+    return (cellX + 0.5) * size, (cellZ + 0.5) * size
+  end
+  return nil, nil
+end
+
+local function wallIsCameraNear(self, item, camera, playerX, playerZ)
+  local eye = type(camera) == "table" and camera.eye or nil
+  if type(eye) ~= "table" then return false end
+  local eyeX = finite(eye[1], nil)
+  local eyeZ = finite(eye[3], nil)
+  local wallX = finite(item.x, nil)
+  local wallZ = finite(item.z, nil)
+  if not (eyeX and eyeZ and wallX and wallZ and playerX and playerZ) then
+    return false
+  end
+  local towardX, towardZ = eyeX - playerX, eyeZ - playerZ
+  if towardX * towardX + towardZ * towardZ < 0.0001 then return false end
+  return (wallX - playerX) * towardX
+      + (wallZ - playerZ) * towardZ > 0
+end
+
 local function shouldCutaway(self, prototype, item, context)
   if not (prototype and prototype.cutaway) then
     return false
@@ -492,10 +521,13 @@ local function shouldCutaway(self, prototype, item, context)
   if role ~= "ceiling" and role ~= "wall" and primitive ~= "canopy" then
     return false
   end
-  -- The callback context is the public, frame-local source of camera mode.
-  -- Do not infer it from extension data or retain the borrowed context.
+  -- The callback context is the public, frame-local source of camera mode and
+  -- eye position. Do not infer either from extension data or retain it.
   local camera = type(context) == "table" and context.camera or nil
-  if type(camera) ~= "table" or camera.mode ~= "first_person" then return false end
+  if primitive == "canopy"
+      and (type(camera) ~= "table" or camera.mode ~= "first_person") then
+    return false
+  end
   local px, pz = playerCell(self.state)
   local cx, cz = integer(item.cellX, nil), integer(item.cellZ, nil)
   -- Released KFP canopy packets predate explicit cell coordinates. Their
@@ -510,7 +542,15 @@ local function shouldCutaway(self, prototype, item, context)
     end
   end
   if not (px and pz and cx and cz) then return false end
-  return math.abs(px - cx) <= 4 and math.abs(pz - cz) <= 4
+  local nearby = math.abs(px - cx) <= 4 and math.abs(pz - cz) <= 4
+  if not nearby or role ~= "wall" then return nearby end
+
+  -- A room cutaway is a cross-section, not deletion of the room shell. Cull
+  -- only the nearby wall between the camera and player. Far and side walls
+  -- keep the room readable in every camera mode. Without a public eye, fail
+  -- open and preserve the wall.
+  local playerX, playerZ = playerWorldPosition(self, px, pz)
+  return wallIsCameraNear(self, item, camera, playerX, playerZ)
 end
 
 local function primitiveDimensions(prototype, item)
@@ -594,7 +634,18 @@ local function setMaterial(color)
   end
 end
 
-local function drawVoxel(mesh, texture, model, borrowed)
+local function evictMesh(self, mesh)
+  for key, cached in pairs(self.meshes) do
+    if cached == mesh then self.meshes[key] = nil end
+  end
+  if mesh and type(mesh.release) == "function" then
+    local released, releaseError = pcall(mesh.release, mesh)
+    if not released then return false, releaseError end
+  end
+  return true
+end
+
+local function drawVoxel(self, mesh, texture, model, borrowed)
   if borrowed and type(mesh and mesh.setTexture) ~= "function" then
     error("companion mesh cannot safely borrow an extension texture", 3)
   end
@@ -606,7 +657,16 @@ local function drawVoxel(mesh, texture, model, borrowed)
     cleared, clearError = pcall(mesh.setTexture, mesh)
   end
   if not cleared then
-    error("could not unbind borrowed extension texture: " .. tostring(clearError), 3)
+    -- The extension still owns the texture. Drop and release only the cached
+    -- host mesh so no host object can retain the borrowed image after return.
+    local released, releaseError = evictMesh(self, mesh)
+    local message = "could not unbind borrowed extension texture: "
+      .. tostring(clearError)
+    if not released then
+      message = message .. "; host mesh release failed: "
+        .. tostring(releaseError)
+    end
+    error(message, 3)
   end
   if not ok then error(err, 3) end
 end
@@ -696,12 +756,12 @@ local function drawItem(self, prototype, item, material, borrowedTexture, contex
         -- drawn later in the frame.
         love.graphics.setDepthMode("lequal", false)
       end
-      drawVoxel(mesh, texture, model, borrowedTexture ~= nil)
+      drawVoxel(self, mesh, texture, model, borrowedTexture ~= nil)
     elseif primitive == "billboard" then
       setMaterial(color)
       local mesh = ensureMesh(self, "billboard")
       if not mesh then error("companion billboard mesh is unavailable", 0) end
-      drawVoxel(mesh, texture, billboardTransform(item, width, height),
+      drawVoxel(self, mesh, texture, billboardTransform(item, width, height),
         borrowedTexture ~= nil)
     else
       setMaterial(color)
@@ -711,7 +771,7 @@ local function drawItem(self, prototype, item, material, borrowedTexture, contex
       local x = clamp(item.x, -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0)
       local y = clamp(item.y, -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0)
       local z = clamp(item.z, -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0)
-      drawVoxel(mesh, texture, transform(x, y, z, width,
+      drawVoxel(self, mesh, texture, transform(x, y, z, width,
         math.max(height, 0.01), depth), borrowedTexture ~= nil)
     end
   end, function(message) return tostring(message) end)
@@ -1185,11 +1245,12 @@ end
 
 local function cameraContext(self)
   local camera = Voxel3D.camera
+  local eye = camera and camera.eye or Voxel3D.eye
   local mode = Voxel.isFirstPerson() and "first_person"
     or (Voxel.isThirdPerson() and "third_person" or "diorama")
   return {
     mode = mode,
-    eye = camera and { camera.eye[1], camera.eye[2], camera.eye[3] } or nil,
+    eye = eye and { eye[1], eye[2], eye[3] } or nil,
     focus = camera and { camera.focus[1], camera.focus[2], camera.focus[3] } or nil,
     fov = camera and camera.fov or Voxel3D.fovY,
   }

--- a/lib/VoxelCompanion.lua
+++ b/lib/VoxelCompanion.lua
@@ -39,6 +39,33 @@ local MAX_PACKET_ITEMS = 2048
 local MAX_DRAWS_PER_FRAME = 4096
 local MAX_WORLD_COORDINATE = 65536
 local MAX_PRIMITIVE_SIZE = 65536
+local MAX_COMMAND_SIGNATURES = 4096
+local MAX_SIGNATURE_NODES = 32768
+local MAX_SIGNATURE_BYTES = 256 * 1024
+
+local MESH_PRIMITIVES = {
+  box = true,
+  plane = true,
+  world_apron = true,
+}
+
+local INSTANCE_PRIMITIVES = {
+  box = true,
+  plane = true,
+  door_frame = true,
+  window = true,
+  poster = true,
+  rail = true,
+  fixture = true,
+  sconce = true,
+  cave_roof = true,
+  grass_clump = true,
+  canopy = true,
+  vine = true,
+  umbrella = true,
+  mountain = true,
+  hood = true,
+}
 
 -- These are exact literals written by released KFP 1.x patchers. Only known
 -- host targets are scanned, so this scanner cannot match its own vocabulary.
@@ -335,9 +362,10 @@ end
 local function useDrawBudget(self, count)
   count = math.max(0, math.floor(tonumber(count) or 0))
   if self.frameDraws + count > MAX_DRAWS_PER_FRAME then
-    error("voxel companion frame draw limit reached", 3)
+    return false, "voxel companion frame draw limit reached"
   end
   self.frameDraws = self.frameDraws + count
+  return true
 end
 
 local function ensureTexture(self)
@@ -378,10 +406,29 @@ local function setMaterial(color)
   end
 end
 
-local function drawItem(self, prototype, item, material)
+local function drawVoxel(mesh, texture, model, borrowed)
+  if borrowed and type(mesh and mesh.setTexture) ~= "function" then
+    error("companion mesh cannot safely borrow an extension texture", 3)
+  end
+  local ok, err = xpcall(function()
+    Voxel3D.draw(mesh, texture, model)
+  end, function(message) return tostring(message) end)
+  local cleared, clearError = true, nil
+  if borrowed then
+    cleared, clearError = pcall(mesh.setTexture, mesh)
+  end
+  if not cleared then
+    error("could not unbind borrowed extension texture: " .. tostring(clearError), 3)
+  end
+  if not ok then error(err, 3) end
+end
+
+local function drawItem(self, prototype, item, material, borrowedTexture)
   if shouldCutaway(self, prototype, item) then return false end
   local primitive, width, height, depth = primitiveDimensions(prototype, item)
-  local texture = ensureTexture(self)
+  -- An extension-owned texture is borrowed for this call only. Never place it
+  -- on the adapter, a mesh cache, or any cleanup list.
+  local texture = borrowedTexture or ensureTexture(self)
   if not texture then error("companion material texture is unavailable", 3) end
   local color = colorFor(material)
   local ok, err = xpcall(function()
@@ -390,7 +437,8 @@ local function drawItem(self, prototype, item, material)
     if primitive == "billboard" then
       local mesh = ensureMesh(self, "billboard")
       if not mesh then error("companion billboard mesh is unavailable", 0) end
-      Voxel3D.draw(mesh, texture, billboardTransform(item, width, height))
+      drawVoxel(mesh, texture, billboardTransform(item, width, height),
+        borrowedTexture ~= nil)
     else
       local meshKind = primitive == "plane" and "plane" or "box"
       local mesh = ensureMesh(self, meshKind)
@@ -398,8 +446,8 @@ local function drawItem(self, prototype, item, material)
       local x = clamp(item.x, -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0)
       local y = clamp(item.y, -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0)
       local z = clamp(item.z, -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0)
-      Voxel3D.draw(mesh, texture, transform(x, y, z, width,
-        math.max(height, 0.01), depth))
+      drawVoxel(mesh, texture, transform(x, y, z, width,
+        math.max(height, 0.01), depth), borrowedTexture ~= nil)
     end
   end, function(message) return tostring(message) end)
   -- Voxel3D keeps its active material shader outside LÖVE's graphics stack.
@@ -409,68 +457,276 @@ local function drawItem(self, prototype, item, material)
   return true
 end
 
+local function validCacheKey(value)
+  return type(value) == "string" and #value >= 1 and #value <= 64
+    and value:match("^[A-Za-z0-9._:%-]+$") ~= nil
+end
+
+local function validOpaqueTexture(value)
+  if value == nil then return true end
+  local kind = type(value)
+  return kind == "table" or kind == "userdata" or kind == "cdata"
+end
+
+local function signatureKeyOrder(a, b)
+  local typeA, typeB = type(a), type(b)
+  if typeA ~= typeB then return typeA < typeB end
+  if typeA == "number" then return a < b end
+  return tostring(a) < tostring(b)
+end
+
+local function commandSignature(command)
+  local mod = 65521
+  local a, b, c, d = 1, 0, 1, 0
+  local nodes, bytes = 0, 0
+  local active = {}
+
+  local function feed(text)
+    bytes = bytes + #text
+    if bytes > MAX_SIGNATURE_BYTES then error("draw command signature byte limit", 0) end
+    for index = 1, #text do
+      local byte = text:byte(index)
+      a = (a + byte) % mod
+      b = (b + a) % mod
+      c = (c + byte + index) % mod
+      d = (d + c) % mod
+    end
+  end
+
+  local encode
+  encode = function(value, depth, root)
+    if depth > 16 then error("draw command signature depth limit", 0) end
+    local kind = type(value)
+    if kind == "nil" then feed("n;"); return end
+    if kind == "boolean" then feed(value and "b1;" or "b0;"); return end
+    if kind == "number" then
+      if finite(value, nil) == nil then error("draw command signature rejects non-finite numbers", 0) end
+      if value == 0 then value = 0 end
+      local text = string.format("%.17g", value)
+      feed("d" .. #text .. ":" .. text .. ";")
+      return
+    end
+    if kind == "string" then feed("s" .. #value .. ":" .. value .. ";"); return end
+    if kind ~= "table" or getmetatable(value) ~= nil then
+      error("draw command signature rejects " .. kind, 0)
+    end
+    if active[value] then error("draw command signature rejects cycles", 0) end
+    active[value] = true
+    local keys = {}
+    for key in pairs(value) do
+      if not (root and (key == "cacheKey" or key == "texture")) then
+        local keyType = type(key)
+        if keyType ~= "string" and keyType ~= "number" then
+          active[value] = nil
+          error("draw command signature rejects key type " .. keyType, 0)
+        end
+        keys[#keys + 1] = key
+        nodes = nodes + 1
+        if nodes > MAX_SIGNATURE_NODES then
+          active[value] = nil
+          error("draw command signature node limit", 0)
+        end
+      end
+    end
+    table.sort(keys, signatureKeyOrder)
+    feed("t" .. #keys .. "{")
+    for _, key in ipairs(keys) do
+      encode(key, depth + 1, false)
+      encode(value[key], depth + 1, false)
+    end
+    feed("};")
+    active[value] = nil
+  end
+
+  local ok, err = pcall(encode, command, 0, true)
+  if not ok then return nil, tostring(err) end
+  return string.format("%08x%08x", b * 65536 + a, d * 65536 + c)
+end
+
+local function validateCommandSignature(self, command)
+  local digest, err = commandSignature(command)
+  if not digest then return false, err end
+  local key = command.cacheKey
+  local previous = self.commandSignatures[key]
+  if previous then
+    if previous ~= digest then
+      return false, "draw command.cacheKey content collision"
+    end
+    return true
+  end
+
+  local slot
+  if self.commandSignatureCount < MAX_COMMAND_SIGNATURES then
+    self.commandSignatureCount = self.commandSignatureCount + 1
+    slot = self.commandSignatureCount
+  else
+    slot = self.commandSignatureNext
+    local evicted = self.commandSignatureOrder[slot]
+    if evicted then self.commandSignatures[evicted] = nil end
+    self.commandSignatureNext = slot % MAX_COMMAND_SIGNATURES + 1
+  end
+  self.commandSignatureOrder[slot] = key
+  self.commandSignatures[key] = digest
+  return true
+end
+
+local function positive(value)
+  local number = finite(value, nil)
+  return number ~= nil and number > 0
+end
+
+local function validateMeshGeometry(geometry)
+  if type(geometry) ~= "table" then return false, "mesh command needs geometry" end
+  local primitive = geometry.primitive
+  if not MESH_PRIMITIVES[primitive] then
+    return false, "unsupported Battle Art mesh primitive: " .. tostring(primitive)
+  end
+  if primitive == "box" then
+    if not (positive(geometry.width) and positive(geometry.height)
+        and positive(geometry.depth)) then
+      return false, "box geometry needs positive width, height, and depth"
+    end
+  elseif primitive == "plane" then
+    if not (positive(geometry.width) and positive(geometry.depth)) then
+      return false, "plane geometry needs positive width and depth"
+    end
+  elseif not (positive(geometry.width) and positive(geometry.depth)
+      and positive(geometry.skirtDepth)) then
+    return false, "world_apron geometry needs positive width, depth, and skirtDepth"
+  end
+  return true
+end
+
+local function validateDrawCommand(packet, expectedKind, context)
+  if type(context) ~= "table" then
+    return false, "draw command needs the current borrowed render context"
+  end
+  if type(packet) ~= "table" then return false, "draw command must be a table" end
+  if packet.kind ~= expectedKind then
+    return false, ("draw.%s received a %s command")
+      :format(expectedKind, tostring(packet.kind))
+  end
+  if packet.schemaVersion ~= 1 then
+    return false, "draw command.schemaVersion must be 1"
+  end
+  if not validCacheKey(packet.cacheKey) then
+    return false, "draw command.cacheKey must be 1..64 safe ASCII bytes"
+  end
+  if not validOpaqueTexture(packet.texture) then
+    return false, "draw command.texture must be an opaque borrowed resource, not a path string"
+  end
+
+  -- The final vendored dispatcher performs the complete shared baseline
+  -- validation. Keep this adapter guard so the frozen wire rules also hold
+  -- when an older dispatcher is loaded during a local amendment test.
+  if type(API.validate_draw_command) == "function" then
+    local called, accepted, err = pcall(API.validate_draw_command, packet, expectedKind)
+    if not called then return false, tostring(accepted) end
+    if accepted ~= true then return false, tostring(err or "invalid draw command") end
+  end
+  return true
+end
+
+local function runDraw(callback)
+  local ok, result, err = xpcall(callback, function(message) return tostring(message) end)
+  if not ok then return false, tostring(result) end
+  if result ~= true then return false, tostring(err or "draw command was rejected") end
+  return true
+end
+
 local function makeDrawFacade(self)
   return {
-    mesh = function(_, packet)
-      if type(packet) ~= "table" or type(packet.geometry) ~= "table" then
-        error("mesh packet needs geometry", 2)
-      end
-      local primitive = packet.geometry.primitive
-      if primitive ~= "world_apron" and primitive ~= "box"
-          and primitive ~= "plane" then
-        error("unsupported Battle Art mesh primitive: " .. tostring(primitive), 2)
-      end
-      useDrawBudget(self, 1)
-      local geometry = packet.geometry
-      if primitive == "world_apron" then
-        local baseWidth = clamp(geometry.width, 0.01,
-          MAX_PRIMITIVE_SIZE, 16)
-        local baseDepth = clamp(geometry.depth, 0.01,
-          MAX_PRIMITIVE_SIZE, 16)
-        local skirt = clamp(geometry.skirtDepth, 0,
-          MAX_PRIMITIVE_SIZE * 0.5, 0)
-        geometry = shallowCopy(geometry)
-        geometry.primitive = "plane"
-        geometry.width = baseWidth + skirt * 2
-        geometry.depth = baseDepth + skirt * 2
-        geometry.x = finite(geometry.x, baseWidth * 0.5)
-        geometry.y = finite(geometry.y, -0.5)
-        geometry.z = finite(geometry.z, baseDepth * 0.5)
-      end
-      drawItem(self, geometry, geometry, packet.material)
-      return true
+    mesh = function(packet, context)
+      local valid, validationError = validateDrawCommand(packet, "mesh", context)
+      if not valid then return false, validationError end
+      valid, validationError = validateMeshGeometry(packet.geometry)
+      if not valid then return false, validationError end
+      valid, validationError = validateCommandSignature(self, packet)
+      if not valid then return false, validationError end
+      local budgeted, budgetError = useDrawBudget(self, 1)
+      if not budgeted then return false, budgetError end
+      return runDraw(function()
+        local geometry = packet.geometry
+        if geometry.primitive == "world_apron" then
+          local baseWidth = clamp(geometry.width, 0.01,
+            MAX_PRIMITIVE_SIZE, 16)
+          local baseDepth = clamp(geometry.depth, 0.01,
+            MAX_PRIMITIVE_SIZE, 16)
+          local skirt = clamp(geometry.skirtDepth, 0,
+            MAX_PRIMITIVE_SIZE * 0.5, 0)
+          geometry = shallowCopy(geometry)
+          geometry.primitive = "plane"
+          geometry.width = baseWidth + skirt * 2
+          geometry.depth = baseDepth + skirt * 2
+          geometry.x = finite(geometry.x, baseWidth * 0.5)
+          geometry.y = finite(geometry.y, -0.5)
+          geometry.z = finite(geometry.z, baseDepth * 0.5)
+        end
+        drawItem(self, geometry, geometry, packet.material, packet.texture)
+        return true
+      end)
     end,
-    instances = function(_, packet)
+    instances = function(packet, context)
+      local valid, validationError = validateDrawCommand(packet, "instances", context)
+      if not valid then return false, validationError end
       if type(packet) ~= "table" or type(packet.prototype) ~= "table"
           or type(packet.items) ~= "table" then
-        error("instance packet needs prototype and items", 2)
+        return false, "instance command needs prototype and items"
       end
-      if #packet.items > MAX_PACKET_ITEMS then error("instance packet limit exceeded", 2) end
-      useDrawBudget(self, #packet.items)
+      if not INSTANCE_PRIMITIVES[packet.prototype.primitive] then
+        return false, "unsupported Battle Art instance primitive: "
+          .. tostring(packet.prototype.primitive)
+      end
+      if #packet.items < 1 or #packet.items > MAX_PACKET_ITEMS then
+        return false, "instance command item count must be 1.." .. MAX_PACKET_ITEMS
+      end
       for _, item in ipairs(packet.items) do
-        if type(item) ~= "table" then error("instance item must be a table", 2) end
-        drawItem(self, packet.prototype, item, packet.material)
+        if type(item) ~= "table" then return false, "instance item must be a table" end
       end
-      return true
+      valid, validationError = validateCommandSignature(self, packet)
+      if not valid then return false, validationError end
+      local budgeted, budgetError = useDrawBudget(self, #packet.items)
+      if not budgeted then return false, budgetError end
+      return runDraw(function()
+        for _, item in ipairs(packet.items) do
+          drawItem(self, packet.prototype, item, packet.material, packet.texture)
+        end
+        return true
+      end)
     end,
-    billboards = function(_, packet)
+    billboards = function(packet, context)
+      local valid, validationError = validateDrawCommand(packet, "billboards", context)
+      if not valid then return false, validationError end
       if type(packet) ~= "table" or type(packet.items) ~= "table" then
-        error("billboard packet needs items", 2)
+        return false, "billboard command needs explicit items"
       end
-      if #packet.items > MAX_PACKET_ITEMS then error("billboard packet limit exceeded", 2) end
-      useDrawBudget(self, #packet.items)
-      local prototype = { primitive = "billboard", width = 3, height = 5 }
-      local material = tostring(packet.material or "")
-      if material:find("bird", 1, true) then prototype.width, prototype.height = 5, 3 end
-      if material:find("aircraft", 1, true) then prototype.width, prototype.height = 12, 4 end
-      if material:find("rain", 1, true) then prototype.width, prototype.height = 0.6, 8 end
-      if material:find("sun_shaft", 1, true) then prototype.width = 8 end
+      if #packet.items < 1 or #packet.items > MAX_PACKET_ITEMS then
+        return false, "billboard command item count must be 1.." .. MAX_PACKET_ITEMS
+      end
       for _, item in ipairs(packet.items) do
-        if type(item) ~= "table" then error("billboard item must be a table", 2) end
-        if finite(item.height, nil) then prototype.height = finite(item.height, 5) end
-        drawItem(self, prototype, item, packet.material)
+        if type(item) ~= "table" then return false, "billboard item must be a table" end
       end
-      return true
+      valid, validationError = validateCommandSignature(self, packet)
+      if not valid then return false, validationError end
+      local budgeted, budgetError = useDrawBudget(self, #packet.items)
+      if not budgeted then return false, budgetError end
+      local baseWidth, baseHeight = 3, 5
+      local material = tostring(packet.material or "")
+      if material:find("bird", 1, true) then baseWidth, baseHeight = 5, 3 end
+      if material:find("aircraft", 1, true) then baseWidth, baseHeight = 12, 4 end
+      if material:find("rain", 1, true) then baseWidth, baseHeight = 0.6, 8 end
+      if material:find("sun_shaft", 1, true) then baseWidth = 8 end
+      return runDraw(function()
+        for _, item in ipairs(packet.items) do
+          local prototype = {
+            primitive = "billboard",
+            width = finite(item.width, baseWidth),
+            height = finite(item.height, baseHeight),
+          }
+          drawItem(self, prototype, item, packet.material, packet.texture)
+        end
+        return true
+      end)
     end,
   }
 end
@@ -696,6 +952,10 @@ function VoxelCompanion.new(options)
     frameDraws = 0,
     meshes = {},
     texture = nil,
+    commandSignatures = {},
+    commandSignatureOrder = {},
+    commandSignatureCount = 0,
+    commandSignatureNext = 1,
     diagnostics = {},
     clock = 0,
     frameIndex = 0,
@@ -901,6 +1161,10 @@ function VoxelCompanion:invalidate(reason)
   end
   if self.texture and self.texture.release then pcall(self.texture.release, self.texture) end
   self.texture = nil
+  self.commandSignatures = {}
+  self.commandSignatureOrder = {}
+  self.commandSignatureCount = 0
+  self.commandSignatureNext = 1
   if self.started then
     return self.dispatcher:invalidate(self:_context(), reason or "host_invalidated")
   end
@@ -944,6 +1208,7 @@ VoxelCompanion.LIMITS = {
   neighbors = MAX_NEIGHBORS,
   packetItems = MAX_PACKET_ITEMS,
   frameDraws = MAX_DRAWS_PER_FRAME,
+  commandSignatures = MAX_COMMAND_SIGNATURES,
 }
 
 return VoxelCompanion

--- a/lib/VoxelCompanion.lua
+++ b/lib/VoxelCompanion.lua
@@ -310,21 +310,33 @@ end
 -- They are bounded visual proxies, not a claim of legacy panorama or weather
 -- parity. Declarative commands and callback-borrowed textures stay outside all
 -- host caches; only these fixed meshes are retained by the adapter.
-local function buildPanorama()
-  local vertices, indices = {}, {}
+local function addPanoramaRing(vertices, indices, bottom, top, bottomV, topV)
+  local radius = 0.5
   for segment = 0, PANORAMA_SEGMENTS - 1 do
     local a0 = segment * math.pi * 2 / PANORAMA_SEGMENTS
     local a1 = (segment + 1) * math.pi * 2 / PANORAMA_SEGMENTS
-    local x0, z0 = math.cos(a0) * 0.5, math.sin(a0) * 0.5
-    local x1, z1 = math.cos(a1) * 0.5, math.sin(a1) * 0.5
+    local x0, z0 = math.cos(a0) * radius, math.sin(a0) * radius
+    local x1, z1 = math.cos(a1) * radius, math.sin(a1) * radius
     local u0, u1 = segment / PANORAMA_SEGMENTS,
       (segment + 1) / PANORAMA_SEGMENTS
     local quad = #vertices / 4
-    vertices[#vertices + 1] = { x0, -0.5, z0, u0, 1, 1 }
-    vertices[#vertices + 1] = { x1, -0.5, z1, u1, 1, 1 }
-    vertices[#vertices + 1] = { x1,  0.5, z1, u1, 0, 1 }
-    vertices[#vertices + 1] = { x0,  0.5, z0, u0, 0, 1 }
+    vertices[#vertices + 1] = { x0, bottom, z0, u0, bottomV, 1 }
+    vertices[#vertices + 1] = { x1, bottom, z1, u1, bottomV, 1 }
+    vertices[#vertices + 1] = { x1, top, z1, u1, topV, 1 }
+    vertices[#vertices + 1] = { x0, top, z0, u0, topV, 1 }
     Voxel3D.pushQuad(indices, quad)
+  end
+end
+
+local function buildPanorama(deepSkirt)
+  local vertices, indices = {}, {}
+  addPanoramaRing(vertices, indices, PANORAMA_BOTTOM, PANORAMA_TOP, 1, 0)
+  if deepSkirt then
+    -- The deep closure samples only the authored bottom row. Stretching the
+    -- full panorama through this range compressed its skyline near the
+    -- horizon and repeated transparent bands across the frame.
+    addPanoramaRing(vertices, indices,
+      PANORAMA_DEEP_BOTTOM, PANORAMA_BOTTOM, 1, 1)
   end
   return Voxel3D.newMesh(vertices, indices)
 end
@@ -563,7 +575,8 @@ local function ensureMesh(self, kind)
   local mesh
   if kind == "plane" then mesh = buildPlane()
   elseif kind == "billboard" then mesh = buildBillboard()
-  elseif kind == "panorama" then mesh = buildPanorama()
+  elseif kind == "panorama" then mesh = buildPanorama(false)
+  elseif kind == "panorama_deep" then mesh = buildPanorama(true)
   elseif kind == "cloud_layer" then mesh = buildCloudLayer()
   elseif kind == "rainbow" then mesh = buildRainbow()
   else mesh = buildBox() end
@@ -604,17 +617,15 @@ local function skyPrimitive(self, prototype)
   if primitive == "panorama" then
     -- sourceWidth and targetWidth describe texture quality, not world scale.
     -- Keep the released physical panorama bounds at every quality tier.
-    local bottom = prototype.deepSkirt == true
-      and PANORAMA_DEEP_BOTTOM or PANORAMA_BOTTOM
-    local height = PANORAMA_TOP - bottom
-    local y = bottom + height * 0.5
     -- Battle's scene shader converts partial material alpha to ordered
     -- coverage. Keep the material opaque so only the panorama texture's
     -- authored alpha controls its silhouette.
     local color = prototype.distanceHaze == true
       and { 0.92, 0.94, 0.98, 1.00 } or COLORS.panorama
-    return ensureMesh(self, "panorama"),
-      transform(eyeX, y, eyeZ, PANORAMA_RADIUS * 2, height,
+    local meshKind = prototype.deepSkirt == true and "panorama_deep"
+      or "panorama"
+    return ensureMesh(self, meshKind),
+      transform(eyeX, 0, eyeZ, PANORAMA_RADIUS * 2, 1,
         PANORAMA_RADIUS * 2), color
   end
 

--- a/lib/VoxelCompanion.lua
+++ b/lib/VoxelCompanion.lua
@@ -50,7 +50,6 @@ local PANORAMA_RADIUS = 900
 local PANORAMA_TOP = 300
 local PANORAMA_BOTTOM = -120
 local PANORAMA_DEEP_BOTTOM = -1400
-local CLOUD_TEXTURE_SIZE = 32
 
 local MESH_PRIMITIVES = {
   box = true,
@@ -559,36 +558,6 @@ local function ensureTexture(self)
   return self.texture or nil
 end
 
-local function ensureCloudTexture(self)
-  if self.cloudTexture ~= nil then return self.cloudTexture or nil end
-  if not (love and love.image and love.image.newImageData
-      and love.graphics and love.graphics.newImage) then
-    self.cloudTexture = false
-    return nil
-  end
-  local ok, texture = pcall(function()
-    local data = love.image.newImageData(CLOUD_TEXTURE_SIZE, CLOUD_TEXTURE_SIZE)
-    local half = (CLOUD_TEXTURE_SIZE - 1) * 0.5
-    for y = 0, CLOUD_TEXTURE_SIZE - 1 do
-      for x = 0, CLOUD_TEXTURE_SIZE - 1 do
-        local dx, dy = (x - half) / half, (y - half) / half
-        local r = math.sqrt(dx * dx + dy * dy)
-        -- The scene shader uses an alpha cutout. A bounded radial mask
-        -- removes the opaque quad corners that made the old white fallback
-        -- read as giant translucent polygons.
-        local alpha = r <= 0.88 and 1 or 0
-        data:setPixel(x, y, 1, 1, 1, alpha)
-      end
-    end
-    local image = love.graphics.newImage(data)
-    image:setFilter("linear", "linear")
-    image:setWrap("clamp", "clamp")
-    return image
-  end)
-  self.cloudTexture = ok and texture or false
-  return self.cloudTexture or nil
-end
-
 local function ensureMesh(self, kind)
   if self.meshes[kind] ~= nil then return self.meshes[kind] or nil end
   local mesh
@@ -698,9 +667,10 @@ local function drawItem(self, prototype, item, material, borrowedTexture, contex
   local primitive, width, height, depth = primitiveDimensions(prototype, item)
   -- An extension-owned texture is borrowed for this call only. Never place it
   -- on the adapter, a mesh cache, or any cleanup list.
-  local texture = borrowedTexture
-    or (primitive == "cloud_layer" and ensureCloudTexture(self))
-    or ensureTexture(self)
+  if primitive == "cloud_layer" and not borrowedTexture then
+    error("companion cloud texture is unavailable", 3)
+  end
+  local texture = borrowedTexture or ensureTexture(self)
   if not texture then error("companion material texture is unavailable", 3) end
   local color = colorFor(material)
   local ok, err = xpcall(function()
@@ -1258,7 +1228,6 @@ function VoxelCompanion.new(options)
     frameDraws = 0,
     meshes = {},
     texture = nil,
-    cloudTexture = nil,
     commandSignatures = {},
     commandSignatureOrder = {},
     commandSignatureCount = 0,
@@ -1477,10 +1446,6 @@ function VoxelCompanion:invalidate(reason)
   end
   if self.texture and self.texture.release then pcall(self.texture.release, self.texture) end
   self.texture = nil
-  if self.cloudTexture and self.cloudTexture.release then
-    pcall(self.cloudTexture.release, self.cloudTexture)
-  end
-  self.cloudTexture = nil
   self.commandSignatures = {}
   self.commandSignatureOrder = {}
   self.commandSignatureCount = 0

--- a/lib/VoxelCompanion.lua
+++ b/lib/VoxelCompanion.lua
@@ -1,0 +1,949 @@
+-- Voxel Companion API v1 adapter for Battle Art Voxel Fork.
+--
+-- The dispatcher owns extension lifecycle and fault isolation. This adapter
+-- owns the real Battle Art seams: copied world facts, additive camera deltas,
+-- three ordered overworld phases, a bounded draw facade, and integrity data.
+-- It does not advertise terrain, shadow, or battle capabilities.
+
+local V = ...
+
+local API = V.require("VoxelCompanionAPI")
+local Mat4 = V.require("Mat4")
+local TileShape = V.require("TileShape")
+local Voxel = V.require("VoxelState")
+local Voxel3D = V.require("Voxel3D")
+local DayNight = V.require("DayNight")
+local Map = require("src.world.Map")
+
+local VoxelCompanion = {}
+VoxelCompanion.__index = VoxelCompanion
+
+local CAPABILITIES = {
+  "world_snapshot",
+  "camera_delta",
+  "render_phases",
+  "quality_tier",
+  "integrity_status",
+}
+
+local WORLD_PHASES = {
+  background = true,
+  opaque_after_terrain = true,
+  translucent_after_actors = true,
+}
+
+local MAX_CELLS = 262144
+local MAX_ACTORS = 2048
+local MAX_NEIGHBORS = 8
+local MAX_PACKET_ITEMS = 2048
+local MAX_DRAWS_PER_FRAME = 4096
+local MAX_WORLD_COORDINATE = 65536
+local MAX_PRIMITIVE_SIZE = 65536
+
+-- These are exact literals written by released KFP 1.x patchers. Only known
+-- host targets are scanned, so this scanner cannot match its own vocabulary.
+local LEGACY_MARKERS = {
+  ["lib/VoxelScene.lua"] = {
+    "pcall(Ceiling.draw",
+    "pcall(Flora.draw",
+    "pcall(Backdrop.draw",
+    "pcall(SkyLayer.draw",
+    "local function __dsMod(name, statusKey)",
+    "__ds_ceiling_status",
+  },
+  ["lib/FirstPerson.lua"] = {
+    'V.require("Jump")',
+    "Jump.eyeOffset(me)",
+    "Jump.swayX(me)",
+    "Jump.swayZ(me)",
+  },
+  ["lib/Structures.lua"] = {
+    "__ds_tree_lift",
+    "__ds_round_key",
+    "__ds_round_tomb",
+    'rawget(_G, "__ds_ceiling_config")',
+  },
+  ["lib/ChunkMesher.lua"] = {
+    "ds_fp_ceilings __ds_round_base",
+    "ds_fp_ceilings fastchunks",
+    'rawget(_G, "__ds_round_base")',
+  },
+  ["main.lua"] = {
+    "Ceiling.setting",
+    "__ds_ceiling_config",
+  },
+  ["lib/Ceiling.lua"] = { "payload-version:", "__ds_ceiling_config" },
+  ["lib/Backdrop.lua"] = { "payload-version:", "__ds_ceiling_config" },
+  ["lib/SkyLayer.lua"] = { "payload-version:", "__ds_ceiling_config" },
+  ["lib/Flora.lua"] = { "payload-version:", "__ds_ceiling_config" },
+  ["lib/Jump.lua"] = { "payload-version:", "Jump.eyeOffset" },
+}
+
+local COLORS = {
+  interior = { 0.82, 0.76, 0.67, 1 },
+  cave = { 0.42, 0.39, 0.45, 1 },
+  rock = { 0.48, 0.47, 0.52, 1 },
+  stone = { 0.52, 0.52, 0.56, 1 },
+  grass = { 0.28, 0.62, 0.31, 1 },
+  tree = { 0.20, 0.48, 0.25, 1 },
+  canopy = { 0.16, 0.43, 0.22, 1 },
+  vine = { 0.23, 0.55, 0.25, 0.92 },
+  water = { 0.26, 0.55, 0.78, 0.64 },
+  puddle = { 0.35, 0.62, 0.80, 0.50 },
+  rain = { 0.70, 0.84, 0.96, 0.70 },
+  shadow = { 0.04, 0.05, 0.07, 0.28 },
+  light = { 1.00, 0.88, 0.55, 0.72 },
+  firefly = { 0.90, 1.00, 0.45, 0.88 },
+  smoke = { 0.70, 0.72, 0.76, 0.52 },
+  default = { 0.68, 0.70, 0.72, 1 },
+}
+
+local function finite(value, fallback)
+  value = tonumber(value)
+  if not value or value ~= value or value == math.huge or value == -math.huge then
+    return fallback
+  end
+  return value
+end
+
+local function integer(value, fallback)
+  value = finite(value, fallback)
+  return value == nil and nil or math.floor(value)
+end
+
+local function clamp(value, minimum, maximum, fallback)
+  value = finite(value, fallback)
+  if value < minimum then return minimum end
+  if value > maximum then return maximum end
+  return value
+end
+
+local function boundedText(value, fallback, limit)
+  if type(value) ~= "string" or value == "" then return fallback end
+  return value:sub(1, limit or 128)
+end
+
+local function shallowCopy(source)
+  local out = {}
+  for key, value in pairs(source or {}) do out[key] = value end
+  return out
+end
+
+local function copyTags(source)
+  local out = {}
+  for key, value in pairs(source or {}) do
+    if type(key) == "string" and value == true then out[key] = true end
+  end
+  return out
+end
+
+local function copySnapshot(source)
+  if type(source) ~= "table" then return nil end
+  local out = shallowCopy(source)
+  out.tags = copyTags(source.tags)
+  out.player = shallowCopy(source.player)
+  out.cells, out.actors, out.neighbors = {}, {}, {}
+  for index, cell in ipairs(source.cells or {}) do
+    local copy = shallowCopy(cell)
+    copy.tags = copyTags(cell.tags)
+    copy.metadata = shallowCopy(cell.metadata)
+    out.cells[index] = copy
+  end
+  for index, actor in ipairs(source.actors or {}) do
+    local copy = shallowCopy(actor)
+    copy.pose = shallowCopy(actor.pose)
+    copy.tags = copyTags(actor.tags)
+    out.actors[index] = copy
+  end
+  for index, neighbor in ipairs(source.neighbors or {}) do
+    local copy = shallowCopy(neighbor)
+    copy.tags = copyTags(neighbor.tags)
+    out.neighbors[index] = copy
+  end
+  return out
+end
+
+local function loggerCall(mod, level, message)
+  local log = mod and mod.log
+  local callback = type(log) == "table" and log[level]
+  if type(callback) == "function" then
+    pcall(callback, log, "%s", tostring(message))
+  end
+end
+
+local function rememberDiagnostic(self, message)
+  self.diagnostics[#self.diagnostics + 1] = tostring(message)
+  if #self.diagnostics > 64 then table.remove(self.diagnostics, 1) end
+end
+
+local function scanIntegrity(mod)
+  local findings = {}
+  for path, markers in pairs(LEGACY_MARKERS) do
+    local ok, source = pcall(mod.read, mod, path)
+    if ok and type(source) == "string" then
+      for _, marker in ipairs(markers) do
+        if source:find(marker, 1, true) then
+          findings[#findings + 1] = { path = path, marker = marker }
+        end
+      end
+    end
+  end
+  table.sort(findings, function(a, b)
+    if a.path ~= b.path then return a.path < b.path end
+    return a.marker < b.marker
+  end)
+  return {
+    clean = #findings == 0,
+    legacyMarkers = #findings > 0,
+    findings = findings,
+    policy = "read-only-refusal",
+  }
+end
+
+local function copyIntegrity(status)
+  local out = {
+    clean = status.clean,
+    legacyMarkers = status.legacyMarkers,
+    policy = status.policy,
+    findings = {},
+  }
+  for index, finding in ipairs(status.findings or {}) do
+    out.findings[index] = { path = finding.path, marker = finding.marker }
+  end
+  return out
+end
+
+local function platformName()
+  if love and love.system and type(love.system.getOS) == "function" then
+    local ok, value = pcall(love.system.getOS)
+    if ok and type(value) == "string" then return value:upper() end
+  end
+  return "UNKNOWN"
+end
+
+local function face(mesh, indices, direction)
+  local corners = Voxel3D.FACE_CORNERS[direction]
+  local shade = Voxel3D.FACE_SHADE[direction] or 1
+  local quad = #mesh / 4
+  for index = 1, 4 do
+    local corner = corners[index]
+    mesh[#mesh + 1] = { corner[1] - 0.5, corner[2] - 0.5,
+      corner[3] - 0.5, 0.5, 0.5, shade }
+  end
+  Voxel3D.pushQuad(indices, quad)
+end
+
+local function buildBox()
+  local vertices, indices = {}, {}
+  for direction = 1, 6 do face(vertices, indices, direction) end
+  return Voxel3D.newMesh(vertices, indices)
+end
+
+local function buildPlane()
+  local vertices = {
+    { -0.5, 0, -0.5, 0.5, 0.5, 1 },
+    {  0.5, 0, -0.5, 0.5, 0.5, 1 },
+    {  0.5, 0,  0.5, 0.5, 0.5, 1 },
+    { -0.5, 0,  0.5, 0.5, 0.5, 1 },
+  }
+  local indices = {}
+  Voxel3D.pushQuad(indices, 0)
+  return Voxel3D.newMesh(vertices, indices)
+end
+
+local function buildBillboard()
+  local vertices = {
+    { -0.5, 0, 0, 0.5, 0.5, 1 },
+    {  0.5, 0, 0, 0.5, 0.5, 1 },
+    {  0.5, 1, 0, 0.5, 0.5, 1 },
+    { -0.5, 1, 0, 0.5, 0.5, 1 },
+  }
+  local indices = {}
+  Voxel3D.pushQuad(indices, 0)
+  return Voxel3D.newMesh(vertices, indices)
+end
+
+local function colorFor(material)
+  local text = tostring(material or ""):lower()
+  for key, color in pairs(COLORS) do
+    if key ~= "default" and text:find(key, 1, true) then return color end
+  end
+  return COLORS.default
+end
+
+local function transform(x, y, z, width, height, depth)
+  return Mat4.mul(Mat4.translate(x, y, z),
+                  Mat4.scale(width, height, depth))
+end
+
+local function billboardTransform(item, width, height)
+  local x = clamp(item.x, -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0)
+  local y = clamp(item.y, -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0)
+  local z = clamp(item.z, -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0)
+  local eye = Voxel3D.eye or { x, y, z + 1 }
+  local yaw = math.atan2((eye[1] or x) - x, (eye[3] or z + 1) - z)
+  return Mat4.mul(Mat4.mul(Mat4.translate(x, y, z), Mat4.rotateY(yaw)),
+                  Mat4.scale(width, height, 1))
+end
+
+local function playerCell(state)
+  local player = state and state.player
+  if type(player) ~= "table" then return nil, nil end
+  return integer(player.cellX, nil), integer(player.cellY, nil)
+end
+
+local function shouldCutaway(self, prototype, item)
+  if not (prototype and prototype.cutaway and prototype.role == "ceiling") then
+    return false
+  end
+  local px, pz = playerCell(self.state)
+  local cx, cz = integer(item.cellX, nil), integer(item.cellZ, nil)
+  if not (px and pz and cx and cz) then return false end
+  return math.abs(px - cx) <= 4 and math.abs(pz - cz) <= 4
+end
+
+local function primitiveDimensions(prototype, item)
+  local primitive = tostring(prototype.primitive or "box")
+  local width = clamp(prototype.width or item.width, 0.01,
+    MAX_PRIMITIVE_SIZE, 8)
+  local height = clamp(prototype.height or item.height, 0,
+    MAX_PRIMITIVE_SIZE, 8)
+  local depth = clamp(prototype.depth or item.depth, 0.01,
+    MAX_PRIMITIVE_SIZE, width)
+
+  if primitive == "plane" then height = 0 end
+  if primitive == "door_frame" then width, height, depth = 12, 24, 2 end
+  if primitive == "window" then width, height, depth = 10, 9, 1 end
+  if primitive == "poster" then width, height, depth = 9, 11, 1 end
+  if primitive == "rail" then width, height, depth = 16, 3, 1 end
+  if primitive == "fixture" then width, height, depth = 4, 3, 4 end
+  if primitive == "cave_roof" then height = 3 end
+  if primitive == "sconce" then width, height, depth = 3, 6, 3 end
+  if primitive == "raised_structure" then width, height, depth = 15, 24, 15 end
+  if primitive == "mountain" then width, height, depth = 18, 26, 18 end
+  if primitive == "hood" then width, height, depth = 18, 10, 18 end
+  if primitive == "grass_clump" then width, height, depth = width, 5, width end
+  if primitive == "canopy" then width, height, depth = width * 1.5, 8, width * 1.5 end
+  if primitive == "vine" then width, height, depth = 3, 16, 3 end
+  if primitive == "umbrella" then width, height, depth = 14, 2, 14 end
+  if primitive == "world_apron" then height = 1 end
+  return primitive, clamp(width, 0.01, MAX_PRIMITIVE_SIZE, 8),
+    clamp(height, 0, MAX_PRIMITIVE_SIZE, 8),
+    clamp(depth, 0.01, MAX_PRIMITIVE_SIZE, 8)
+end
+
+local function useDrawBudget(self, count)
+  count = math.max(0, math.floor(tonumber(count) or 0))
+  if self.frameDraws + count > MAX_DRAWS_PER_FRAME then
+    error("voxel companion frame draw limit reached", 3)
+  end
+  self.frameDraws = self.frameDraws + count
+end
+
+local function ensureTexture(self)
+  if self.texture ~= nil then return self.texture or nil end
+  if not (love and love.image and love.image.newImageData
+      and love.graphics and love.graphics.newImage) then
+    self.texture = false
+    return nil
+  end
+  local ok, texture = pcall(function()
+    local data = love.image.newImageData(1, 1)
+    data:setPixel(0, 0, 1, 1, 1, 1)
+    local image = love.graphics.newImage(data)
+    image:setFilter("nearest", "nearest")
+    return image
+  end)
+  self.texture = ok and texture or false
+  return self.texture or nil
+end
+
+local function ensureMesh(self, kind)
+  if self.meshes[kind] ~= nil then return self.meshes[kind] or nil end
+  local mesh
+  if kind == "plane" then mesh = buildPlane()
+  elseif kind == "billboard" then mesh = buildBillboard()
+  else mesh = buildBox() end
+  self.meshes[kind] = mesh or false
+  return mesh
+end
+
+local function setMaterial(color)
+  love.graphics.setColor(color[1], color[2], color[3], color[4])
+  if color[4] < 1 then
+    love.graphics.setBlendMode("alpha", "alphamultiply")
+    love.graphics.setDepthMode("lequal", false)
+  else
+    love.graphics.setDepthMode("lequal", true)
+  end
+end
+
+local function drawItem(self, prototype, item, material)
+  if shouldCutaway(self, prototype, item) then return false end
+  local primitive, width, height, depth = primitiveDimensions(prototype, item)
+  local texture = ensureTexture(self)
+  if not texture then error("companion material texture is unavailable", 3) end
+  local color = colorFor(material)
+  local ok, err = xpcall(function()
+    setMaterial(color)
+    Voxel3D.glass(false)
+    if primitive == "billboard" then
+      local mesh = ensureMesh(self, "billboard")
+      if not mesh then error("companion billboard mesh is unavailable", 0) end
+      Voxel3D.draw(mesh, texture, billboardTransform(item, width, height))
+    else
+      local meshKind = primitive == "plane" and "plane" or "box"
+      local mesh = ensureMesh(self, meshKind)
+      if not mesh then error("companion primitive mesh is unavailable", 0) end
+      local x = clamp(item.x, -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0)
+      local y = clamp(item.y, -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0)
+      local z = clamp(item.z, -MAX_WORLD_COORDINATE, MAX_WORLD_COORDINATE, 0)
+      Voxel3D.draw(mesh, texture, transform(x, y, z, width,
+        math.max(height, 0.01), depth))
+    end
+  end, function(message) return tostring(message) end)
+  -- Voxel3D keeps its active material shader outside LÖVE's graphics stack.
+  -- Restore that host-owned selector even when an extension draw faults.
+  pcall(Voxel3D.glass, true)
+  if not ok then error(err, 3) end
+  return true
+end
+
+local function makeDrawFacade(self)
+  return {
+    mesh = function(_, packet)
+      if type(packet) ~= "table" or type(packet.geometry) ~= "table" then
+        error("mesh packet needs geometry", 2)
+      end
+      local primitive = packet.geometry.primitive
+      if primitive ~= "world_apron" and primitive ~= "box"
+          and primitive ~= "plane" then
+        error("unsupported Battle Art mesh primitive: " .. tostring(primitive), 2)
+      end
+      useDrawBudget(self, 1)
+      local geometry = packet.geometry
+      if primitive == "world_apron" then
+        local baseWidth = clamp(geometry.width, 0.01,
+          MAX_PRIMITIVE_SIZE, 16)
+        local baseDepth = clamp(geometry.depth, 0.01,
+          MAX_PRIMITIVE_SIZE, 16)
+        local skirt = clamp(geometry.skirtDepth, 0,
+          MAX_PRIMITIVE_SIZE * 0.5, 0)
+        geometry = shallowCopy(geometry)
+        geometry.primitive = "plane"
+        geometry.width = baseWidth + skirt * 2
+        geometry.depth = baseDepth + skirt * 2
+        geometry.x = finite(geometry.x, baseWidth * 0.5)
+        geometry.y = finite(geometry.y, -0.5)
+        geometry.z = finite(geometry.z, baseDepth * 0.5)
+      end
+      drawItem(self, geometry, geometry, packet.material)
+      return true
+    end,
+    instances = function(_, packet)
+      if type(packet) ~= "table" or type(packet.prototype) ~= "table"
+          or type(packet.items) ~= "table" then
+        error("instance packet needs prototype and items", 2)
+      end
+      if #packet.items > MAX_PACKET_ITEMS then error("instance packet limit exceeded", 2) end
+      useDrawBudget(self, #packet.items)
+      for _, item in ipairs(packet.items) do
+        if type(item) ~= "table" then error("instance item must be a table", 2) end
+        drawItem(self, packet.prototype, item, packet.material)
+      end
+      return true
+    end,
+    billboards = function(_, packet)
+      if type(packet) ~= "table" or type(packet.items) ~= "table" then
+        error("billboard packet needs items", 2)
+      end
+      if #packet.items > MAX_PACKET_ITEMS then error("billboard packet limit exceeded", 2) end
+      useDrawBudget(self, #packet.items)
+      local prototype = { primitive = "billboard", width = 3, height = 5 }
+      local material = tostring(packet.material or "")
+      if material:find("bird", 1, true) then prototype.width, prototype.height = 5, 3 end
+      if material:find("aircraft", 1, true) then prototype.width, prototype.height = 12, 4 end
+      if material:find("rain", 1, true) then prototype.width, prototype.height = 0.6, 8 end
+      if material:find("sun_shaft", 1, true) then prototype.width = 8 end
+      for _, item in ipairs(packet.items) do
+        if type(item) ~= "table" then error("billboard item must be a table", 2) end
+        if finite(item.height, nil) then prototype.height = finite(item.height, 5) end
+        drawItem(self, prototype, item, packet.material)
+      end
+      return true
+    end,
+  }
+end
+
+local function cellClass(map, shapes, x, z)
+  local tile = map:cellTile(x, z)
+  local shape = tile ~= nil and shapes[tile] or nil
+  return tile, shape and shape.class or "ground", shape and shape.h or 0
+end
+
+local function addWorldTags(tags, map)
+  local def = map and map.def or {}
+  local mapId = tostring(map and map.id or ""):upper()
+  local tilesetId = tostring(map and map.tileset and map.tileset.id
+    or def.tileset or ""):upper()
+  local outdoor = false
+  local ok, result = pcall(Map.isOutdoor, def)
+  if ok then outdoor = result == true end
+  local cave = tilesetId:find("CAVERN", 1, true)
+    or tilesetId:find("CAVE", 1, true)
+    or mapId:find("ROCK_TUNNEL", 1, true)
+  if cave then tags.cave = true
+  elseif outdoor then tags.outdoor = true
+  else tags.interior, tags.building = true, true end
+  if DayNight.isCanopy(map) or mapId:find("FOREST", 1, true) then
+    tags.forest, tags.canopy = true, true
+  end
+  if mapId:find("LAVENDER", 1, true) or mapId:find("POKEMON_TOWER", 1, true) then
+    tags.lavender = true
+  end
+  if DayNight.tod() == "NIGHT" then tags.night = true end
+end
+
+local function cellRecord(map, shapes, x, z, worldTags)
+  local tile, class, shapeHeight = cellClass(map, shapes, x, z)
+  local walkable = map:isWalkableCell(x, z) == true
+  local water = map:isWaterCell(x, z) == true
+  local grass = map:isGrassCell(x, z) == true
+  local warp = map:warpAtCell(x, z) or map:isWarpTileCell(x, z)
+  local tags = { [class] = true }
+  if worldTags.interior then tags.interior, tags.room = true, true end
+  if worldTags.cave then tags.cave = true end
+  if worldTags.forest then tags.forest = true end
+  if water then tags.water = true end
+  if grass then tags.grass = true end
+  if warp then tags.door = true end
+  if class == "tree" or class == "canopy" or class == "cylinder" then
+    tags.tree = true
+  end
+  if class == "cliff" or class == "rock" then tags.mountain = true end
+  if class == "flower" then tags.flower = true end
+  if class == "wall" or class == "tree" or class == "cliff" then
+    tags.object = true
+  end
+  return {
+    x = x,
+    z = z,
+    worldY = math.max(0, finite(shapeHeight, 0)),
+    height = finite(shapeHeight, 0),
+    kind = class,
+    material = table.concat({ "tileset", tostring(map.tileset and map.tileset.id
+      or "unknown"), class, tostring(tile or -1) }, ":"),
+    solid = not walkable and not water,
+    walkable = walkable,
+    tags = tags,
+    metadata = { tile = tile, class = class },
+  }
+end
+
+local function poseOf(entity)
+  entity = type(entity) == "table" and entity or {}
+  local px = finite(entity.px, finite(entity.x, 0))
+  local pz = finite(entity.py, finite(entity.y, 0))
+  return {
+    x = px + 8,
+    y = finite(entity.gh, 0) + finite(entity.lift, 0),
+    z = pz + 8,
+    cellX = integer(entity.cellX, math.floor(px / 16)),
+    cellZ = integer(entity.cellY, math.floor(pz / 16)),
+    facing = boundedText(entity.facing, "down", 16),
+  }
+end
+
+local function currentGameVersion()
+  local ok, Game = pcall(require, "src.core.Game")
+  local version = ok and Game and Game.save and Game.save.version
+  if version == "red" or version == "blue" or version == "yellow" then
+    return version
+  end
+  return nil
+end
+
+local function snapshotFor(self)
+  local state, map = self.state, self.state and self.state.map
+  if not (state and map and map.id and map.tileset) then
+    return nil, "overworld map is unavailable"
+  end
+  local game = currentGameVersion()
+  if not game then return nil, "Gen 1 game identity is unavailable" end
+  local width = integer(map.widthCells, nil)
+    or integer(map.def and map.def.width, 0) * 2
+  local height = integer(map.heightCells, nil)
+    or integer(map.def and map.def.height, 0) * 2
+  if width < 1 or height < 1 or width * height > MAX_CELLS then
+    return nil, "world dimensions exceed the companion limit"
+  end
+
+  local tags = {}
+  addWorldTags(tags, map)
+  local shapes = TileShape.forMap(map)
+  local cells = {}
+  for z = 0, height - 1 do
+    for x = 0, width - 1 do
+      cells[#cells + 1] = cellRecord(map, shapes, x, z, tags)
+    end
+  end
+
+  local actors = {}
+  for index, entity in ipairs(state.entities or {}) do
+    if entity ~= state.player and #actors < MAX_ACTORS then
+      actors[#actors + 1] = {
+        id = boundedText(entity.id or entity.objectId, tostring(index), 128),
+        kind = boundedText(entity.kind, "npc", 64),
+        pose = poseOf(entity),
+        tags = {},
+      }
+    end
+  end
+
+  local neighbors = {}
+  for index = 1, math.min(#(state.neighbors or {}), MAX_NEIGHBORS) do
+    local neighbor = state.neighbors[index]
+    if neighbor and neighbor.map and neighbor.map.id then
+      neighbors[#neighbors + 1] = {
+        id = tostring(neighbor.map.id),
+        revision = self.revision,
+        offsetX = finite(neighbor.ox, 0),
+        offsetZ = finite(neighbor.oy, 0),
+        atlas = tostring(neighbor.map.tileset and neighbor.map.tileset.id or ""),
+        tilesetRevision = tostring(neighbor.map.tileset and neighbor.map.tileset.id or "0"),
+        tags = {},
+      }
+    end
+  end
+
+  local mode = "diorama"
+  if Voxel.isFirstPerson() then mode = "first_person"
+  elseif Voxel.isThirdPerson() then mode = "third_person" end
+  return {
+    id = tostring(map.id),
+    revision = self.revision,
+    game = game,
+    width = width,
+    height = height,
+    cellSize = 16,
+    paletteRevision = tostring(DayNight.tod()),
+    tilesetRevision = tostring(map.tileset.id or "0"),
+    atlasRevision = tostring(map.tileset.image or map.tileset.id or "0"),
+    mode = mode,
+    tags = tags,
+    player = poseOf(state.player),
+    actors = actors,
+    neighbors = neighbors,
+    cells = cells,
+    time = finite(DayNight.time(), 0),
+    weather = "clear",
+  }
+end
+
+local function cameraContext(self)
+  local camera = Voxel3D.camera
+  local mode = Voxel.isFirstPerson() and "first_person"
+    or (Voxel.isThirdPerson() and "third_person" or "diorama")
+  return {
+    mode = mode,
+    eye = camera and { camera.eye[1], camera.eye[2], camera.eye[3] } or nil,
+    focus = camera and { camera.focus[1], camera.focus[2], camera.focus[3] } or nil,
+    fov = camera and camera.fov or Voxel3D.fovY,
+  }
+end
+
+local function updateFrame(self, dt)
+  local state, player = self.state, self.state and self.state.player
+  local px = player and finite(player.px, nil)
+  local pz = player and finite(player.py, nil)
+  local speed = 0
+  if px and pz and self.lastPlayerX and self.lastPlayerZ and dt > 0 then
+    local dx, dz = px - self.lastPlayerX, pz - self.lastPlayerZ
+    speed = math.sqrt(dx * dx + dz * dz) / dt
+  end
+  self.lastPlayerX, self.lastPlayerZ = px, pz
+  return {
+    index = self.frameIndex,
+    dt = dt,
+    qualityTier = "BALANCED",
+    platform = self.platform,
+    playerSpeed = speed,
+    mapId = state and state.map and state.map.id or nil,
+    time = DayNight.time(),
+  }
+end
+
+function VoxelCompanion.new(options)
+  options = options or {}
+  local mod = options.mod or V.mod
+  assert(type(mod) == "table" and type(mod.read) == "function",
+    "VoxelCompanion needs a mod reader")
+
+  local self = setmetatable({
+    mod = mod,
+    integrity = scanIntegrity(mod),
+    platform = platformName(),
+    state = nil,
+    mapIdentity = nil,
+    timeIdentity = nil,
+    revision = 0,
+    snapshot = nil,
+    worldPending = false,
+    started = false,
+    attached = false,
+    startContext = nil,
+    frame = { dt = 0, qualityTier = "BALANCED", platform = platformName() },
+    frameDraws = 0,
+    meshes = {},
+    texture = nil,
+    diagnostics = {},
+    clock = 0,
+    frameIndex = 0,
+    nextSnapshotAttempt = 0,
+    lastSnapshotError = nil,
+  }, VoxelCompanion)
+
+  self.draw = makeDrawFacade(self)
+  self.materials = {
+    color = function(_, id)
+      local color = colorFor(id)
+      return { color[1], color[2], color[3], color[4] }
+    end,
+  }
+  self.world = {
+    snapshot = function()
+      if not self.snapshot then
+        local ok, source, err = pcall(snapshotFor, self)
+        if not ok then return nil, tostring(source) end
+        if not source then return nil, err end
+        self.snapshot = source
+      end
+      return copySnapshot(self.snapshot)
+    end,
+  }
+  self.quality = {
+    tier = "BALANCED",
+    platform = self.platform,
+    getTier = function() return "BALANCED" end,
+    getPlatform = function() return self.platform end,
+  }
+  self.integrityFacade = {
+    status = function() return copyIntegrity(self.integrity) end,
+  }
+
+  self.dispatcher = API.new({
+    host_id = "BATTLE_ART_VOXEL_FORK",
+    host_version = "1.9.7",
+    capabilities = CAPABILITIES,
+    max_extensions = 32,
+    max_errors = 64,
+    logger = function(event)
+      local message = type(event) == "table" and event.message or tostring(event)
+      rememberDiagnostic(self, message)
+      loggerCall(mod, "error", "Voxel Companion: " .. tostring(message))
+    end,
+  })
+
+  local raw = self.dispatcher:provider()
+  self.provider = raw
+  local register = raw.register
+  raw.register = function(spec)
+    self.integrity = scanIntegrity(mod)
+    if not self.integrity.clean then
+      local finding = self.integrity.findings[1]
+      local message = "legacy KFP splice markers detected"
+      if finding then message = message .. " in " .. finding.path end
+      loggerCall(mod, "error", "Voxel Companion registration refused: " .. message)
+      return nil, message .. "; reinstall a clean voxel host"
+    end
+    local phases = type(spec) == "table" and spec.phases or nil
+    local render = type(spec) == "table" and spec.render or nil
+    if (type(phases) == "table" and phases.shadow_casters ~= nil)
+        or (type(render) == "table" and render.shadow_casters ~= nil) then
+      return nil, "shadow_casters requires unavailable shadow_pass capability"
+    end
+    if (type(phases) == "table" and phases.battle_opaque ~= nil)
+        or (type(render) == "table" and render.battle_opaque ~= nil) then
+      return nil, "battle_opaque requires unavailable battle_pass capability"
+    end
+    -- Use the reference provider closure. It joins an already-running host
+    -- with the dispatcher's retained activation context.
+    return register(spec)
+  end
+  return self
+end
+
+function VoxelCompanion:_context()
+  return {
+    world = self.world,
+    camera = cameraContext(self),
+    frame = self.frame,
+    materials = self.materials,
+    draw = self.draw,
+  }
+end
+
+function VoxelCompanion:start()
+  if self.started then return true end
+  if not self.attached then
+    local ok, err = self.dispatcher:attach({
+      world = self.world,
+      materials = self.materials,
+      draw = self.draw,
+      quality = self.quality,
+      integrity = self.integrityFacade,
+    })
+    if not ok then return nil, err end
+    self.attached = true
+  end
+  self.startContext = self:_context()
+  local report, err = self.dispatcher:start(self.startContext)
+  if not report then return nil, err end
+  self.started = true
+  return report
+end
+
+function VoxelCompanion:_observeState(state)
+  if type(state) == "table" and type(state.map) == "table" then self.state = state end
+  local map = self.state and self.state.map
+  local mapIdentity = map and (tostring(map.id) .. ":" .. tostring(map)) or "none"
+  local timeIdentity = tostring(DayNight.tod())
+  local changed = mapIdentity ~= self.mapIdentity
+    or timeIdentity ~= self.timeIdentity
+  if changed then
+    self.mapIdentity, self.timeIdentity = mapIdentity, timeIdentity
+    self:worldChanged("observed_world_identity")
+  end
+  return changed
+end
+
+-- Mark copied world facts stale without touching host geometry or adapter GPU
+-- resources. Repeated edits before the next update coalesce into one revision
+-- and one canonical worldChanged callback.
+function VoxelCompanion:worldChanged(reason)
+  if not self.worldPending then self.revision = self.revision + 1 end
+  self.snapshot = nil
+  self.worldPending = true
+  self.nextSnapshotAttempt = 0
+  self.worldChangeReason = boundedText(reason, "host_world_changed", 128)
+  return true
+end
+
+function VoxelCompanion:update(dt, state)
+  dt = math.max(0, math.min(0.1, finite(dt, 0)))
+  self.clock = self.clock + dt
+  self.frameIndex = self.frameIndex + 1
+  local changed = self:_observeState(state)
+  self.frame = updateFrame(self, dt)
+  self.frameDraws = 0
+  if not self.started then return false end
+  if (changed or self.worldPending) and self.state and self.state.map
+      and self.clock >= self.nextSnapshotAttempt then
+    local snapshot, snapshotError = self.world.snapshot()
+    if snapshot then
+      local report, dispatchError = self.dispatcher:world_changed(snapshot)
+      if report then
+        self.worldPending = false
+        self.worldChangeReason = nil
+        self.lastSnapshotError = nil
+      else
+        snapshotError = dispatchError
+      end
+    end
+    if not snapshot or self.worldPending then
+      self.nextSnapshotAttempt = self.clock + 1
+      snapshotError = tostring(snapshotError or "snapshot dispatch failed")
+      if snapshotError ~= self.lastSnapshotError then
+        self.lastSnapshotError = snapshotError
+        rememberDiagnostic(self, "world snapshot: " .. snapshotError)
+        loggerCall(self.mod, "warn", "Voxel Companion world snapshot: "
+          .. snapshotError)
+      end
+    end
+  end
+  return self.dispatcher:update(self.frame)
+end
+
+function VoxelCompanion:cameraDelta(state)
+  self:_observeState(state)
+  if not self.started then return nil end
+  local delta = self.dispatcher:modifyCamera(cameraContext(self))
+  return delta
+end
+
+function VoxelCompanion:render(phase, state)
+  if not WORLD_PHASES[phase] then return nil, "unsupported world phase" end
+  self:_observeState(state)
+  if not self.started then return false end
+  local graphics = love and love.graphics
+  if not (graphics and type(graphics.push) == "function"
+      and type(graphics.pop) == "function") then
+    return nil, "graphics state isolation is unavailable"
+  end
+  local pushed = pcall(graphics.push, "all")
+  if not pushed then return nil, "could not isolate graphics state" end
+  local ok, report, err = pcall(self.dispatcher.render, self.dispatcher,
+    phase, self:_context())
+  local popped, popError = pcall(graphics.pop)
+  if not popped then
+    loggerCall(self.mod, "error", "Voxel Companion graphics restore failed: "
+      .. tostring(popError))
+  end
+  if not ok then return nil, tostring(report) end
+  return report, err
+end
+
+function VoxelCompanion:invalidate(reason)
+  self:worldChanged(reason or "host_invalidated")
+  for key, mesh in pairs(self.meshes) do
+    if mesh and mesh.release then pcall(mesh.release, mesh) end
+    self.meshes[key] = nil
+  end
+  if self.texture and self.texture.release then pcall(self.texture.release, self.texture) end
+  self.texture = nil
+  if self.started then
+    return self.dispatcher:invalidate(self:_context(), reason or "host_invalidated")
+  end
+  return true
+end
+
+function VoxelCompanion:dispose(reason)
+  self:invalidate(reason or "host_dispose")
+  local result, err = true, nil
+  if self.started then
+    result, err = self.dispatcher:dispose(self:_context(), reason or "host_dispose")
+  end
+  self.started = false
+  self.attached = false
+  self.startContext = nil
+  self.state = nil
+  self.snapshot = nil
+  self.worldPending = false
+  self.worldChangeReason = nil
+  self.mapIdentity = nil
+  self.timeIdentity = nil
+  self.lastSnapshotError = nil
+  self.nextSnapshotAttempt = 0
+  return result, err
+end
+
+function VoxelCompanion:status()
+  local status = self.dispatcher:status()
+  status.integrity = copyIntegrity(self.integrity)
+  status.revision = self.revision
+  status.diagnostics = {}
+  for index, message in ipairs(self.diagnostics) do status.diagnostics[index] = message end
+  return status
+end
+
+VoxelCompanion.CAPABILITIES = CAPABILITIES
+VoxelCompanion.LEGACY_MARKERS = LEGACY_MARKERS
+VoxelCompanion.LIMITS = {
+  cells = MAX_CELLS,
+  actors = MAX_ACTORS,
+  neighbors = MAX_NEIGHBORS,
+  packetItems = MAX_PACKET_ITEMS,
+  frameDraws = MAX_DRAWS_PER_FRAME,
+}
+
+return VoxelCompanion

--- a/lib/VoxelCompanion.lua
+++ b/lib/VoxelCompanion.lua
@@ -52,6 +52,20 @@ local PANORAMA_TOP = 300
 local PANORAMA_BOTTOM = -120
 local PANORAMA_DEEP_BOTTOM = -1400
 
+-- Semantic density roles are intentionally narrower than TileShape classes.
+-- A `cylinder` is only a host geometry choice; it is not proof that a cell is
+-- a tree. Likewise, a generic wall or cliff is not proof of mountain rock.
+-- These authored OVERWORLD ids are the public KFP 1.60 distinctions that the
+-- host can verify without exposing engine state to an extension.
+local SEMANTIC_TILESETS = {
+  OVERWORLD = {
+    tree_support = { [64] = true, [65] = true, [80] = true, [81] = true },
+    boulder_tree = { [42] = true, [43] = true, [58] = true, [59] = true },
+    mountain_seed = { [2] = true, [36] = true },
+  },
+}
+local MOUNTAIN_REACH = 2
+
 local MESH_PRIMITIVES = {
   box = true,
   plane = true,
@@ -1156,10 +1170,9 @@ local function cellRecord(map, shapes, x, z, worldTags)
   if water then tags.water = true end
   if grass then tags.grass = true end
   if warp then tags.door = true end
-  if class == "tree" or class == "canopy" or class == "cylinder" then
+  if (class == "tree" or class == "canopy") and not walkable and not water then
     tags.tree = true
   end
-  if class == "cliff" or class == "rock" then tags.mountain = true end
   if class == "flower" then tags.flower = true end
   if class == "wall" or class == "tree" or class == "cliff" then
     tags.object = true
@@ -1177,6 +1190,133 @@ local function cellRecord(map, shapes, x, z, worldTags)
     tags = tags,
     metadata = { tile = tile, class = class },
   }
+end
+
+local function cellAt(cells, width, height, x, z)
+  if x < 0 or z < 0 or x >= width or z >= height then return nil end
+  return cells[z * width + x + 1]
+end
+
+local function stableObstacle(cell)
+  return cell ~= nil and cell.solid == true and cell.walkable ~= true
+    and not (cell.tags and cell.tags.water)
+end
+
+local function nearClass(cells, width, height, cell, class, radius)
+  for dz = -radius, radius do
+    for dx = -radius, radius do
+      if dx ~= 0 or dz ~= 0 then
+        local neighbor = cellAt(cells, width, height,
+          cell.x + dx, cell.z + dz)
+        if neighbor and neighbor.metadata
+            and neighbor.metadata.class == class then
+          return true
+        end
+      end
+    end
+  end
+  return false
+end
+
+local function nearTag(cells, width, height, cell, tag, radius)
+  for dz = -radius, radius do
+    for dx = -radius, radius do
+      if dx ~= 0 or dz ~= 0 then
+        local neighbor = cellAt(cells, width, height,
+          cell.x + dx, cell.z + dz)
+        if neighbor and neighbor.tags and neighbor.tags[tag] then return true end
+      end
+    end
+  end
+  return false
+end
+
+local function inConnectionBand(def, width, height, cell)
+  local connections = type(def) == "table" and def.connections or nil
+  if type(connections) ~= "table" then return false end
+  return (connections.north and cell.z < 2)
+    or (connections.south and cell.z > height - 3)
+    or (connections.west and cell.x < 2)
+    or (connections.east and cell.x > width - 3)
+    or false
+end
+
+-- Add only host-proven semantic roles. Seeds and support candidates use the
+-- corrected KFP 1.60 mountain gates: authored OVERWORLD rock ids start a
+-- bounded four-neighbor flood through upright, solid cells. Roof proximity
+-- rejects every candidate; door proximity rejects only non-seed support so a
+-- real cave mouth can retain its rock shoulders. Unknowns fail closed.
+local function applySemanticTags(cells, width, height, map, worldTags)
+  if not (worldTags and worldTags.outdoor) then return end
+  local def = map and map.def or {}
+  local tilesetId = tostring(map and map.tileset and map.tileset.id
+    or def.tileset or ""):upper()
+  local semantic = SEMANTIC_TILESETS[tilesetId]
+  if not semantic then return end
+
+  local mountainCandidates = {}
+  local mountainSeeds = {}
+  local queue, distance = {}, {}
+  local cardinalX = { -1, 1, 0, 0 }
+  local cardinalZ = { 0, 0, -1, 1 }
+  for index, cell in ipairs(cells) do
+    local metadata = cell.metadata or {}
+    local tile, class = metadata.tile, metadata.class
+    if stableObstacle(cell) and class == "cylinder" then
+      if semantic.tree_support[tile] then
+        cell.tags.tree_support = true
+        cell.tags.tree = true
+        cell.tags.object = true
+      elseif semantic.boulder_tree[tile] then
+        cell.tags.boulder_tree = true
+        cell.tags.boulder = true
+        cell.tags.object = true
+      end
+    end
+
+    if stableObstacle(cell) and (class == "wall" or class == "cliff")
+        and not inConnectionBand(def, width, height, cell)
+        and not nearClass(cells, width, height, cell, "roof", MOUNTAIN_REACH)
+    then
+      local seed = semantic.mountain_seed[tile] == true
+      if seed or not nearTag(cells, width, height, cell,
+          "door", MOUNTAIN_REACH) then
+        mountainCandidates[index] = true
+        if seed then
+          mountainSeeds[index] = true
+          distance[index] = 0
+          queue[#queue + 1] = index
+        end
+      end
+    end
+  end
+
+  local head = 1
+  while queue[head] do
+    local index = queue[head]
+    head = head + 1
+    local cell = cells[index]
+    if distance[index] < MOUNTAIN_REACH then
+      for direction = 1, 4 do
+        local nextCell = cellAt(cells, width, height,
+          cell.x + cardinalX[direction], cell.z + cardinalZ[direction])
+        local nextIndex = nextCell and nextCell.z * width + nextCell.x + 1
+        if nextIndex and mountainCandidates[nextIndex]
+            and distance[nextIndex] == nil then
+          distance[nextIndex] = distance[index] + 1
+          queue[#queue + 1] = nextIndex
+        end
+      end
+    end
+  end
+
+  for index in pairs(distance) do
+    local tags = cells[index].tags
+    tags.mountain_support = true
+    tags.mountain = true
+    tags.object = true
+    if mountainSeeds[index] then tags.mountain_seed = true end
+  end
 end
 
 local function poseOf(entity)
@@ -1226,6 +1366,7 @@ local function snapshotFor(self)
       cells[#cells + 1] = cellRecord(map, shapes, x, z, tags)
     end
   end
+  applySemanticTags(cells, width, height, map, tags)
 
   local actors = {}
   for index, entity in ipairs(state.entities or {}) do

--- a/lib/VoxelCompanionAPI.lua
+++ b/lib/VoxelCompanionAPI.lua
@@ -1,0 +1,1635 @@
+-- Voxel Companion API v1 reference dispatcher.
+--
+-- This module is pure Lua 5.1/LuaJIT. It does not require LÖVE, gen1recomp,
+-- or a voxel renderer. Hosts own rendering and call this dispatcher at the
+-- documented lifecycle and render seams.
+
+local API = {
+  VERSION = 1,
+}
+
+API.CAPABILITIES = {
+  RENDER_PHASES = "render_phases",
+  CAMERA_DELTA = "camera_delta",
+  TERRAIN_PATCH = "terrain_patch",
+  WORLD_SNAPSHOT = "world_snapshot",
+  QUALITY_TIER = "quality_tier",
+  SHADOW_PASS = "shadow_pass",
+  BATTLE_PASS = "battle_pass",
+  INTEGRITY_STATUS = "integrity_status",
+  -- Optional facade declarations for adapters that negotiate them separately.
+  MATERIALS = "materials",
+  DRAW = "draw",
+}
+-- Short aliases name the attach facades while retaining the wire capability
+-- names used by KFP's host client.
+API.CAPABILITIES.WORLD = API.CAPABILITIES.WORLD_SNAPSHOT
+API.CAPABILITIES.QUALITY = API.CAPABILITIES.QUALITY_TIER
+API.CAPABILITIES.INTEGRITY = API.CAPABILITIES.INTEGRITY_STATUS
+
+API.PHASES = {
+  "update",
+  "map_changed",
+  "background",
+  "opaque_after_terrain",
+  "translucent_after_actors",
+  "shadow_casters",
+  "battle_opaque",
+}
+
+local PHASE_SET = {}
+for _, phase in ipairs(API.PHASES) do PHASE_SET[phase] = true end
+
+local RENDER_PHASE_SET = {
+  background = true,
+  opaque_after_terrain = true,
+  translucent_after_actors = true,
+  shadow_casters = true,
+  battle_opaque = true,
+}
+
+local SERVICE_CAPABILITIES = {
+  world_snapshot = "world",
+  materials = "materials",
+  draw = "draw",
+  quality_tier = "quality",
+  integrity_status = "integrity",
+}
+
+local TOP_LEVEL_SPEC_KEYS = {
+  api = true,
+  id = true,
+  name = true,
+  version = true,
+  priority = true,
+  requires = true,
+  optional = true,
+  attach = true,
+  worldChanged = true,
+  update = true,
+  modifyCamera = true,
+  terrainPatch = true,
+  render = true,
+  invalidate = true,
+  dispose = true,
+  lifecycle = true,
+  phases = true,
+  camera = true,
+  terrain = true,
+}
+
+local LIFECYCLE_KEYS = {
+  attach = true,
+  start = true,
+  invalidate = true,
+  dispose = true,
+}
+
+local TERRAIN_RESULT_KEYS = {
+  cacheKey = true,
+  suppressCells = true,
+  transforms = true,
+  instances = true,
+  tags = true,
+  invalidate = true,
+}
+
+local CAMERA_RESULT_KEYS = {
+  positionDelta = true,
+  rotationDelta = true,
+  fovDelta = true,
+}
+
+local POSITION_KEYS = { x = true, y = true, z = true }
+local ROTATION_KEYS = { yaw = true, pitch = true, roll = true }
+
+local MAX_ID_LENGTH = 128
+local MAX_VERSION_LENGTH = 64
+local MAX_CACHE_KEY_LENGTH = 512
+local MAX_REQUIREMENTS = 64
+local MAX_PATCH_ITEMS = 8192
+local MAX_MERGED_PATCH_ITEMS = 32768
+local MAX_DATA_DEPTH = 16
+local MAX_DATA_NODES = 32768
+local MAX_DATA_BYTES = 256 * 1024
+local MAX_ERROR_MESSAGE_LENGTH = 4096
+
+local function is_finite(value)
+  return type(value) == "number"
+     and value == value
+     and value ~= math.huge
+     and value ~= -math.huge
+end
+
+local function is_integer(value)
+  return is_finite(value) and value == math.floor(value)
+end
+
+local function pack(...)
+  return { n = select("#", ...), ... }
+end
+
+local function copy_array(values)
+  local out = {}
+  for i = 1, #values do out[i] = values[i] end
+  return out
+end
+
+local function sorted_keys(set)
+  local out = {}
+  for key in pairs(set) do out[#out + 1] = key end
+  table.sort(out)
+  return out
+end
+
+local function validate_known_keys(value, allowed, path)
+  for key in pairs(value) do
+    if not allowed[key] then
+      return nil, ("%s has unknown field %q"):format(path, tostring(key))
+    end
+  end
+  return true
+end
+
+local function validate_dense_array(value, path, limit)
+  if type(value) ~= "table" then
+    return nil, path .. " must be an array"
+  end
+  if getmetatable(value) ~= nil then
+    return nil, path .. " must not have a metatable"
+  end
+
+  local count, maximum = 0, 0
+  for key in pairs(value) do
+    if not is_integer(key) or key < 1 then
+      return nil, path .. " must use positive integer indexes"
+    end
+    count = count + 1
+    if key > maximum then maximum = key end
+  end
+  if count ~= maximum then
+    return nil, path .. " must not contain holes"
+  end
+  if maximum > limit then
+    return nil, ("%s exceeds its %d item limit"):format(path, limit)
+  end
+  return maximum
+end
+
+local function clone_declarative(value, path, state, depth)
+  local kind = type(value)
+  if kind == "string" then
+    state.bytes = state.bytes + #value
+    if state.bytes > MAX_DATA_BYTES then
+      return nil, path .. " exceeds the maximum data byte size"
+    end
+    return value
+  end
+  if kind == "nil" or kind == "boolean" then return value end
+  if kind == "number" then
+    if not is_finite(value) then
+      return nil, path .. " contains a non-finite number"
+    end
+    state.bytes = state.bytes + 8
+    if state.bytes > MAX_DATA_BYTES then
+      return nil, path .. " exceeds the maximum data byte size"
+    end
+    return value
+  end
+  if kind ~= "table" then
+    return nil, ("%s contains unsupported %s data"):format(path, kind)
+  end
+  if getmetatable(value) ~= nil then
+    return nil, path .. " contains a table with a metatable"
+  end
+  if depth >= MAX_DATA_DEPTH then
+    return nil, path .. " exceeds the maximum data depth"
+  end
+  if state.active[value] then
+    return nil, path .. " contains a cycle"
+  end
+
+  state.active[value] = true
+  local out = {}
+  for key, item in pairs(value) do
+    state.nodes = state.nodes + 1
+    if state.nodes > MAX_DATA_NODES then
+      state.active[value] = nil
+      return nil, path .. " exceeds the maximum data size"
+    end
+
+    local key_kind = type(key)
+    if key_kind == "number" then
+      if not is_integer(key) or key < 1 then
+        state.active[value] = nil
+        return nil, path .. " has an invalid numeric key"
+      end
+      state.bytes = state.bytes + 8
+    elseif key_kind ~= "string" then
+      state.active[value] = nil
+      return nil, path .. " has a non-string, non-integer key"
+    else
+      state.bytes = state.bytes + #key
+    end
+    if state.bytes > MAX_DATA_BYTES then
+      state.active[value] = nil
+      return nil, path .. " exceeds the maximum data byte size"
+    end
+
+    local cloned, err = clone_declarative(
+      item,
+      path .. "[" .. tostring(key) .. "]",
+      state,
+      depth + 1
+    )
+    if err then
+      state.active[value] = nil
+      return nil, err
+    end
+    out[key] = cloned
+  end
+  state.active[value] = nil
+  return out
+end
+
+local function clone_data(value, path, state)
+  state = state or { active = {}, nodes = 0, bytes = 0 }
+  return clone_declarative(value, path, state, 0)
+end
+
+-- LuaJIT 2.1 follows Lua 5.1 table semantics. It does not honor __pairs for
+-- tables, so the lease intentionally protects named top-level fields only.
+-- Nested facades and handles remain borrowed under the documented contract.
+local function borrowed_view(source, label)
+  local lease = { active = true }
+  local proxy
+  proxy = setmetatable({}, {
+    __index = function(_, key)
+      if not lease.active then
+        error(label .. " is no longer valid", 2)
+      end
+      return source[key]
+    end,
+    __newindex = function()
+      error(label .. " is read-only", 2)
+    end,
+    __metatable = "voxel-companion borrowed view",
+  })
+
+  local function close()
+    lease.active = false
+    local dirty_key = nil
+    for key in next, proxy do
+      if dirty_key == nil then dirty_key = key end
+      rawset(proxy, key, nil)
+    end
+    if dirty_key ~= nil then
+      return nil, ("%s was changed with rawset at field %q")
+        :format(label, tostring(dirty_key))
+    end
+    return true
+  end
+
+  return proxy, close
+end
+
+local function validate_draw_facade(draw, path)
+  if type(draw) ~= "table" then
+    return nil, path .. " must be a table"
+  end
+  for _, method in ipairs({ "mesh", "instances", "billboards" }) do
+    if type(draw[method]) ~= "function" then
+      return nil, ("%s.%s must be a function"):format(path, method)
+    end
+  end
+  return true
+end
+
+local function validate_required_facades(services, requirements, path)
+  for capability in pairs(requirements) do
+    local facade_name = SERVICE_CAPABILITIES[capability]
+    if facade_name then
+      local facade = services[facade_name]
+      if type(facade) ~= "table" then
+        return nil, ("%s.%s is required by capability %q")
+          :format(path, facade_name, capability)
+      end
+      if facade_name == "draw" then
+        local ok, err = validate_draw_facade(facade, path .. ".draw")
+        if not ok then return nil, err end
+      end
+    end
+  end
+  return true
+end
+
+local function validate_render_context(context, path)
+  for _, key in ipairs({ "world", "camera", "frame", "materials", "draw" }) do
+    if type(context[key]) ~= "table" then
+      return nil, ("%s.%s must be a borrowed table facade"):format(path, key)
+    end
+  end
+  return validate_draw_facade(context.draw, path .. ".draw")
+end
+
+local function normalize_capability_list(value, path)
+  if value == nil then return {}, {} end
+  local count, err = validate_dense_array(value, path, MAX_REQUIREMENTS)
+  if not count then return nil, err end
+
+  local set, list = {}, {}
+  for i = 1, count do
+    local capability = value[i]
+    if type(capability) ~= "string" or capability == "" then
+      return nil, ("%s[%d] must be a non-empty string"):format(path, i)
+    end
+    if set[capability] then
+      return nil, ("%s contains duplicate %q"):format(path, capability)
+    end
+    set[capability] = true
+    list[#list + 1] = capability
+  end
+  table.sort(list)
+  return set, list
+end
+
+local function add_automatic_requirement(set, list, capability)
+  if not set[capability] then
+    set[capability] = true
+    list[#list + 1] = capability
+    table.sort(list)
+  end
+end
+
+local function normalize_spec(spec, host_capabilities)
+  if type(spec) ~= "table" then
+    return nil, "extension must be a table"
+  end
+  local ok, err = validate_known_keys(spec, TOP_LEVEL_SPEC_KEYS, "extension")
+  if not ok then return nil, err end
+  if spec.api ~= API.VERSION then
+    return nil, ("extension.api must be %d"):format(API.VERSION)
+  end
+  if type(spec.id) ~= "string"
+     or #spec.id < 1
+     or #spec.id > MAX_ID_LENGTH
+     or not spec.id:match("^[A-Za-z0-9][A-Za-z0-9_.%-]*$") then
+    return nil, "extension.id must be a stable 1-128 character identifier"
+  end
+  if spec.name ~= nil and (type(spec.name) ~= "string" or spec.name == "") then
+    return nil, "extension.name must be a non-empty string when present"
+  end
+  if spec.version ~= nil
+     and (type(spec.version) ~= "string"
+          or spec.version == ""
+          or #spec.version > MAX_VERSION_LENGTH) then
+    return nil, "extension.version must be a 1-64 character string when present"
+  end
+
+  local priority = spec.priority or 0
+  if not is_integer(priority) or priority < -100000 or priority > 100000 then
+    return nil, "extension.priority must be an integer from -100000 to 100000"
+  end
+
+  local requirements, requirement_list = normalize_capability_list(
+    spec.requires,
+    "extension.requires"
+  )
+  if not requirements then return nil, requirement_list end
+  local optional, optional_list = normalize_capability_list(
+    spec.optional,
+    "extension.optional"
+  )
+  if not optional then return nil, optional_list end
+  for _, capability in ipairs(optional_list) do
+    if requirements[capability] then
+      return nil, ("capability %q cannot be both required and optional")
+        :format(capability)
+    end
+  end
+
+  local lifecycle = {}
+  if spec.lifecycle ~= nil then
+    if type(spec.lifecycle) ~= "table" then
+      return nil, "extension.lifecycle must be a table"
+    end
+    ok, err = validate_known_keys(spec.lifecycle, LIFECYCLE_KEYS, "extension.lifecycle")
+    if not ok then return nil, err end
+    for name in pairs(LIFECYCLE_KEYS) do
+      local handler = spec.lifecycle[name]
+      if handler ~= nil and type(handler) ~= "function" then
+        return nil, ("extension.lifecycle.%s must be a function"):format(name)
+      end
+      lifecycle[name] = handler
+    end
+  end
+  for _, name in ipairs({ "attach", "invalidate", "dispose" }) do
+    if spec[name] ~= nil and type(spec[name]) ~= "function" then
+      return nil, ("extension.%s must be a function"):format(name)
+    end
+    if spec[name] ~= nil and lifecycle[name] ~= nil then
+      return nil, ("extension.%s conflicts with extension.lifecycle.%s")
+        :format(name, name)
+    end
+  end
+  if spec.attach then lifecycle.attach = spec.attach end
+  if spec.invalidate then
+    lifecycle.invalidate = function(_, reason) return spec.invalidate(reason) end
+  end
+  if spec.dispose then
+    lifecycle.dispose = function() return spec.dispose() end
+  end
+
+  local phases = {}
+  local has_phase = false
+  if spec.phases ~= nil then
+    if type(spec.phases) ~= "table" then
+      return nil, "extension.phases must be a table"
+    end
+    ok, err = validate_known_keys(spec.phases, PHASE_SET, "extension.phases")
+    if not ok then return nil, err end
+    for _, phase in ipairs(API.PHASES) do
+      local handler = spec.phases[phase]
+      if handler ~= nil and type(handler) ~= "function" then
+        return nil, ("extension.phases.%s must be a function"):format(phase)
+      end
+      if handler ~= nil then has_phase = true end
+      phases[phase] = handler
+    end
+  end
+
+  if spec.render ~= nil then
+    if type(spec.render) ~= "table" then
+      return nil, "extension.render must be a table"
+    end
+    ok, err = validate_known_keys(spec.render, RENDER_PHASE_SET, "extension.render")
+    if not ok then return nil, err end
+    for phase in pairs(RENDER_PHASE_SET) do
+      local handler = spec.render[phase]
+      if handler ~= nil and type(handler) ~= "function" then
+        return nil, ("extension.render.%s must be a function"):format(phase)
+      end
+      if handler ~= nil and phases[phase] ~= nil then
+        return nil, ("extension.render.%s conflicts with extension.phases.%s")
+          :format(phase, phase)
+      end
+      if handler ~= nil then
+        phases[phase] = handler
+        has_phase = true
+      end
+    end
+  end
+
+  for flat_name, phase in pairs({
+    update = "update",
+    worldChanged = "map_changed",
+  }) do
+    local handler = spec[flat_name]
+    if handler ~= nil and type(handler) ~= "function" then
+      return nil, ("extension.%s must be a function"):format(flat_name)
+    end
+    if handler ~= nil and phases[phase] ~= nil then
+      return nil, ("extension.%s conflicts with extension.phases.%s")
+        :format(flat_name, phase)
+    end
+    if handler ~= nil then
+      phases[phase] = handler
+      has_phase = true
+    end
+  end
+
+  if spec.camera ~= nil and type(spec.camera) ~= "function" then
+    return nil, "extension.camera must be a function"
+  end
+  if spec.modifyCamera ~= nil and type(spec.modifyCamera) ~= "function" then
+    return nil, "extension.modifyCamera must be a function"
+  end
+  if spec.camera ~= nil and spec.modifyCamera ~= nil then
+    return nil, "extension.modifyCamera conflicts with extension.camera"
+  end
+  if spec.terrain ~= nil and type(spec.terrain) ~= "function" then
+    return nil, "extension.terrain must be a function"
+  end
+  if spec.terrainPatch ~= nil and type(spec.terrainPatch) ~= "function" then
+    return nil, "extension.terrainPatch must be a function"
+  end
+  if spec.terrain ~= nil and spec.terrainPatch ~= nil then
+    return nil, "extension.terrainPatch conflicts with extension.terrain"
+  end
+  local camera = spec.modifyCamera or spec.camera
+  local terrain = spec.terrainPatch or spec.terrain
+
+  if has_phase then
+    add_automatic_requirement(requirements, requirement_list, "render_phases")
+  end
+  if phases.shadow_casters then
+    add_automatic_requirement(requirements, requirement_list, "shadow_pass")
+  end
+  if phases.battle_opaque then
+    add_automatic_requirement(requirements, requirement_list, "battle_pass")
+  end
+  if camera then
+    add_automatic_requirement(requirements, requirement_list, "camera_delta")
+  end
+  if terrain then
+    add_automatic_requirement(requirements, requirement_list, "terrain_patch")
+  end
+
+  local promoted_optional = {}
+  for _, capability in ipairs(optional_list) do
+    if requirements[capability] then
+      optional[capability] = nil
+    else
+      promoted_optional[#promoted_optional + 1] = capability
+    end
+  end
+  optional_list = promoted_optional
+
+  for _, capability in ipairs(requirement_list) do
+    if not host_capabilities[capability] then
+      return nil, ("host does not provide required capability %q"):format(capability)
+    end
+  end
+
+  local has_handler = camera ~= nil or terrain ~= nil or has_phase
+  for _, handler in pairs(lifecycle) do
+    if handler ~= nil then has_handler = true break end
+  end
+  if not has_handler then
+    return nil, "extension must declare at least one handler"
+  end
+
+  return {
+    source = spec,
+    id = spec.id,
+    name = spec.name or spec.id,
+    version = spec.version,
+    priority = priority,
+    requirements = requirements,
+    requirement_list = requirement_list,
+    optional = optional,
+    optional_list = optional_list,
+    lifecycle = lifecycle,
+    phases = phases,
+    camera = camera,
+    terrain = terrain,
+    state = "registered",
+    active = false,
+    attached = false,
+    started = false,
+    faulted = false,
+    dispose_called = false,
+  }
+end
+
+local function validate_vector(value, allowed, path)
+  if value == nil then
+    local zero = {}
+    for key in pairs(allowed) do zero[key] = 0 end
+    return zero
+  end
+  if type(value) ~= "table" or getmetatable(value) ~= nil then
+    return nil, path .. " must be a plain table"
+  end
+  local ok, err = validate_known_keys(value, allowed, path)
+  if not ok then return nil, err end
+  local out = {}
+  for key in pairs(allowed) do
+    local number = value[key]
+    if number ~= nil and not is_finite(number) then
+      return nil, ("%s.%s must be a finite number"):format(path, key)
+    end
+    out[key] = number or 0
+  end
+  return out
+end
+
+local function validate_camera_result(value)
+  if value == nil then
+    return {
+      positionDelta = { x = 0, y = 0, z = 0 },
+      rotationDelta = { yaw = 0, pitch = 0, roll = 0 },
+      fovDelta = 0,
+    }
+  end
+  if type(value) ~= "table" or getmetatable(value) ~= nil then
+    return nil, "camera result must be a plain table or nil"
+  end
+  local ok, err = validate_known_keys(value, CAMERA_RESULT_KEYS, "camera result")
+  if not ok then return nil, err end
+  local position
+  position, err = validate_vector(value.positionDelta, POSITION_KEYS, "camera result.positionDelta")
+  if not position then return nil, err end
+  local rotation
+  rotation, err = validate_vector(value.rotationDelta, ROTATION_KEYS, "camera result.rotationDelta")
+  if not rotation then return nil, err end
+  local fov = value.fovDelta or 0
+  if not is_finite(fov) then
+    return nil, "camera result.fovDelta must be a finite number"
+  end
+  return {
+    positionDelta = position,
+    rotationDelta = rotation,
+    fovDelta = fov,
+  }
+end
+
+local function patch_entry_key(entry, path, allow_string)
+  if allow_string and type(entry) == "string" and entry ~= "" then
+    return entry
+  end
+  if type(entry) ~= "table" then
+    return nil, path .. " must be a table with a non-empty key"
+  end
+  if type(entry.key) ~= "string" or entry.key == "" then
+    return nil, path .. ".key must be a non-empty string"
+  end
+  return entry.key
+end
+
+local function validate_patch_array(value, path, kind, clone_state)
+  if value == nil then return {}, {} end
+  local count, err = validate_dense_array(value, path, MAX_PATCH_ITEMS)
+  if not count then return nil, err end
+
+  local out, keys = {}, {}
+  for i = 1, count do
+    local item = value[i]
+    if kind == "instances" and type(item) ~= "table" then
+      return nil, ("%s[%d] must be a declarative table"):format(path, i)
+    end
+    local key = nil
+    if kind ~= "instances" then
+      key, err = patch_entry_key(item, ("%s[%d]"):format(path, i), kind == "suppressCells")
+      if not key then return nil, err end
+      if keys[key] then
+        return nil, ("%s contains duplicate key %q"):format(path, key)
+      end
+      keys[key] = true
+    end
+    local cloned
+    cloned, err = clone_data(item, ("%s[%d]"):format(path, i), clone_state)
+    if err then return nil, err end
+    out[i] = cloned
+  end
+  return out, keys
+end
+
+local function validate_tags(value, clone_state)
+  if value == nil then return {} end
+  if type(value) ~= "table" or getmetatable(value) ~= nil then
+    return nil, "terrain result.tags must be a plain table"
+  end
+  for key in pairs(value) do
+    if type(key) ~= "string" or key == "" then
+      return nil, "terrain result.tags must use non-empty string keys"
+    end
+  end
+  return clone_data(value, "terrain result.tags", clone_state)
+end
+
+local function validate_terrain_result(value)
+  if value == nil then
+    return {
+      cacheKey = nil,
+      suppressCells = {},
+      suppressionKeys = {},
+      transforms = {},
+      transformKeys = {},
+      instances = {},
+      tags = {},
+      invalidate = false,
+      hasPatchData = false,
+    }
+  end
+  if type(value) ~= "table" or getmetatable(value) ~= nil then
+    return nil, "terrain result must be a plain table or nil"
+  end
+  local ok, err = validate_known_keys(value, TERRAIN_RESULT_KEYS, "terrain result")
+  if not ok then return nil, err end
+
+  local cache_key = value.cacheKey
+  if cache_key ~= nil
+     and (type(cache_key) ~= "string"
+          or cache_key == ""
+          or #cache_key > MAX_CACHE_KEY_LENGTH) then
+    return nil, "terrain result.cacheKey must be a 1-512 character string when present"
+  end
+  if value.invalidate ~= nil and type(value.invalidate) ~= "boolean" then
+    return nil, "terrain result.invalidate must be a boolean when present"
+  end
+
+  local clone_state = { active = {}, nodes = 0, bytes = 0 }
+
+  local suppressions, suppression_keys = validate_patch_array(
+    value.suppressCells,
+    "terrain result.suppressCells",
+    "suppressCells",
+    clone_state
+  )
+  if not suppressions then return nil, suppression_keys end
+  local transforms, transform_keys = validate_patch_array(
+    value.transforms,
+    "terrain result.transforms",
+    "transforms",
+    clone_state
+  )
+  if not transforms then return nil, transform_keys end
+  local instances
+  instances, err = validate_patch_array(
+    value.instances,
+    "terrain result.instances",
+    "instances",
+    clone_state
+  )
+  if not instances then return nil, err end
+  local tags
+  tags, err = validate_tags(value.tags, clone_state)
+  if not tags then return nil, err end
+
+  return {
+    cacheKey = cache_key,
+    suppressCells = suppressions,
+    suppressionKeys = suppression_keys,
+    transforms = transforms,
+    transformKeys = transform_keys,
+    instances = instances,
+    tags = tags,
+    invalidate = value.invalidate == true,
+    hasPatchData = #suppressions > 0
+      or #transforms > 0
+      or #instances > 0
+      or next(tags) ~= nil,
+  }
+end
+
+local function cache_segment(value)
+  return tostring(#value) .. ":" .. value
+end
+
+local Dispatcher = {}
+Dispatcher.__index = Dispatcher
+
+local Handle = {}
+Handle.__index = Handle
+
+local function new_report(kind, name)
+  return {
+    kind = kind,
+    name = name,
+    called = 0,
+    succeeded = 0,
+    failed = 0,
+    skipped = 0,
+    contributors = {},
+  }
+end
+
+function API.new(options)
+  options = options or {}
+  if type(options) ~= "table" then error("options must be a table", 2) end
+  local allowed = {
+    host_id = true,
+    host_version = true,
+    capabilities = true,
+    logger = true,
+    clock = true,
+    max_errors = true,
+    max_extensions = true,
+  }
+  local ok, err = validate_known_keys(options, allowed, "options")
+  if not ok then error(err, 2) end
+
+  local host_id = options.host_id or "voxel-host"
+  if type(host_id) ~= "string" or host_id == "" then
+    error("options.host_id must be a non-empty string", 2)
+  end
+  local host_version = options.host_version or "unknown"
+  if type(host_version) ~= "string" or host_version == "" then
+    error("options.host_version must be a non-empty string", 2)
+  end
+  if options.logger ~= nil and type(options.logger) ~= "function" then
+    error("options.logger must be a function", 2)
+  end
+  if options.clock ~= nil and type(options.clock) ~= "function" then
+    error("options.clock must be a function", 2)
+  end
+  local max_errors = options.max_errors or 64
+  if not is_integer(max_errors) or max_errors < 1 or max_errors > 4096 then
+    error("options.max_errors must be an integer from 1 to 4096", 2)
+  end
+  local max_extensions = options.max_extensions or 64
+  if not is_integer(max_extensions) or max_extensions < 1 or max_extensions > 1024 then
+    error("options.max_extensions must be an integer from 1 to 1024", 2)
+  end
+
+  local capabilities = {}
+  if options.capabilities ~= nil then
+    local count
+    count, err = validate_dense_array(options.capabilities, "options.capabilities", 128)
+    if not count then error(err, 2) end
+    for i = 1, count do
+      local capability = options.capabilities[i]
+      if type(capability) ~= "string" or capability == "" then
+        error(("options.capabilities[%d] must be a non-empty string"):format(i), 2)
+      end
+      if capabilities[capability] then
+        error(("options.capabilities contains duplicate %q"):format(capability), 2)
+      end
+      capabilities[capability] = true
+    end
+  end
+
+  return setmetatable({
+    _host_id = host_id,
+    _host_version = host_version,
+    _capabilities = capabilities,
+    _logger = options.logger,
+    _clock = options.clock or os.clock,
+    _max_errors = max_errors,
+    _max_extensions = max_extensions,
+    _errors = {},
+    _error_sequence = 0,
+    _records = {},
+    _order = {},
+    _services = nil,
+    _running_context = nil,
+    _attached = false,
+    _state = "open",
+    _dispatch_depth = 0,
+  }, Dispatcher)
+end
+
+function Dispatcher:_time()
+  local ok, value = pcall(self._clock)
+  if ok and is_finite(value) then return value end
+  return 0
+end
+
+function Dispatcher:_log(event)
+  if not self._logger then return end
+  pcall(self._logger, event)
+end
+
+function Dispatcher:_append_error(record, stage, message)
+  message = tostring(message)
+  if #message > MAX_ERROR_MESSAGE_LENGTH then
+    message = message:sub(1, MAX_ERROR_MESSAGE_LENGTH - 14) .. "...[truncated]"
+  end
+  self._error_sequence = self._error_sequence + 1
+  local fault = {
+    sequence = self._error_sequence,
+    time = self:_time(),
+    host = self._host_id,
+    extension = record and record.id or nil,
+    stage = stage,
+    message = message,
+  }
+  local errors = self._errors
+  errors[#errors + 1] = fault
+  if #errors > self._max_errors then table.remove(errors, 1) end
+  self:_log({
+    level = "error",
+    event = "voxel_companion.extension_fault",
+    fault = {
+      sequence = fault.sequence,
+      time = fault.time,
+      host = fault.host,
+      extension = fault.extension,
+      stage = fault.stage,
+      message = fault.message,
+    },
+  })
+  return fault
+end
+
+function Dispatcher:_rebuild_order()
+  local order = {}
+  for _, record in pairs(self._records) do
+    if record.state ~= "disposed" then order[#order + 1] = record end
+  end
+  table.sort(order, function(a, b)
+    if a.priority ~= b.priority then return a.priority < b.priority end
+    return a.id < b.id
+  end)
+  self._order = order
+end
+
+function Dispatcher:_invoke(record, stage, handler, source, ...)
+  local context, close = borrowed_view(source, stage .. " context")
+  local extra = pack(...)
+  local function run()
+    return pack(handler(context, unpack(extra, 1, extra.n)))
+  end
+  local ok, result = xpcall(run, function(problem)
+    if debug and debug.traceback then
+      return debug.traceback(tostring(problem), 2)
+    end
+    return tostring(problem)
+  end)
+  local clean, mutation = close()
+  if not ok then return nil, result end
+  if not clean then return nil, mutation end
+  return result
+end
+
+function Dispatcher:_invoke_dispose(record, source, reason, keep_fault_state)
+  if record.dispose_called then return true end
+  record.dispose_called = true
+  record.active = false
+  local handler = record.lifecycle.dispose
+  if handler then
+    local result, err = self:_invoke(record, record.id .. ".dispose", handler, source, reason)
+    if not result then
+      self:_append_error(record, "dispose", err)
+      if not keep_fault_state then record.state = "disposed" end
+      return nil, err
+    end
+    for i = 1, result.n do
+      if result[i] ~= nil then
+        local message = "lifecycle.dispose must not return a value"
+        self:_append_error(record, "dispose", message)
+        if not keep_fault_state then record.state = "disposed" end
+        return nil, message
+      end
+    end
+  end
+  if not keep_fault_state then record.state = "disposed" end
+  return true
+end
+
+function Dispatcher:_fault(record, stage, message, source)
+  if record.faulted or record.state == "disposed" then return record.fault end
+  record.active = false
+  record.faulted = true
+  record.state = "faulted"
+  record.fault = self:_append_error(record, stage, message)
+  self:_invoke_dispose(record, source or {}, "fault", true)
+  return record.fault
+end
+
+function Dispatcher:_handler_records(selector)
+  local out = {}
+  for _, record in ipairs(self._order) do
+    if selector(record) then out[#out + 1] = record end
+  end
+  return out
+end
+
+function Dispatcher:_enter(operation)
+  if self._state ~= "running" then
+    return nil, ("cannot %s while dispatcher state is %s"):format(operation, self._state)
+  end
+  if self._dispatch_depth > 0 then
+    return nil, "reentrant dispatch is not allowed"
+  end
+  self._dispatch_depth = self._dispatch_depth + 1
+  return true
+end
+
+function Dispatcher:_leave()
+  self._dispatch_depth = math.max(0, self._dispatch_depth - 1)
+end
+
+function Dispatcher:capabilities()
+  return sorted_keys(self._capabilities)
+end
+
+-- Return the public wire descriptor used at `mod.exports.voxel_companion`.
+-- The returned tables are fresh copies. The register closure is intentionally
+-- a plain function because Gen1recomp consumers call exports without `self`.
+function Dispatcher:provider()
+  local dispatcher = self
+  local capabilities = {}
+  for capability in pairs(self._capabilities) do capabilities[capability] = 1 end
+  return {
+    api = API.VERSION,
+    host = {
+      id = self._host_id,
+      version = self._host_version,
+    },
+    capabilities = capabilities,
+    register = function(spec, running_context)
+      return dispatcher:register(spec, running_context or dispatcher._running_context)
+    end,
+  }
+end
+
+Dispatcher.export = Dispatcher.provider
+
+function Dispatcher:attach(services)
+  if self._state == "disposed" or self._state == "disposing" then
+    return nil, "cannot attach services to a disposed dispatcher"
+  end
+  if self._dispatch_depth > 0 then return nil, "cannot attach during dispatch" end
+  if self._attached then
+    if self._services == services then return true end
+    return nil, "services are already attached"
+  end
+  if type(services) ~= "table" then return nil, "services must be a table" end
+
+  for _, record in ipairs(self._order) do
+    local ok, err = validate_required_facades(
+      services,
+      record.requirements,
+      "services"
+    )
+    if not ok then return nil, ("extension %s: %s"):format(record.id, err) end
+  end
+
+  self._services = services
+  self._attached = true
+  local report = new_report("lifecycle", "attach")
+  self._dispatch_depth = self._dispatch_depth + 1
+  for _, record in ipairs(copy_array(self._order)) do
+    if not record.faulted and record.state ~= "disposed" then
+      local handler = record.lifecycle.attach
+      report.called = report.called + (handler and 1 or 0)
+      if handler then
+        local result, err = self:_invoke(record, record.id .. ".attach", handler, services)
+        if not result then
+          self:_fault(record, "attach", err, services)
+          report.failed = report.failed + 1
+        else
+          local invalid = false
+          for i = 1, result.n do
+            if result[i] ~= nil then invalid = true break end
+          end
+          if invalid then
+            self:_fault(record, "attach", "lifecycle.attach must not return a value", services)
+            report.failed = report.failed + 1
+          else
+            record.attached = true
+            report.succeeded = report.succeeded + 1
+            report.contributors[#report.contributors + 1] = record.id
+          end
+        end
+      else
+        record.attached = true
+      end
+    end
+  end
+  self._dispatch_depth = self._dispatch_depth - 1
+  return report
+end
+
+function Dispatcher:register(spec, running_context)
+  if self._state == "disposed" or self._state == "disposing" then
+    return nil, "cannot register on a disposed dispatcher"
+  end
+  if self._dispatch_depth > 0 then return nil, "cannot register during dispatch" end
+
+  local record, err = normalize_spec(spec, self._capabilities)
+  if not record then return nil, err end
+
+  local existing = self._records[record.id]
+  if existing then
+    if existing.source == spec and existing.state ~= "disposed" then
+      return existing.handle
+    end
+    return nil, ("extension id %q is already registered"):format(record.id)
+  end
+
+  local extension_count = 0
+  for _ in pairs(self._records) do extension_count = extension_count + 1 end
+  if extension_count >= self._max_extensions then
+    return nil, ("dispatcher reached its %d extension limit"):format(self._max_extensions)
+  end
+
+  if self._attached then
+    local ok
+    ok, err = validate_required_facades(self._services, record.requirements, "services")
+    if not ok then return nil, err end
+  end
+  if self._state == "running" and type(running_context) ~= "table" then
+    return nil, "running_context is required for registration after start"
+  end
+
+  local handle = setmetatable({ _dispatcher = self, _record = record }, Handle)
+  record.handle = handle
+  self._records[record.id] = record
+  self:_rebuild_order()
+
+  if self._attached then
+    local handler = record.lifecycle.attach
+    if handler then
+      self._dispatch_depth = self._dispatch_depth + 1
+      local result
+      result, err = self:_invoke(record, record.id .. ".attach", handler, self._services)
+      self._dispatch_depth = self._dispatch_depth - 1
+      if not result then
+        self:_fault(record, "attach", err, self._services)
+      else
+        for i = 1, result.n do
+          if result[i] ~= nil then
+            self:_fault(record, "attach", "lifecycle.attach must not return a value", self._services)
+            break
+          end
+        end
+        if not record.faulted then record.attached = true end
+      end
+    else
+      record.attached = true
+    end
+  end
+
+  if self._state == "running" and not record.faulted then
+    local handler = record.lifecycle.start
+    if handler then
+      self._dispatch_depth = self._dispatch_depth + 1
+      local result
+      result, err = self:_invoke(record, record.id .. ".start", handler, running_context)
+      self._dispatch_depth = self._dispatch_depth - 1
+      if not result then
+        self:_fault(record, "start", err, running_context)
+      else
+        for i = 1, result.n do
+          if result[i] ~= nil then
+            self:_fault(record, "start", "lifecycle.start must not return a value", running_context)
+            break
+          end
+        end
+      end
+    end
+    if not record.faulted then
+      record.started = true
+      record.active = true
+      record.state = "active"
+    end
+  end
+  return handle
+end
+
+function Dispatcher:start(context)
+  if self._state == "running" then return true end
+  if self._state ~= "open" then
+    return nil, ("cannot start while dispatcher state is %s"):format(self._state)
+  end
+  if not self._attached then return nil, "attach services before start" end
+  if type(context) ~= "table" then return nil, "start context must be a table" end
+  if self._dispatch_depth > 0 then return nil, "cannot start during dispatch" end
+
+  self._state = "starting"
+  self._running_context = context
+  self._dispatch_depth = self._dispatch_depth + 1
+  local report = new_report("lifecycle", "start")
+  for _, record in ipairs(copy_array(self._order)) do
+    if record.state ~= "disposed" and not record.faulted then
+      local handler = record.lifecycle.start
+      report.called = report.called + (handler and 1 or 0)
+      if handler then
+        local result, err = self:_invoke(record, record.id .. ".start", handler, context)
+        if not result then
+          self:_fault(record, "start", err, context)
+          report.failed = report.failed + 1
+        else
+          local invalid = false
+          for i = 1, result.n do
+            if result[i] ~= nil then invalid = true break end
+          end
+          if invalid then
+            self:_fault(record, "start", "lifecycle.start must not return a value", context)
+            report.failed = report.failed + 1
+          else
+            record.started = true
+            record.active = true
+            record.state = "active"
+            report.succeeded = report.succeeded + 1
+            report.contributors[#report.contributors + 1] = record.id
+          end
+        end
+      else
+        record.started = true
+        record.active = true
+        record.state = "active"
+      end
+    end
+  end
+  self._dispatch_depth = self._dispatch_depth - 1
+  self._state = "running"
+  return report
+end
+
+function Dispatcher:dispatch(phase, context)
+  if not PHASE_SET[phase] then return nil, "unknown phase " .. tostring(phase) end
+  if type(context) ~= "table" then return nil, "phase context must be a table" end
+  local ok, err = self:_enter("dispatch " .. phase)
+  if not ok then return nil, err end
+
+  local records = self:_handler_records(function(record)
+    return record.phases[phase] ~= nil
+  end)
+  if #records > 0 and RENDER_PHASE_SET[phase] then
+    ok, err = validate_render_context(context, phase .. " context")
+    if not ok then self:_leave(); return nil, err end
+  end
+
+  local report = new_report("phase", phase)
+  for _, record in ipairs(records) do
+    if not record.active then
+      report.skipped = report.skipped + 1
+    else
+      report.called = report.called + 1
+      local result
+      result, err = self:_invoke(record, record.id .. "." .. phase, record.phases[phase], context)
+      if not result then
+        self:_fault(record, phase, err, context)
+        report.failed = report.failed + 1
+      else
+        local invalid = false
+        for i = 1, result.n do
+          if result[i] ~= nil then invalid = true break end
+        end
+        if invalid then
+          self:_fault(record, phase, "phase handlers must not return a value", context)
+          report.failed = report.failed + 1
+        else
+          report.succeeded = report.succeeded + 1
+          report.contributors[#report.contributors + 1] = record.id
+        end
+      end
+    end
+  end
+  self:_leave()
+  return report
+end
+
+Dispatcher.dispatch_phase = Dispatcher.dispatch
+
+function Dispatcher:update(frame)
+  return self:dispatch("update", frame)
+end
+
+function Dispatcher:world_changed(snapshot)
+  return self:dispatch("map_changed", snapshot)
+end
+
+Dispatcher.worldChanged = Dispatcher.world_changed
+
+function Dispatcher:render(phase, context)
+  if not RENDER_PHASE_SET[phase] then
+    return nil, "unknown render phase " .. tostring(phase)
+  end
+  return self:dispatch(phase, context)
+end
+
+function Dispatcher:dispatch_camera(context)
+  if type(context) ~= "table" then return nil, "camera context must be a table" end
+  local ok, err = self:_enter("dispatch camera")
+  if not ok then return nil, err end
+  local records = self:_handler_records(function(record) return record.camera ~= nil end)
+
+  local aggregate = {
+    positionDelta = { x = 0, y = 0, z = 0 },
+    rotationDelta = { yaw = 0, pitch = 0, roll = 0 },
+    fovDelta = 0,
+  }
+  local report = new_report("result", "camera")
+  for _, record in ipairs(records) do
+    if not record.active then
+      report.skipped = report.skipped + 1
+    else
+      report.called = report.called + 1
+      local packed
+      packed, err = self:_invoke(record, record.id .. ".camera", record.camera, context)
+      if not packed then
+        self:_fault(record, "camera", err, context)
+        report.failed = report.failed + 1
+      elseif packed.n > 1 then
+        self:_fault(record, "camera", "camera handler must return zero or one value", context)
+        report.failed = report.failed + 1
+      else
+        local contribution
+        contribution, err = validate_camera_result(packed[1])
+        if not contribution then
+          self:_fault(record, "camera.result", err, context)
+          report.failed = report.failed + 1
+        else
+          aggregate.positionDelta.x = aggregate.positionDelta.x + contribution.positionDelta.x
+          aggregate.positionDelta.y = aggregate.positionDelta.y + contribution.positionDelta.y
+          aggregate.positionDelta.z = aggregate.positionDelta.z + contribution.positionDelta.z
+          aggregate.rotationDelta.yaw = aggregate.rotationDelta.yaw + contribution.rotationDelta.yaw
+          aggregate.rotationDelta.pitch = aggregate.rotationDelta.pitch + contribution.rotationDelta.pitch
+          aggregate.rotationDelta.roll = aggregate.rotationDelta.roll + contribution.rotationDelta.roll
+          aggregate.fovDelta = aggregate.fovDelta + contribution.fovDelta
+          report.succeeded = report.succeeded + 1
+          report.contributors[#report.contributors + 1] = record.id
+        end
+      end
+    end
+  end
+  self:_leave()
+  return aggregate, report
+end
+
+Dispatcher.modify_camera = Dispatcher.dispatch_camera
+Dispatcher.modifyCamera = Dispatcher.dispatch_camera
+
+function Dispatcher:dispatch_terrain(context)
+  if type(context) ~= "table" then return nil, "terrain context must be a table" end
+  local ok, err = self:_enter("dispatch terrain")
+  if not ok then return nil, err end
+  local records = self:_handler_records(function(record) return record.terrain ~= nil end)
+
+  local aggregate = {
+    cacheKey = nil,
+    suppressCells = {},
+    transforms = {},
+    instances = {},
+    tags = {},
+    invalidate = false,
+  }
+  local suppression_owners, transform_owners = {}, {}
+  local cache_parts = {}
+  local cacheable, has_patch_data = true, false
+  local report = new_report("result", "terrain")
+
+  for _, record in ipairs(records) do
+    if not record.active then
+      report.skipped = report.skipped + 1
+    else
+      report.called = report.called + 1
+      local packed
+      packed, err = self:_invoke(record, record.id .. ".terrain", record.terrain, context)
+      if not packed then
+        self:_fault(record, "terrain", err, context)
+        report.failed = report.failed + 1
+      elseif packed.n > 1 then
+        self:_fault(record, "terrain", "terrain handler must return zero or one value", context)
+        report.failed = report.failed + 1
+      else
+        local contribution
+        contribution, err = validate_terrain_result(packed[1])
+        if contribution then
+          for key in pairs(contribution.suppressionKeys) do
+            if suppression_owners[key] then
+              err = ("suppression key %q is already owned by %s")
+                :format(key, suppression_owners[key])
+              break
+            end
+          end
+        end
+        if contribution and not err then
+          for key in pairs(contribution.transformKeys) do
+            if transform_owners[key] then
+              err = ("transform key %q is already owned by %s")
+                :format(key, transform_owners[key])
+              break
+            end
+          end
+        end
+        if contribution and not err then
+          local merged_items = #aggregate.suppressCells
+            + #aggregate.transforms
+            + #aggregate.instances
+            + #contribution.suppressCells
+            + #contribution.transforms
+            + #contribution.instances
+          if merged_items > MAX_MERGED_PATCH_ITEMS then
+            err = ("merged terrain patch exceeds its %d item limit")
+              :format(MAX_MERGED_PATCH_ITEMS)
+          end
+        end
+
+        if not contribution or err then
+          self:_fault(record, "terrain.result", err or "invalid terrain result", context)
+          report.failed = report.failed + 1
+        else
+          for key in pairs(contribution.suppressionKeys) do
+            suppression_owners[key] = record.id
+          end
+          for key in pairs(contribution.transformKeys) do
+            transform_owners[key] = record.id
+          end
+          for _, item in ipairs(contribution.suppressCells) do
+            aggregate.suppressCells[#aggregate.suppressCells + 1] = item
+          end
+          for _, item in ipairs(contribution.transforms) do
+            aggregate.transforms[#aggregate.transforms + 1] = item
+          end
+          for _, item in ipairs(contribution.instances) do
+            aggregate.instances[#aggregate.instances + 1] = item
+          end
+          for key, value in pairs(contribution.tags) do
+            aggregate.tags[key] = value
+          end
+          aggregate.invalidate = aggregate.invalidate or contribution.invalidate
+
+          if contribution.cacheKey then
+            cache_parts[#cache_parts + 1] = cache_segment(record.id)
+              .. cache_segment(contribution.cacheKey)
+          elseif contribution.hasPatchData or contribution.invalidate then
+            cacheable = false
+          end
+          has_patch_data = has_patch_data or contribution.hasPatchData
+          report.succeeded = report.succeeded + 1
+          report.contributors[#report.contributors + 1] = record.id
+        end
+      end
+    end
+  end
+
+  if cacheable and #cache_parts > 0 and (has_patch_data or aggregate.invalidate) then
+    aggregate.cacheKey = table.concat(cache_parts, "|")
+  end
+  self:_leave()
+  return aggregate, report
+end
+
+Dispatcher.terrain_patch = Dispatcher.dispatch_terrain
+Dispatcher.terrainPatch = Dispatcher.dispatch_terrain
+
+function Dispatcher:invalidate(context, reason)
+  if type(context) ~= "table" then return nil, "invalidate context must be a table" end
+  local ok, err = self:_enter("invalidate")
+  if not ok then return nil, err end
+  local report = new_report("lifecycle", "invalidate")
+  for _, record in ipairs(copy_array(self._order)) do
+    local handler = record.lifecycle.invalidate
+    if handler then
+      if not record.active then
+        report.skipped = report.skipped + 1
+      else
+        report.called = report.called + 1
+        local result
+        result, err = self:_invoke(record, record.id .. ".invalidate", handler, context, reason)
+        if not result then
+          self:_fault(record, "invalidate", err, context)
+          report.failed = report.failed + 1
+        else
+          local invalid = false
+          for i = 1, result.n do
+            if result[i] ~= nil then invalid = true break end
+          end
+          if invalid then
+            self:_fault(record, "invalidate", "lifecycle.invalidate must not return a value", context)
+            report.failed = report.failed + 1
+          else
+            report.succeeded = report.succeeded + 1
+            report.contributors[#report.contributors + 1] = record.id
+          end
+        end
+      end
+    end
+  end
+  self:_leave()
+  return report
+end
+
+function Dispatcher:dispose(context, reason)
+  if self._state == "disposed" then return true end
+  if self._dispatch_depth > 0 then return nil, "cannot dispose during dispatch" end
+  if type(context) ~= "table" then return nil, "dispose context must be a table" end
+
+  self._state = "disposing"
+  self._dispatch_depth = self._dispatch_depth + 1
+  local report = new_report("lifecycle", "dispose")
+  for i = #self._order, 1, -1 do
+    local record = self._order[i]
+    if record.state ~= "disposed" then
+      local had_handler = record.lifecycle.dispose ~= nil and not record.dispose_called
+      if had_handler then report.called = report.called + 1 end
+      local ok = self:_invoke_dispose(record, context, reason or "host-dispose", false)
+      if had_handler then
+        if ok then
+          report.succeeded = report.succeeded + 1
+          report.contributors[#report.contributors + 1] = record.id
+        else
+          report.failed = report.failed + 1
+        end
+      end
+      record.state = "disposed"
+      record.active = false
+    end
+  end
+  self._dispatch_depth = self._dispatch_depth - 1
+  self._services = nil
+  self._running_context = nil
+  self._records = {}
+  self._order = {}
+  self._state = "disposed"
+  return report
+end
+
+function Dispatcher:errors()
+  local out = {}
+  for i, fault in ipairs(self._errors) do
+    out[i] = {
+      sequence = fault.sequence,
+      time = fault.time,
+      host = fault.host,
+      extension = fault.extension,
+      stage = fault.stage,
+      message = fault.message,
+    }
+  end
+  return out
+end
+
+function Dispatcher:status()
+  local extensions = {}
+  for _, record in ipairs(self._order) do
+    extensions[#extensions + 1] = {
+      id = record.id,
+      name = record.name,
+      version = record.version,
+      priority = record.priority,
+      requires = copy_array(record.requirement_list),
+      state = record.state,
+      active = record.active,
+      faulted = record.faulted,
+    }
+  end
+  return {
+    api = API.VERSION,
+    host = self._host_id,
+    state = self._state,
+    attached = self._attached,
+    capabilities = self:capabilities(),
+    extensions = extensions,
+    errorCount = #self._errors,
+  }
+end
+
+function Handle:id()
+  return self._record.id
+end
+
+function Handle:is_active()
+  return self._record.active == true
+end
+
+function Handle:status()
+  local record = self._record
+  return {
+    id = record.id,
+    state = record.state,
+    active = record.active,
+    faulted = record.faulted,
+    fault = record.fault and {
+      sequence = record.fault.sequence,
+      stage = record.fault.stage,
+      message = record.fault.message,
+    } or nil,
+  }
+end
+
+function Handle:invalidate(context, reason)
+  local dispatcher, record = self._dispatcher, self._record
+  if record.state == "disposed" then return true end
+  if not record.active then return nil, "extension is not active" end
+  if dispatcher._dispatch_depth > 0 then return nil, "cannot invalidate during dispatch" end
+  if type(context) ~= "table" then
+    reason = context
+    context = {}
+  end
+  if type(context) ~= "table" then return nil, "invalidate context must be a table" end
+  local handler = record.lifecycle.invalidate
+  if not handler then return true end
+
+  dispatcher._dispatch_depth = dispatcher._dispatch_depth + 1
+  local result, err = dispatcher:_invoke(
+    record,
+    record.id .. ".invalidate",
+    handler,
+    context,
+    reason
+  )
+  dispatcher._dispatch_depth = dispatcher._dispatch_depth - 1
+  if not result then
+    dispatcher:_fault(record, "invalidate", err, context)
+    return nil, err
+  end
+  for i = 1, result.n do
+    if result[i] ~= nil then
+      err = "lifecycle.invalidate must not return a value"
+      dispatcher:_fault(record, "invalidate", err, context)
+      return nil, err
+    end
+  end
+  return true
+end
+
+function Handle:dispose(context, reason)
+  local dispatcher, record = self._dispatcher, self._record
+  if record.state == "disposed" then return true end
+  if dispatcher._dispatch_depth > 0 then return nil, "cannot dispose handle during dispatch" end
+  context = context or {}
+  if type(context) ~= "table" then return nil, "dispose context must be a table" end
+
+  dispatcher._dispatch_depth = dispatcher._dispatch_depth + 1
+  local ok, err = dispatcher:_invoke_dispose(
+    record,
+    context,
+    reason or "handle-dispose",
+    false
+  )
+  dispatcher._dispatch_depth = dispatcher._dispatch_depth - 1
+  record.state = "disposed"
+  record.active = false
+  dispatcher._records[record.id] = nil
+  dispatcher:_rebuild_order()
+  return ok, err
+end
+
+return API

--- a/lib/VoxelCompanionAPI.lua
+++ b/lib/VoxelCompanionAPI.lua
@@ -313,6 +313,44 @@ local function pack(...)
   return { n = select("#", ...), ... }
 end
 
+local function safe_error_text(problem)
+  local kind = type(problem)
+  local message
+  if kind == "string" then
+    message = problem
+  elseif kind == "number" or kind == "boolean" then
+    message = tostring(problem)
+  else
+    message = "error value of type " .. kind
+  end
+  if #message > MAX_ERROR_MESSAGE_LENGTH then
+    message = message:sub(1, MAX_ERROR_MESSAGE_LENGTH - 14) .. "...[truncated]"
+  end
+  return message
+end
+
+local function traceback_error(problem)
+  local message = safe_error_text(problem)
+  if debug and debug.traceback then return debug.traceback(message, 2) end
+  return message
+end
+
+local function safe_key_label(key)
+  local kind = type(key)
+  if kind == "string" then
+    local value = key
+    if #value > 128 then value = value:sub(1, 128) .. "...[truncated]" end
+    return value
+  end
+  if kind == "number" then return tostring(key) end
+  if kind == "boolean" then return key and "true" or "false" end
+  return "<" .. kind .. " key>"
+end
+
+local function safe_key_path(key)
+  return "[" .. safe_key_label(key) .. "]"
+end
+
 local function copy_array(values)
   local out = {}
   for i = 1, #values do out[i] = values[i] end
@@ -329,7 +367,7 @@ end
 local function validate_known_keys(value, allowed, path)
   for key in pairs(value) do
     if not allowed[key] then
-      return nil, ("%s has unknown field %q"):format(path, tostring(key))
+      return nil, ("%s has unknown field %s"):format(path, safe_key_label(key))
     end
   end
   return true
@@ -422,7 +460,7 @@ local function clone_declarative(value, path, state, depth)
 
     local cloned, err = clone_declarative(
       item,
-      path .. "[" .. tostring(key) .. "]",
+      path .. safe_key_path(key),
       state,
       depth + 1
     )
@@ -520,11 +558,11 @@ local function validate_no_resource_locator(value, path, active)
   for key, item in pairs(value) do
     if locator_field(key) then
       active[value] = nil
-      return nil, path .. " contains forbidden resource locator field " .. tostring(key)
+      return nil, path .. " contains forbidden resource locator field " .. safe_key_label(key)
     end
     local ok, err = validate_no_resource_locator(
       item,
-      path .. "[" .. tostring(key) .. "]",
+      path .. safe_key_path(key),
       active
     )
     if not ok then active[value] = nil; return nil, err end
@@ -589,7 +627,7 @@ local function validate_schema_table(value, schemas, path, state)
   end
   local schema = schemas[primitive]
   if not schema then
-    return nil, path .. ".primitive is not in the API v1 baseline: " .. tostring(primitive)
+    return nil, path .. ".primitive is not in the API v1 baseline: " .. primitive
   end
   local allowed = {}
   for key in pairs(schema.fields) do allowed[key] = true end
@@ -691,10 +729,11 @@ local function validate_draw_common(command, expected_kind)
   end
   local kind = command.kind
   if not DRAW_KIND_SET[kind] then
-    return nil, "draw command.kind is not in the API v1 baseline: " .. tostring(kind)
+    return nil, "draw command.kind is not in the API v1 baseline: " .. safe_key_label(kind)
   end
   if expected_kind ~= nil and expected_kind ~= kind then
-    return nil, ("draw.%s received a %s command"):format(tostring(expected_kind), tostring(kind))
+    return nil, ("draw.%s received a %s command")
+      :format(safe_key_label(expected_kind), safe_key_label(kind))
   end
   local allowed = kind == "mesh" and MESH_COMMAND_KEYS
     or (kind == "instances" and INSTANCES_COMMAND_KEYS or BILLBOARDS_COMMAND_KEYS)
@@ -879,8 +918,8 @@ local function borrowed_view(source, label)
       rawset(proxy, key, nil)
     end
     if dirty_key ~= nil then
-      return nil, ("%s was changed with rawset at field %q")
-        :format(label, tostring(dirty_key))
+      return nil, ("%s was changed with rawset at field %s")
+        :format(label, safe_key_label(dirty_key))
     end
     return true
   end
@@ -1036,10 +1075,12 @@ local function normalize_spec(spec, host_capabilities)
   end
   if spec.attach then lifecycle.attach = spec.attach end
   if spec.invalidate then
-    lifecycle.invalidate = function(_, reason) return spec.invalidate(reason) end
+    local invalidate = spec.invalidate
+    lifecycle.invalidate = function(_, reason) return invalidate(reason) end
   end
   if spec.dispose then
-    lifecycle.dispose = function() return spec.dispose() end
+    local dispose = spec.dispose
+    lifecycle.dispose = function() return dispose() end
   end
 
   local phases = {}
@@ -1242,12 +1283,45 @@ local function validate_camera_result(value)
   }
 end
 
+local function merge_camera_result(aggregate, contribution)
+  local merged = {
+    positionDelta = {
+      x = aggregate.positionDelta.x + contribution.positionDelta.x,
+      y = aggregate.positionDelta.y + contribution.positionDelta.y,
+      z = aggregate.positionDelta.z + contribution.positionDelta.z,
+    },
+    rotationDelta = {
+      yaw = aggregate.rotationDelta.yaw + contribution.rotationDelta.yaw,
+      pitch = aggregate.rotationDelta.pitch + contribution.rotationDelta.pitch,
+      roll = aggregate.rotationDelta.roll + contribution.rotationDelta.roll,
+    },
+    fovDelta = aggregate.fovDelta + contribution.fovDelta,
+  }
+  for _, value in ipairs({
+    merged.positionDelta.x,
+    merged.positionDelta.y,
+    merged.positionDelta.z,
+    merged.rotationDelta.yaw,
+    merged.rotationDelta.pitch,
+    merged.rotationDelta.roll,
+    merged.fovDelta,
+  }) do
+    if not is_finite(value) then
+      return nil, "camera contribution would make the aggregate non-finite"
+    end
+  end
+  return merged
+end
+
 local function patch_entry_key(entry, path, allow_string)
   if allow_string and type(entry) == "string" and entry ~= "" then
     return entry
   end
   if type(entry) ~= "table" then
     return nil, path .. " must be a table with a non-empty key"
+  end
+  if getmetatable(entry) ~= nil then
+    return nil, path .. " must be a plain table with a non-empty key"
   end
   if type(entry.key) ~= "string" or entry.key == "" then
     return nil, path .. ".key must be a non-empty string"
@@ -1484,10 +1558,7 @@ function Dispatcher:_log(event)
 end
 
 function Dispatcher:_append_error(record, stage, message)
-  message = tostring(message)
-  if #message > MAX_ERROR_MESSAGE_LENGTH then
-    message = message:sub(1, MAX_ERROR_MESSAGE_LENGTH - 14) .. "...[truncated]"
-  end
+  message = safe_error_text(message)
   self._error_sequence = self._error_sequence + 1
   local fault = {
     sequence = self._error_sequence,
@@ -1533,12 +1604,7 @@ function Dispatcher:_invoke(record, stage, handler, source, ...)
   local function run()
     return pack(handler(context, unpack(extra, 1, extra.n)))
   end
-  local ok, result = xpcall(run, function(problem)
-    if debug and debug.traceback then
-      return debug.traceback(tostring(problem), 2)
-    end
-    return tostring(problem)
-  end)
+  local ok, result = xpcall(run, traceback_error)
   local clean, mutation = close()
   if not ok then return nil, result end
   if not clean then return nil, mutation end
@@ -1601,6 +1667,19 @@ end
 
 function Dispatcher:_leave()
   self._dispatch_depth = math.max(0, self._dispatch_depth - 1)
+end
+
+function Dispatcher:_run_dispatch(operation, callback)
+  local entered, err = self:_enter(operation)
+  if not entered then return nil, err end
+
+  local result
+  local ok, problem = xpcall(function()
+    result = pack(callback())
+  end, traceback_error)
+  self:_leave()
+  if not ok then return nil, problem end
+  return unpack(result, 1, result.n)
 end
 
 function Dispatcher:capabilities()
@@ -1829,47 +1908,49 @@ function Dispatcher:start(context)
 end
 
 function Dispatcher:dispatch(phase, context)
-  if not PHASE_SET[phase] then return nil, "unknown phase " .. tostring(phase) end
+  if not PHASE_SET[phase] then return nil, "unknown phase " .. safe_key_label(phase) end
   if type(context) ~= "table" then return nil, "phase context must be a table" end
-  local ok, err = self:_enter("dispatch " .. phase)
-  if not ok then return nil, err end
+  return self:_run_dispatch("dispatch " .. phase, function()
+    local records = self:_handler_records(function(record)
+      return record.phases[phase] ~= nil
+    end)
+    if #records > 0 and RENDER_PHASE_SET[phase] then
+      local valid, validation_error = validate_render_context(context, phase .. " context")
+      if not valid then return nil, validation_error end
+    end
 
-  local records = self:_handler_records(function(record)
-    return record.phases[phase] ~= nil
-  end)
-  if #records > 0 and RENDER_PHASE_SET[phase] then
-    ok, err = validate_render_context(context, phase .. " context")
-    if not ok then self:_leave(); return nil, err end
-  end
-
-  local report = new_report("phase", phase)
-  for _, record in ipairs(records) do
-    if not record.active then
-      report.skipped = report.skipped + 1
-    else
-      report.called = report.called + 1
-      local result
-      result, err = self:_invoke(record, record.id .. "." .. phase, record.phases[phase], context)
-      if not result then
-        self:_fault(record, phase, err, context)
-        report.failed = report.failed + 1
+    local report = new_report("phase", phase)
+    for _, record in ipairs(records) do
+      if not record.active then
+        report.skipped = report.skipped + 1
       else
-        local invalid = false
-        for i = 1, result.n do
-          if result[i] ~= nil then invalid = true break end
-        end
-        if invalid then
-          self:_fault(record, phase, "phase handlers must not return a value", context)
+        report.called = report.called + 1
+        local result, err = self:_invoke(
+          record,
+          record.id .. "." .. phase,
+          record.phases[phase],
+          context
+        )
+        if not result then
+          self:_fault(record, phase, err, context)
           report.failed = report.failed + 1
         else
-          report.succeeded = report.succeeded + 1
-          report.contributors[#report.contributors + 1] = record.id
+          local invalid = false
+          for i = 1, result.n do
+            if result[i] ~= nil then invalid = true break end
+          end
+          if invalid then
+            self:_fault(record, phase, "phase handlers must not return a value", context)
+            report.failed = report.failed + 1
+          else
+            report.succeeded = report.succeeded + 1
+            report.contributors[#report.contributors + 1] = record.id
+          end
         end
       end
     end
-  end
-  self:_leave()
-  return report
+    return report
+  end)
 end
 
 Dispatcher.dispatch_phase = Dispatcher.dispatch
@@ -1886,58 +1967,59 @@ Dispatcher.worldChanged = Dispatcher.world_changed
 
 function Dispatcher:render(phase, context)
   if not RENDER_PHASE_SET[phase] then
-    return nil, "unknown render phase " .. tostring(phase)
+    return nil, "unknown render phase " .. safe_key_label(phase)
   end
   return self:dispatch(phase, context)
 end
 
 function Dispatcher:dispatch_camera(context)
   if type(context) ~= "table" then return nil, "camera context must be a table" end
-  local ok, err = self:_enter("dispatch camera")
-  if not ok then return nil, err end
-  local records = self:_handler_records(function(record) return record.camera ~= nil end)
-
-  local aggregate = {
-    positionDelta = { x = 0, y = 0, z = 0 },
-    rotationDelta = { yaw = 0, pitch = 0, roll = 0 },
-    fovDelta = 0,
-  }
-  local report = new_report("result", "camera")
-  for _, record in ipairs(records) do
-    if not record.active then
-      report.skipped = report.skipped + 1
-    else
-      report.called = report.called + 1
-      local packed
-      packed, err = self:_invoke(record, record.id .. ".camera", record.camera, context)
-      if not packed then
-        self:_fault(record, "camera", err, context)
-        report.failed = report.failed + 1
-      elseif packed.n > 1 then
-        self:_fault(record, "camera", "camera handler must return zero or one value", context)
-        report.failed = report.failed + 1
+  return self:_run_dispatch("dispatch camera", function()
+    local records = self:_handler_records(function(record) return record.camera ~= nil end)
+    local aggregate = {
+      positionDelta = { x = 0, y = 0, z = 0 },
+      rotationDelta = { yaw = 0, pitch = 0, roll = 0 },
+      fovDelta = 0,
+    }
+    local report = new_report("result", "camera")
+    for _, record in ipairs(records) do
+      if not record.active then
+        report.skipped = report.skipped + 1
       else
-        local contribution
-        contribution, err = validate_camera_result(packed[1])
-        if not contribution then
-          self:_fault(record, "camera.result", err, context)
+        report.called = report.called + 1
+        local packed, err = self:_invoke(
+          record,
+          record.id .. ".camera",
+          record.camera,
+          context
+        )
+        if not packed then
+          self:_fault(record, "camera", err, context)
+          report.failed = report.failed + 1
+        elseif packed.n > 1 then
+          self:_fault(record, "camera", "camera handler must return zero or one value", context)
           report.failed = report.failed + 1
         else
-          aggregate.positionDelta.x = aggregate.positionDelta.x + contribution.positionDelta.x
-          aggregate.positionDelta.y = aggregate.positionDelta.y + contribution.positionDelta.y
-          aggregate.positionDelta.z = aggregate.positionDelta.z + contribution.positionDelta.z
-          aggregate.rotationDelta.yaw = aggregate.rotationDelta.yaw + contribution.rotationDelta.yaw
-          aggregate.rotationDelta.pitch = aggregate.rotationDelta.pitch + contribution.rotationDelta.pitch
-          aggregate.rotationDelta.roll = aggregate.rotationDelta.roll + contribution.rotationDelta.roll
-          aggregate.fovDelta = aggregate.fovDelta + contribution.fovDelta
-          report.succeeded = report.succeeded + 1
-          report.contributors[#report.contributors + 1] = record.id
+          local contribution
+          contribution, err = validate_camera_result(packed[1])
+          if contribution then
+            local merged
+            merged, err = merge_camera_result(aggregate, contribution)
+            contribution = merged
+          end
+          if not contribution then
+            self:_fault(record, "camera.result", err, context)
+            report.failed = report.failed + 1
+          else
+            aggregate = contribution
+            report.succeeded = report.succeeded + 1
+            report.contributors[#report.contributors + 1] = record.id
+          end
         end
       end
     end
-  end
-  self:_leave()
-  return aggregate, report
+    return aggregate, report
+  end)
 end
 
 Dispatcher.modify_camera = Dispatcher.dispatch_camera
@@ -1945,113 +2027,112 @@ Dispatcher.modifyCamera = Dispatcher.dispatch_camera
 
 function Dispatcher:dispatch_terrain(context)
   if type(context) ~= "table" then return nil, "terrain context must be a table" end
-  local ok, err = self:_enter("dispatch terrain")
-  if not ok then return nil, err end
-  local records = self:_handler_records(function(record) return record.terrain ~= nil end)
+  return self:_run_dispatch("dispatch terrain", function()
+    local records = self:_handler_records(function(record) return record.terrain ~= nil end)
+    local aggregate = {
+      cacheKey = nil,
+      suppressCells = {},
+      transforms = {},
+      instances = {},
+      tags = {},
+      invalidate = false,
+    }
+    local suppression_owners, transform_owners = {}, {}
+    local cache_parts = {}
+    local cacheable, has_patch_data = true, false
+    local report = new_report("result", "terrain")
+    local err
 
-  local aggregate = {
-    cacheKey = nil,
-    suppressCells = {},
-    transforms = {},
-    instances = {},
-    tags = {},
-    invalidate = false,
-  }
-  local suppression_owners, transform_owners = {}, {}
-  local cache_parts = {}
-  local cacheable, has_patch_data = true, false
-  local report = new_report("result", "terrain")
-
-  for _, record in ipairs(records) do
-    if not record.active then
-      report.skipped = report.skipped + 1
-    else
-      report.called = report.called + 1
-      local packed
-      packed, err = self:_invoke(record, record.id .. ".terrain", record.terrain, context)
-      if not packed then
-        self:_fault(record, "terrain", err, context)
-        report.failed = report.failed + 1
-      elseif packed.n > 1 then
-        self:_fault(record, "terrain", "terrain handler must return zero or one value", context)
-        report.failed = report.failed + 1
+    for _, record in ipairs(records) do
+      if not record.active then
+        report.skipped = report.skipped + 1
       else
-        local contribution
-        contribution, err = validate_terrain_result(packed[1])
-        if contribution then
-          for key in pairs(contribution.suppressionKeys) do
-            if suppression_owners[key] then
-              err = ("suppression key %q is already owned by %s")
-                :format(key, suppression_owners[key])
-              break
-            end
-          end
-        end
-        if contribution and not err then
-          for key in pairs(contribution.transformKeys) do
-            if transform_owners[key] then
-              err = ("transform key %q is already owned by %s")
-                :format(key, transform_owners[key])
-              break
-            end
-          end
-        end
-        if contribution and not err then
-          local merged_items = #aggregate.suppressCells
-            + #aggregate.transforms
-            + #aggregate.instances
-            + #contribution.suppressCells
-            + #contribution.transforms
-            + #contribution.instances
-          if merged_items > MAX_MERGED_PATCH_ITEMS then
-            err = ("merged terrain patch exceeds its %d item limit")
-              :format(MAX_MERGED_PATCH_ITEMS)
-          end
-        end
-
-        if not contribution or err then
-          self:_fault(record, "terrain.result", err or "invalid terrain result", context)
+        report.called = report.called + 1
+        local packed
+        packed, err = self:_invoke(record, record.id .. ".terrain", record.terrain, context)
+        if not packed then
+          self:_fault(record, "terrain", err, context)
+          report.failed = report.failed + 1
+        elseif packed.n > 1 then
+          self:_fault(record, "terrain", "terrain handler must return zero or one value", context)
           report.failed = report.failed + 1
         else
-          for key in pairs(contribution.suppressionKeys) do
-            suppression_owners[key] = record.id
+          local contribution
+          contribution, err = validate_terrain_result(packed[1])
+          if contribution then
+            for key in pairs(contribution.suppressionKeys) do
+              if suppression_owners[key] then
+                err = ("suppression key %q is already owned by %s")
+                  :format(key, suppression_owners[key])
+                break
+              end
+            end
           end
-          for key in pairs(contribution.transformKeys) do
-            transform_owners[key] = record.id
+          if contribution and not err then
+            for key in pairs(contribution.transformKeys) do
+              if transform_owners[key] then
+                err = ("transform key %q is already owned by %s")
+                  :format(key, transform_owners[key])
+                break
+              end
+            end
           end
-          for _, item in ipairs(contribution.suppressCells) do
-            aggregate.suppressCells[#aggregate.suppressCells + 1] = item
+          if contribution and not err then
+            local merged_items = #aggregate.suppressCells
+              + #aggregate.transforms
+              + #aggregate.instances
+              + #contribution.suppressCells
+              + #contribution.transforms
+              + #contribution.instances
+            if merged_items > MAX_MERGED_PATCH_ITEMS then
+              err = ("merged terrain patch exceeds its %d item limit")
+                :format(MAX_MERGED_PATCH_ITEMS)
+            end
           end
-          for _, item in ipairs(contribution.transforms) do
-            aggregate.transforms[#aggregate.transforms + 1] = item
-          end
-          for _, item in ipairs(contribution.instances) do
-            aggregate.instances[#aggregate.instances + 1] = item
-          end
-          for key, value in pairs(contribution.tags) do
-            aggregate.tags[key] = value
-          end
-          aggregate.invalidate = aggregate.invalidate or contribution.invalidate
 
-          if contribution.cacheKey then
-            cache_parts[#cache_parts + 1] = cache_segment(record.id)
-              .. cache_segment(contribution.cacheKey)
-          elseif contribution.hasPatchData or contribution.invalidate then
-            cacheable = false
+          if not contribution or err then
+            self:_fault(record, "terrain.result", err or "invalid terrain result", context)
+            report.failed = report.failed + 1
+          else
+            for key in pairs(contribution.suppressionKeys) do
+              suppression_owners[key] = record.id
+            end
+            for key in pairs(contribution.transformKeys) do
+              transform_owners[key] = record.id
+            end
+            for _, item in ipairs(contribution.suppressCells) do
+              aggregate.suppressCells[#aggregate.suppressCells + 1] = item
+            end
+            for _, item in ipairs(contribution.transforms) do
+              aggregate.transforms[#aggregate.transforms + 1] = item
+            end
+            for _, item in ipairs(contribution.instances) do
+              aggregate.instances[#aggregate.instances + 1] = item
+            end
+            for key, value in pairs(contribution.tags) do
+              aggregate.tags[key] = value
+            end
+            aggregate.invalidate = aggregate.invalidate or contribution.invalidate
+
+            if contribution.cacheKey then
+              cache_parts[#cache_parts + 1] = cache_segment(record.id)
+                .. cache_segment(contribution.cacheKey)
+            elseif contribution.hasPatchData or contribution.invalidate then
+              cacheable = false
+            end
+            has_patch_data = has_patch_data or contribution.hasPatchData
+            report.succeeded = report.succeeded + 1
+            report.contributors[#report.contributors + 1] = record.id
           end
-          has_patch_data = has_patch_data or contribution.hasPatchData
-          report.succeeded = report.succeeded + 1
-          report.contributors[#report.contributors + 1] = record.id
         end
       end
     end
-  end
 
-  if cacheable and #cache_parts > 0 and (has_patch_data or aggregate.invalidate) then
-    aggregate.cacheKey = table.concat(cache_parts, "|")
-  end
-  self:_leave()
-  return aggregate, report
+    if cacheable and #cache_parts > 0 and (has_patch_data or aggregate.invalidate) then
+      aggregate.cacheKey = table.concat(cache_parts, "|")
+    end
+    return aggregate, report
+  end)
 end
 
 Dispatcher.terrain_patch = Dispatcher.dispatch_terrain
@@ -2059,39 +2140,43 @@ Dispatcher.terrainPatch = Dispatcher.dispatch_terrain
 
 function Dispatcher:invalidate(context, reason)
   if type(context) ~= "table" then return nil, "invalidate context must be a table" end
-  local ok, err = self:_enter("invalidate")
-  if not ok then return nil, err end
-  local report = new_report("lifecycle", "invalidate")
-  for _, record in ipairs(copy_array(self._order)) do
-    local handler = record.lifecycle.invalidate
-    if handler then
-      if not record.active then
-        report.skipped = report.skipped + 1
-      else
-        report.called = report.called + 1
-        local result
-        result, err = self:_invoke(record, record.id .. ".invalidate", handler, context, reason)
-        if not result then
-          self:_fault(record, "invalidate", err, context)
-          report.failed = report.failed + 1
+  return self:_run_dispatch("invalidate", function()
+    local report = new_report("lifecycle", "invalidate")
+    for _, record in ipairs(copy_array(self._order)) do
+      local handler = record.lifecycle.invalidate
+      if handler then
+        if not record.active then
+          report.skipped = report.skipped + 1
         else
-          local invalid = false
-          for i = 1, result.n do
-            if result[i] ~= nil then invalid = true break end
-          end
-          if invalid then
-            self:_fault(record, "invalidate", "lifecycle.invalidate must not return a value", context)
+          report.called = report.called + 1
+          local result, err = self:_invoke(
+            record,
+            record.id .. ".invalidate",
+            handler,
+            context,
+            reason
+          )
+          if not result then
+            self:_fault(record, "invalidate", err, context)
             report.failed = report.failed + 1
           else
-            report.succeeded = report.succeeded + 1
-            report.contributors[#report.contributors + 1] = record.id
+            local invalid = false
+            for i = 1, result.n do
+              if result[i] ~= nil then invalid = true break end
+            end
+            if invalid then
+              self:_fault(record, "invalidate", "lifecycle.invalidate must not return a value", context)
+              report.failed = report.failed + 1
+            else
+              report.succeeded = report.succeeded + 1
+              report.contributors[#report.contributors + 1] = record.id
+            end
           end
         end
       end
     end
-  end
-  self:_leave()
-  return report
+    return report
+  end)
 end
 
 function Dispatcher:dispose(context, reason)

--- a/lib/VoxelCompanionAPI.lua
+++ b/lib/VoxelCompanionAPI.lua
@@ -780,6 +780,9 @@ local function validate_draw_mesh(command, state)
   if command.geometry == nil and direct_count == 0 then
     return nil, "mesh command needs geometry or one opaque mesh/resource"
   end
+  if direct_count > 0 and command.texture ~= nil then
+    return nil, "mesh command cannot combine an opaque mesh/resource with a texture"
+  end
   local ok, err
   if direct_count > 0 then
     ok, err = validate_opaque_resource(command.mesh or command.resource, "mesh command resource")

--- a/lib/VoxelCompanionAPI.lua
+++ b/lib/VoxelCompanionAPI.lua
@@ -1638,11 +1638,14 @@ end
 
 function Dispatcher:_fault(record, stage, message, source)
   if record.faulted or record.state == "disposed" then return record.fault end
+  local owns_guard = self._dispatch_depth == 0
+  if owns_guard then self._dispatch_depth = 1 end
   record.active = false
   record.faulted = true
   record.state = "faulted"
   record.fault = self:_append_error(record, stage, message)
   self:_invoke_dispose(record, source or {}, "fault", true)
+  if owns_guard then self:_leave() end
   return record.fault
 end
 
@@ -1813,7 +1816,6 @@ function Dispatcher:register(spec, running_context)
       self._dispatch_depth = self._dispatch_depth + 1
       local result
       result, err = self:_invoke(record, record.id .. ".attach", handler, self._services)
-      self._dispatch_depth = self._dispatch_depth - 1
       if not result then
         self:_fault(record, "attach", err, self._services)
       else
@@ -1825,6 +1827,7 @@ function Dispatcher:register(spec, running_context)
         end
         if not record.faulted then record.attached = true end
       end
+      self:_leave()
     else
       record.attached = true
     end
@@ -1836,7 +1839,6 @@ function Dispatcher:register(spec, running_context)
       self._dispatch_depth = self._dispatch_depth + 1
       local result
       result, err = self:_invoke(record, record.id .. ".start", handler, running_context)
-      self._dispatch_depth = self._dispatch_depth - 1
       if not result then
         self:_fault(record, "start", err, running_context)
       else
@@ -1847,6 +1849,7 @@ function Dispatcher:register(spec, running_context)
           end
         end
       end
+      self:_leave()
     end
     if not record.faulted then
       record.started = true
@@ -2298,18 +2301,20 @@ function Handle:invalidate(context, reason)
     context,
     reason
   )
-  dispatcher._dispatch_depth = dispatcher._dispatch_depth - 1
   if not result then
     dispatcher:_fault(record, "invalidate", err, context)
+    dispatcher:_leave()
     return nil, err
   end
   for i = 1, result.n do
     if result[i] ~= nil then
       err = "lifecycle.invalidate must not return a value"
       dispatcher:_fault(record, "invalidate", err, context)
+      dispatcher:_leave()
       return nil, err
     end
   end
+  dispatcher:_leave()
   return true
 end
 

--- a/lib/VoxelCompanionAPI.lua
+++ b/lib/VoxelCompanionAPI.lua
@@ -17,15 +17,30 @@ API.CAPABILITIES = {
   SHADOW_PASS = "shadow_pass",
   BATTLE_PASS = "battle_pass",
   INTEGRITY_STATUS = "integrity_status",
-  -- Optional facade declarations for adapters that negotiate them separately.
-  MATERIALS = "materials",
-  DRAW = "draw",
 }
--- Short aliases name the attach facades while retaining the wire capability
--- names used by KFP's host client.
+-- Short aliases name capability-backed attach facades. Materials and draw are
+-- normalized render services, not negotiated wire capabilities.
 API.CAPABILITIES.WORLD = API.CAPABILITIES.WORLD_SNAPSHOT
 API.CAPABILITIES.QUALITY = API.CAPABILITIES.QUALITY_TIER
 API.CAPABILITIES.INTEGRITY = API.CAPABILITIES.INTEGRITY_STATUS
+
+API.DRAW_SCHEMA_VERSION = 1
+API.DRAW_KINDS = {
+  MESH = "mesh",
+  INSTANCES = "instances",
+  BILLBOARDS = "billboards",
+}
+
+local STANDARD_CAPABILITY_SET = {
+  render_phases = true,
+  camera_delta = true,
+  terrain_patch = true,
+  world_snapshot = true,
+  quality_tier = true,
+  shadow_pass = true,
+  battle_pass = true,
+  integrity_status = true,
+}
 
 API.PHASES = {
   "update",
@@ -50,8 +65,6 @@ local RENDER_PHASE_SET = {
 
 local SERVICE_CAPABILITIES = {
   world_snapshot = "world",
-  materials = "materials",
-  draw = "draw",
   quality_tier = "quality",
   integrity_status = "integrity",
 }
@@ -113,6 +126,177 @@ local MAX_DATA_DEPTH = 16
 local MAX_DATA_NODES = 32768
 local MAX_DATA_BYTES = 256 * 1024
 local MAX_ERROR_MESSAGE_LENGTH = 4096
+local MAX_DRAW_ITEMS = 8192
+local MAX_DRAW_TEXT_LENGTH = 512
+local MAX_DRAW_CACHE_KEY_LENGTH = 64
+
+API.DRAW_LIMITS = {
+  cacheKeyBytes = MAX_DRAW_CACHE_KEY_LENGTH,
+  items = MAX_DRAW_ITEMS,
+  dataDepth = MAX_DATA_DEPTH,
+  dataNodes = MAX_DATA_NODES,
+  dataBytes = MAX_DATA_BYTES,
+}
+
+local DRAW_KIND_SET = {
+  mesh = true,
+  instances = true,
+  billboards = true,
+}
+
+local MESH_COMMAND_KEYS = {
+  schemaVersion = true,
+  cacheKey = true,
+  kind = true,
+  owner = true,
+  phase = true,
+  sequence = true,
+  sortKey = true,
+  material = true,
+  color = true,
+  texture = true,
+  geometry = true,
+  mesh = true,
+  resource = true,
+  model = true,
+}
+
+local INSTANCES_COMMAND_KEYS = {
+  schemaVersion = true,
+  cacheKey = true,
+  kind = true,
+  owner = true,
+  phase = true,
+  sequence = true,
+  sortKey = true,
+  material = true,
+  color = true,
+  texture = true,
+  key = true,
+  prototype = true,
+  items = true,
+}
+
+local BILLBOARDS_COMMAND_KEYS = {
+  schemaVersion = true,
+  cacheKey = true,
+  kind = true,
+  owner = true,
+  phase = true,
+  sequence = true,
+  sortKey = true,
+  material = true,
+  color = true,
+  texture = true,
+  key = true,
+  items = true,
+  procedural = true,
+  animated = true,
+}
+
+local MESH_GEOMETRY_SCHEMAS = {
+  box = {
+    fields = { primitive = "text", x = "finite", y = "finite", z = "finite",
+      width = "positive", height = "positive", depth = "positive" },
+    required = { width = true, height = true, depth = true },
+  },
+  plane = {
+    fields = { primitive = "text", x = "finite", y = "finite", z = "finite",
+      width = "positive", depth = "positive" },
+    required = { width = true, depth = true },
+  },
+  world_apron = {
+    fields = { primitive = "text", width = "positive", depth = "positive",
+      skirtDepth = "positive", neighbors = "plain" },
+    required = { width = true, depth = true, skirtDepth = true },
+  },
+  panorama = {
+    fields = { primitive = "text", sourceWidth = "positive",
+      targetWidth = "positive", deepSkirt = "boolean", distanceHaze = "boolean" },
+    required = { sourceWidth = true, targetWidth = true },
+    needsTexture = true,
+  },
+  cloud_layer = {
+    fields = { primitive = "text", layer = "positive_integer", parallax = "finite",
+      density = "unit", seed = "finite" },
+    required = { layer = true, parallax = true, density = true, seed = true },
+  },
+  rainbow = {
+    fields = { primitive = "text", seed = "finite" },
+    required = { seed = true },
+  },
+}
+
+local INSTANCE_PROTOTYPE_SCHEMAS = {
+  box = {
+    fields = { primitive = "text", width = "positive", height = "positive",
+      depth = "positive", cutaway = "boolean", role = "token" },
+  },
+  plane = {
+    fields = { primitive = "text", width = "positive", depth = "positive",
+      role = "token", alphaCutoff = "unit" },
+  },
+  door_frame = {
+    fields = { primitive = "text", role = "token", double = "boolean" },
+  },
+  window = { fields = { primitive = "text", role = "token" } },
+  poster = { fields = { primitive = "text", role = "token" }, needsTexture = true },
+  rail = { fields = { primitive = "text", role = "token" } },
+  fixture = { fields = { primitive = "text", role = "token" } },
+  sconce = { fields = { primitive = "text", role = "token" } },
+  grass_clump = {
+    fields = { primitive = "text", width = "positive", wind = "token" },
+  },
+  canopy = {
+    fields = { primitive = "text", width = "positive", cutaway = "boolean" },
+  },
+  vine = { fields = { primitive = "text", animated = "boolean" } },
+  cave_roof = {
+    fields = { primitive = "text", width = "positive", depth = "positive",
+      role = "token" },
+  },
+  mountain = {
+    fields = { primitive = "text", role = "token", shadow = "boolean" },
+  },
+  hood = {
+    fields = { primitive = "text", role = "token", shadow = "boolean" },
+  },
+  umbrella = { fields = { primitive = "text" } },
+}
+
+local INSTANCE_ITEM_KEYS = {
+  x = true,
+  y = true,
+  z = true,
+  cellX = true,
+  cellZ = true,
+  side = true,
+  facing = true,
+  poster = true,
+  seed = true,
+  lift = true,
+  summit = true,
+  kind = true,
+}
+
+local BILLBOARD_ITEM_KEYS = {
+  x = true,
+  y = true,
+  z = true,
+  width = true,
+  height = true,
+  seed = true,
+  extra = true,
+}
+
+local STAR_PROCEDURAL_KEYS = {
+  kind = true,
+  count = true,
+  seed = true,
+  twinkle = true,
+  nebula = true,
+  shootingStars = true,
+}
 
 local function is_finite(value)
   return type(value) == "number"
@@ -257,6 +441,417 @@ local function clone_data(value, path, state)
   return clone_declarative(value, path, state, 0)
 end
 
+local function bounded_text(value, path, maximum)
+  if type(value) ~= "string" or value == "" then
+    return nil, path .. " must be a non-empty string"
+  end
+  if #value > maximum then
+    return nil, ("%s must be at most %d bytes"):format(path, maximum)
+  end
+  if value:find("\0", 1, true) then return nil, path .. " must not contain NUL" end
+  return value
+end
+
+local function looks_like_resource_path(value)
+  if type(value) ~= "string" then return false end
+  local lower = value:lower()
+  if value:find("/", 1, true) or value:find("\\", 1, true)
+      or value:match("^[A-Za-z][A-Za-z0-9+%.%-]*://") then
+    return true
+  end
+  return lower:match("%.png$") ~= nil
+    or lower:match("%.jpe?g$") ~= nil
+    or lower:match("%.webp$") ~= nil
+    or lower:match("%.mp3$") ~= nil
+    or lower:match("%.ogg$") ~= nil
+    or lower:match("%.wav$") ~= nil
+    or lower:match("%.flac$") ~= nil
+    or lower:match("%.glsl$") ~= nil
+    or lower:match("%.obj$") ~= nil
+    or lower:match("%.gltf$") ~= nil
+    or lower:match("%.glb$") ~= nil
+end
+
+local function semantic_token(value, path, maximum)
+  local text, err = bounded_text(value, path, maximum or MAX_DRAW_TEXT_LENGTH)
+  if not text then return nil, err end
+  if looks_like_resource_path(text) then
+    return nil, path .. " must be a semantic identifier, not an asset or path string"
+  end
+  return text
+end
+
+local function validate_draw_cache_key(value)
+  local key, err = bounded_text(
+    value,
+    "draw command.cacheKey",
+    MAX_DRAW_CACHE_KEY_LENGTH
+  )
+  if not key then return nil, err end
+  if not key:match("^[A-Za-z0-9%._:%-]+$") then
+    return nil, "draw command.cacheKey can contain only A-Z, a-z, 0-9, dot, underscore, colon, and hyphen"
+  end
+  return true
+end
+
+local function locator_field(key)
+  if type(key) ~= "string" then return false end
+  local lower = key:lower()
+  return lower:find("asset", 1, true) ~= nil
+    or lower:find("path", 1, true) ~= nil
+    or lower == "file"
+    or lower == "filename"
+    or lower == "uri"
+    or lower == "url"
+end
+
+local function validate_no_resource_locator(value, path, active)
+  local kind = type(value)
+  if kind == "string" then
+    if looks_like_resource_path(value) then
+      return nil, path .. " contains an asset or path string"
+    end
+    return true
+  end
+  if kind ~= "table" then return true end
+  active = active or {}
+  if active[value] then return nil, path .. " contains a cycle" end
+  active[value] = true
+  for key, item in pairs(value) do
+    if locator_field(key) then
+      active[value] = nil
+      return nil, path .. " contains forbidden resource locator field " .. tostring(key)
+    end
+    local ok, err = validate_no_resource_locator(
+      item,
+      path .. "[" .. tostring(key) .. "]",
+      active
+    )
+    if not ok then active[value] = nil; return nil, err end
+  end
+  active[value] = nil
+  return true
+end
+
+local function validate_plain_wire_data(value, path, state)
+  local copy, err = clone_data(value, path, state)
+  if err then return nil, err end
+  local ok
+  ok, err = validate_no_resource_locator(copy, path)
+  if not ok then return nil, err end
+  return true
+end
+
+local function validate_opaque_resource(value, path)
+  if value == nil then return true end
+  if type(value) == "string" then
+    return nil, path .. " must be an opaque extension-owned resource, not an asset/path string"
+  end
+  local kind = type(value)
+  if kind ~= "table" and kind ~= "userdata" and kind ~= "cdata" then
+    return nil, path .. " must be an opaque extension-owned resource"
+  end
+  return true
+end
+
+local function validate_schema_field(value, rule, path, state)
+  if rule == "finite" then
+    if not is_finite(value) then return nil, path .. " must be finite" end
+  elseif rule == "positive" then
+    if not is_finite(value) or value <= 0 then return nil, path .. " must be positive" end
+  elseif rule == "positive_integer" then
+    if not is_integer(value) or value < 1 then return nil, path .. " must be a positive integer" end
+  elseif rule == "unit" then
+    if not is_finite(value) or value < 0 or value > 1 then
+      return nil, path .. " must be from 0 through 1"
+    end
+  elseif rule == "boolean" then
+    if type(value) ~= "boolean" then return nil, path .. " must be a Boolean" end
+  elseif rule == "text" then
+    return bounded_text(value, path, MAX_DRAW_TEXT_LENGTH)
+  elseif rule == "token" then
+    return semantic_token(value, path, MAX_DRAW_TEXT_LENGTH)
+  elseif rule == "plain" then
+    return validate_plain_wire_data(value, path, state)
+  else
+    return nil, path .. " has an unknown schema rule"
+  end
+  return true
+end
+
+local function validate_schema_table(value, schemas, path, state)
+  if type(value) ~= "table" or getmetatable(value) ~= nil then
+    return nil, path .. " must be a plain table"
+  end
+  local primitive = value.primitive
+  if type(primitive) ~= "string" or primitive == "" then
+    return nil, path .. ".primitive must be a non-empty string"
+  end
+  local schema = schemas[primitive]
+  if not schema then
+    return nil, path .. ".primitive is not in the API v1 baseline: " .. tostring(primitive)
+  end
+  local allowed = {}
+  for key in pairs(schema.fields) do allowed[key] = true end
+  local ok, err = validate_known_keys(value, allowed, path)
+  if not ok then return nil, err end
+  for key in pairs(schema.required or {}) do
+    if value[key] == nil then return nil, path .. "." .. key .. " is required" end
+  end
+  for key, rule in pairs(schema.fields) do
+    if key ~= "primitive" and value[key] ~= nil then
+      ok, err = validate_schema_field(value[key], rule, path .. "." .. key, state)
+      if not ok then return nil, err end
+    end
+  end
+  return schema
+end
+
+local function validate_color(value, path)
+  if value == nil then return true end
+  local count, err = validate_dense_array(value, path, 4)
+  if not count then return nil, err end
+  if count ~= 3 and count ~= 4 then return nil, path .. " must have 3 or 4 values" end
+  for index = 1, count do
+    local channel = value[index]
+    if not is_finite(channel) or channel < 0 or channel > 1 then
+      return nil, ("%s[%d] must be from 0 through 1"):format(path, index)
+    end
+  end
+  return true
+end
+
+local function validate_instance_item(item, path, state)
+  if type(item) ~= "table" or getmetatable(item) ~= nil then
+    return nil, path .. " must be a plain table"
+  end
+  local ok, err = validate_known_keys(item, INSTANCE_ITEM_KEYS, path)
+  if not ok then return nil, err end
+  for _, key in ipairs({ "x", "y", "z" }) do
+    if not is_finite(item[key]) then return nil, path .. "." .. key .. " must be finite" end
+  end
+  for _, key in ipairs({ "cellX", "cellZ" }) do
+    if item[key] ~= nil and not is_integer(item[key]) then
+      return nil, path .. "." .. key .. " must be an integer"
+    end
+  end
+  for _, key in ipairs({ "seed", "lift" }) do
+    if item[key] ~= nil and not is_finite(item[key]) then
+      return nil, path .. "." .. key .. " must be finite"
+    end
+  end
+  for _, key in ipairs({ "side", "facing", "kind" }) do
+    if item[key] ~= nil then
+      ok, err = semantic_token(item[key], path .. "." .. key, MAX_DRAW_TEXT_LENGTH)
+      if not ok then return nil, err end
+    end
+  end
+  if item.poster ~= nil then
+    local kind = type(item.poster)
+    if kind == "string" then
+      ok, err = semantic_token(item.poster, path .. ".poster", MAX_DRAW_TEXT_LENGTH)
+      if not ok then return nil, err end
+    elseif kind ~= "number" or not is_finite(item.poster) then
+      return nil, path .. ".poster must be a finite number or semantic identifier"
+    end
+  end
+  if item.summit ~= nil and type(item.summit) ~= "boolean" then
+    return nil, path .. ".summit must be a Boolean"
+  end
+  return true
+end
+
+local function validate_billboard_item(item, path, state)
+  if type(item) ~= "table" or getmetatable(item) ~= nil then
+    return nil, path .. " must be a plain table"
+  end
+  local ok, err = validate_known_keys(item, BILLBOARD_ITEM_KEYS, path)
+  if not ok then return nil, err end
+  for _, key in ipairs({ "x", "y", "z" }) do
+    if not is_finite(item[key]) then return nil, path .. "." .. key .. " must be finite" end
+  end
+  for _, key in ipairs({ "width", "height" }) do
+    if item[key] ~= nil and (not is_finite(item[key]) or item[key] <= 0) then
+      return nil, path .. "." .. key .. " must be positive"
+    end
+  end
+  if item.seed ~= nil and not is_finite(item.seed) then
+    return nil, path .. ".seed must be finite"
+  end
+  if item.extra ~= nil then
+    ok, err = validate_plain_wire_data(item.extra, path .. ".extra", state)
+    if not ok then return nil, err end
+  end
+  return true
+end
+
+local function validate_draw_common(command, expected_kind)
+  if type(command) ~= "table" or getmetatable(command) ~= nil then
+    return nil, "draw command must be a plain table"
+  end
+  local kind = command.kind
+  if not DRAW_KIND_SET[kind] then
+    return nil, "draw command.kind is not in the API v1 baseline: " .. tostring(kind)
+  end
+  if expected_kind ~= nil and expected_kind ~= kind then
+    return nil, ("draw.%s received a %s command"):format(tostring(expected_kind), tostring(kind))
+  end
+  local allowed = kind == "mesh" and MESH_COMMAND_KEYS
+    or (kind == "instances" and INSTANCES_COMMAND_KEYS or BILLBOARDS_COMMAND_KEYS)
+  local ok, err = validate_known_keys(command, allowed, "draw command")
+  if not ok then return nil, err end
+  if command.schemaVersion ~= API.DRAW_SCHEMA_VERSION then
+    return nil, ("draw command.schemaVersion must be %d"):format(API.DRAW_SCHEMA_VERSION)
+  end
+  ok, err = semantic_token(command.owner, "draw command.owner", MAX_ID_LENGTH)
+  if not ok then return nil, err end
+  if not RENDER_PHASE_SET[command.phase] then
+    return nil, "draw command.phase must be a render phase"
+  end
+  if not is_integer(command.sequence) or command.sequence < 1 then
+    return nil, "draw command.sequence must be a positive integer"
+  end
+  ok, err = validate_draw_cache_key(command.cacheKey)
+  if not ok then return nil, err end
+  ok, err = semantic_token(command.sortKey, "draw command.sortKey", MAX_DRAW_TEXT_LENGTH)
+  if not ok then return nil, err end
+  ok, err = semantic_token(command.material, "draw command.material", MAX_DRAW_TEXT_LENGTH)
+  if not ok then return nil, err end
+  ok, err = validate_color(command.color, "draw command.color")
+  if not ok then return nil, err end
+  ok, err = validate_opaque_resource(command.texture, "draw command.texture")
+  if not ok then return nil, err end
+  if command.key ~= nil then
+    ok, err = semantic_token(command.key, "draw command.key", MAX_DRAW_TEXT_LENGTH)
+    if not ok then return nil, err end
+  end
+  if command.animated ~= nil and type(command.animated) ~= "boolean" then
+    return nil, "draw command.animated must be a Boolean"
+  end
+  return true
+end
+
+local function validate_draw_mesh(command, state)
+  local direct_count = (command.mesh ~= nil and 1 or 0) + (command.resource ~= nil and 1 or 0)
+  if direct_count > 1 then return nil, "mesh command cannot contain both mesh and resource" end
+  if command.geometry ~= nil and direct_count > 0 then
+    return nil, "mesh command cannot combine declarative geometry with an opaque mesh/resource"
+  end
+  if command.geometry == nil and direct_count == 0 then
+    return nil, "mesh command needs geometry or one opaque mesh/resource"
+  end
+  local ok, err
+  if direct_count > 0 then
+    ok, err = validate_opaque_resource(command.mesh or command.resource, "mesh command resource")
+    if not ok then return nil, err end
+  else
+    local schema
+    schema, err = validate_schema_table(command.geometry, MESH_GEOMETRY_SCHEMAS,
+      "mesh command.geometry", state)
+    if not schema then return nil, err end
+    if schema.needsTexture and command.texture == nil then
+      return nil, "mesh command.texture is required for panorama geometry"
+    end
+  end
+  ok, err = validate_opaque_resource(command.model, "mesh command.model")
+  if not ok then return nil, err end
+  return true
+end
+
+local function validate_draw_instances(command, state)
+  local schema, err = validate_schema_table(
+    command.prototype,
+    INSTANCE_PROTOTYPE_SCHEMAS,
+    "instances command.prototype",
+    state
+  )
+  if not schema then return nil, err end
+  if schema.needsTexture and command.texture == nil then
+    return nil, "instances command.texture is required for poster geometry"
+  end
+  local count
+  count, err = validate_dense_array(command.items, "instances command.items", MAX_DRAW_ITEMS)
+  if not count then return nil, err end
+  if count < 1 then return nil, "instances command.items must not be empty" end
+  for index = 1, count do
+    local ok
+    ok, err = validate_instance_item(
+      command.items[index],
+      ("instances command.items[%d]"):format(index),
+      state
+    )
+    if not ok then return nil, err end
+  end
+  return true
+end
+
+local function validate_draw_billboards(command, state)
+  local has_items = command.items ~= nil
+  local has_procedural = command.procedural ~= nil
+  if has_items == has_procedural then
+    return nil, "billboards command needs exactly one of items or procedural"
+  end
+  local err
+  if has_items then
+    local count
+    count, err = validate_dense_array(command.items, "billboards command.items", MAX_DRAW_ITEMS)
+    if not count then return nil, err end
+    if count < 1 then return nil, "billboards command.items must not be empty" end
+    for index = 1, count do
+      local ok
+      ok, err = validate_billboard_item(
+        command.items[index],
+        ("billboards command.items[%d]"):format(index),
+        state
+      )
+      if not ok then return nil, err end
+    end
+    return true
+  end
+
+  local procedural = command.procedural
+  if type(procedural) ~= "table" or getmetatable(procedural) ~= nil then
+    return nil, "billboards command.procedural must be a plain table"
+  end
+  local ok
+  ok, err = validate_known_keys(procedural, STAR_PROCEDURAL_KEYS,
+    "billboards command.procedural")
+  if not ok then return nil, err end
+  if procedural.kind ~= "stars" then
+    return nil, "billboards command.procedural.kind must be stars"
+  end
+  if not is_integer(procedural.count) or procedural.count < 1
+      or procedural.count > MAX_DRAW_ITEMS then
+    return nil, ("billboards command.procedural.count must be from 1 through %d")
+      :format(MAX_DRAW_ITEMS)
+  end
+  if not is_finite(procedural.seed) then
+    return nil, "billboards command.procedural.seed must be finite"
+  end
+  for _, key in ipairs({ "twinkle", "nebula", "shootingStars" }) do
+    if procedural[key] ~= nil and type(procedural[key]) ~= "boolean" then
+      return nil, "billboards command.procedural." .. key .. " must be a Boolean"
+    end
+  end
+  return true
+end
+
+-- Hosts call this pure validator, or an equivalent implementation, before
+-- executing a draw facade command. It never changes or retains the command.
+function API.validate_draw_command(command, expected_kind)
+  if expected_kind ~= nil and not DRAW_KIND_SET[expected_kind] then
+    return nil, "expected draw kind is not in the API v1 baseline"
+  end
+  local ok, err = validate_draw_common(command, expected_kind)
+  if not ok then return nil, err end
+  local state = { active = {}, nodes = 0, bytes = 0 }
+  if command.kind == "mesh" then return validate_draw_mesh(command, state) end
+  if command.kind == "instances" then return validate_draw_instances(command, state) end
+  return validate_draw_billboards(command, state)
+end
+
+API.validateDrawCommand = API.validate_draw_command
+
 -- LuaJIT 2.1 follows Lua 5.1 table semantics. It does not honor __pairs for
 -- tables, so the lease intentionally protects named top-level fields only.
 -- Nested facades and handles remain borrowed under the documented contract.
@@ -305,7 +900,7 @@ local function validate_draw_facade(draw, path)
   return true
 end
 
-local function validate_required_facades(services, requirements, path)
+local function validate_required_facades(services, requirements, path, uses_render_services)
   for capability in pairs(requirements) do
     local facade_name = SERVICE_CAPABILITIES[capability]
     if facade_name then
@@ -314,11 +909,14 @@ local function validate_required_facades(services, requirements, path)
         return nil, ("%s.%s is required by capability %q")
           :format(path, facade_name, capability)
       end
-      if facade_name == "draw" then
-        local ok, err = validate_draw_facade(facade, path .. ".draw")
-        if not ok then return nil, err end
-      end
     end
+  end
+  if uses_render_services then
+    if type(services.materials) ~= "table" then
+      return nil, path .. ".materials is required by a render handler"
+    end
+    local ok, err = validate_draw_facade(services.draw, path .. ".draw")
+    if not ok then return nil, err end
   end
   return true
 end
@@ -342,6 +940,10 @@ local function normalize_capability_list(value, path)
     local capability = value[i]
     if type(capability) ~= "string" or capability == "" then
       return nil, ("%s[%d] must be a non-empty string"):format(path, i)
+    end
+    if not STANDARD_CAPABILITY_SET[capability] then
+      return nil, ("%s[%d] is not a standard API v1 capability: %q")
+        :format(path, i, capability)
     end
     if set[capability] then
       return nil, ("%s contains duplicate %q"):format(path, capability)
@@ -442,6 +1044,7 @@ local function normalize_spec(spec, host_capabilities)
 
   local phases = {}
   local has_phase = false
+  local uses_render_services = false
   if spec.phases ~= nil then
     if type(spec.phases) ~= "table" then
       return nil, "extension.phases must be a table"
@@ -453,7 +1056,10 @@ local function normalize_spec(spec, host_capabilities)
       if handler ~= nil and type(handler) ~= "function" then
         return nil, ("extension.phases.%s must be a function"):format(phase)
       end
-      if handler ~= nil then has_phase = true end
+      if handler ~= nil then
+        has_phase = true
+        if RENDER_PHASE_SET[phase] then uses_render_services = true end
+      end
       phases[phase] = handler
     end
   end
@@ -476,6 +1082,7 @@ local function normalize_spec(spec, host_capabilities)
       if handler ~= nil then
         phases[phase] = handler
         has_phase = true
+        uses_render_services = true
       end
     end
   end
@@ -579,6 +1186,7 @@ local function normalize_spec(spec, host_capabilities)
     started = false,
     faulted = false,
     dispose_called = false,
+    uses_render_services = uses_render_services,
   }
 end
 
@@ -833,6 +1441,10 @@ function API.new(options)
       if type(capability) ~= "string" or capability == "" then
         error(("options.capabilities[%d] must be a non-empty string"):format(i), 2)
       end
+      if not STANDARD_CAPABILITY_SET[capability] then
+        error(("options.capabilities[%d] is not a standard API v1 capability: %q")
+          :format(i, capability), 2)
+      end
       if capabilities[capability] then
         error(("options.capabilities contains duplicate %q"):format(capability), 2)
       end
@@ -1032,7 +1644,8 @@ function Dispatcher:attach(services)
     local ok, err = validate_required_facades(
       services,
       record.requirements,
-      "services"
+      "services",
+      record.uses_render_services
     )
     if not ok then return nil, ("extension %s: %s"):format(record.id, err) end
   end
@@ -1098,7 +1711,12 @@ function Dispatcher:register(spec, running_context)
 
   if self._attached then
     local ok
-    ok, err = validate_required_facades(self._services, record.requirements, "services")
+    ok, err = validate_required_facades(
+      self._services,
+      record.requirements,
+      "services",
+      record.uses_render_services
+    )
     if not ok then return nil, err end
   end
   if self._state == "running" and type(running_context) ~= "table" then

--- a/lib/VoxelCompanionAPI.lua
+++ b/lib/VoxelCompanionAPI.lua
@@ -220,6 +220,7 @@ local MESH_GEOMETRY_SCHEMAS = {
     fields = { primitive = "text", layer = "positive_integer", parallax = "finite",
       density = "unit", seed = "finite" },
     required = { layer = true, parallax = true, density = true, seed = true },
+    needsTexture = true,
   },
   rainbow = {
     fields = { primitive = "text", seed = "finite" },
@@ -789,7 +790,8 @@ local function validate_draw_mesh(command, state)
       "mesh command.geometry", state)
     if not schema then return nil, err end
     if schema.needsTexture and command.texture == nil then
-      return nil, "mesh command.texture is required for panorama geometry"
+      return nil, "mesh command.texture is required for "
+        .. tostring(command.geometry.primitive) .. " geometry"
     end
   end
   ok, err = validate_opaque_resource(command.model, "mesh command.model")

--- a/lib/VoxelScene.lua
+++ b/lib/VoxelScene.lua
@@ -1070,6 +1070,16 @@ function VoxelScene.render(state, w, h, vw, vh, paletteFor)
   local fpRig, fpCx, fpCy = FirstPerson.frame(me, cx, cy, vw, vh)
   if fpRig then cx, cy = fpCx, fpCy end
 
+  -- The host camera remains authoritative. A companion can return only a
+  -- finite additive delta, which Voxel3D copies and bounds before projection.
+  local companion = V.companion
+  local cameraDelta = nil
+  if companion and type(companion.cameraDelta) == "function" then
+    local ok, value = pcall(companion.cameraDelta, companion, state)
+    if ok then cameraDelta = value end
+  end
+  Voxel3D.setCompanionCameraDelta(cameraDelta)
+
   -- The sun's box, pushed along the first-person look so it covers the
   -- ground THIS camera sees (a no-op at blend zero): the orbit's fit
   -- reaches far north and barely south, which is right for every rung
@@ -1086,7 +1096,15 @@ function VoxelScene.render(state, w, h, vw, vh, paletteFor)
               water, nbWater)
 
   if not Voxel3D.beginScene(w, h, cx, cy, vw, vh, skyFor(state.map)) then
+    Voxel3D.setCompanionCameraDelta(nil)
     return nil
+  end
+
+  -- Extension backgrounds run after the host has opened its isolated 3D
+  -- target and before any host terrain. Adapter and extension failures are
+  -- contained; the base scene continues either way.
+  if companion and type(companion.render) == "function" then
+    pcall(companion.render, companion, "background", state)
   end
 
   -- One material-coloured plane below the whole loaded neighborhood closes
@@ -1105,6 +1123,12 @@ function VoxelScene.render(state, w, h, vw, vh, paletteFor)
   -- stand only on world cells outside the root/connected-map rectangles,
   -- so no billboard can poke through valid terrain or block the player.
   WorldFillProps.draw(state, cx, cy, vw, vh)
+
+  -- The first additive world seam: base terrain and distant host props are
+  -- complete, while actors, water, and translucent work have not drawn.
+  if companion and type(companion.render) == "function" then
+    pcall(companion.render, companion, "opaque_after_terrain", state)
+  end
 
   -- Without a shadow map (headless, or a driver that could not make the
   -- canvas) the old flat decals stand in: ground-only, characters only,
@@ -1237,7 +1261,17 @@ function VoxelScene.render(state, w, h, vw, vh, paletteFor)
     end
   end
 
+  -- The second additive world seam: host actors, water, grass, and flowers
+  -- are complete. The companion may add bounded blended packets before the
+  -- host closes and resolves its scene canvas.
+  if companion and type(companion.render) == "function" then
+    pcall(companion.render, companion, "translucent_after_actors", state)
+  end
+
   local finished = Voxel3D.endScene()
+  -- The delta belongs only to this overworld render. Do not let it reach a
+  -- later battle or another owner of Voxel3D's placed-camera seam.
+  Voxel3D.setCompanionCameraDelta(nil)
   if finished then
     lastCompleteCanvas, lastCompleteW, lastCompleteH = finished, w, h
     lastCompleteMapId = state.map and state.map.id or nil

--- a/main.lua
+++ b/main.lua
@@ -115,13 +115,19 @@ local PoisonFlash = V.require("PoisonFlash")
 local MomHealFlash = V.require("MomHealFlash")
 local TransformCompat = V.require("TransformCompat")
 local VoxelCompanion = V.require("VoxelCompanion")
+local CompanionLifecycle = V.require("CompanionLifecycle")
 
 -- The public provider is created while this mod loads, before consumers resolve
 -- optional dependencies. The dispatcher starts at mods.loaded; a consumer that
 -- registers later in that event joins the running dispatcher automatically.
 local Companion = VoxelCompanion.new({ mod = mod })
 V.companion = Companion
-local companionUpdateFault = false
+
+-- mods.loaded runs before Game.overworld necessarily has a live map. Use the
+-- engine's public per-frame hook to retry after the real overworld update and
+-- to observe later map/revision changes. This must not depend on a render
+-- pipeline being active: KFP can attach while Battle Art's voxel mode is off.
+CompanionLifecycle.install(mod, Companion)
 
 -- `mods.loaded` is the first point at which every content mod has finished
 -- patching the registries and the last point before a save can mutate live map
@@ -256,15 +262,6 @@ mod.content.render_pipelines:register("voxel", {
     -- battles and menus, and a CYCLE evening falls mid-fight exactly as it
     -- would mid-walk
     DayNight.update(dt)
-    -- Companion work is additive and fault-contained. It runs with the mode
-    -- off so a newly selected voxel rung can use an already compiled scene.
-    local companionOk, companionError = pcall(Companion.update, Companion, dt,
-      Game and Game.overworld)
-    if not companionOk and not companionUpdateFault
-        and mod.log and mod.log.error then
-      companionUpdateFault = true
-      mod.log:error("Voxel Companion update failed: %s", tostring(companionError))
-    end
     -- The overworld battle rides this hook rather than owning a pipeline of
     -- its own, because it owns no pass of the FRAME: it draws under a battle
     -- screen the engine composites, which is not a stage the registry has.

--- a/main.lua
+++ b/main.lua
@@ -114,6 +114,14 @@ local FreeMove = V.require("FreeMove")
 local PoisonFlash = V.require("PoisonFlash")
 local MomHealFlash = V.require("MomHealFlash")
 local TransformCompat = V.require("TransformCompat")
+local VoxelCompanion = V.require("VoxelCompanion")
+
+-- The public provider is created while this mod loads, before consumers resolve
+-- optional dependencies. The dispatcher starts at mods.loaded; a consumer that
+-- registers later in that event joins the running dispatcher automatically.
+local Companion = VoxelCompanion.new({ mod = mod })
+V.companion = Companion
+local companionUpdateFault = false
 
 -- `mods.loaded` is the first point at which every content mod has finished
 -- patching the registries and the last point before a save can mutate live map
@@ -125,6 +133,10 @@ mod.events:on("mods.loaded", function(payload)
   -- shiny opponent fronts cannot alternate after those providers advance.
   OverworldBattle.refreshSpriteOwnershipHook()
   StadiumBattleFxProvider.register()
+  local started, err = Companion:start()
+  if not started and mod.log and mod.log.error then
+    mod.log:error("Voxel Companion host did not start: %s", tostring(err))
+  end
 end)
 
 -- Forward declaration: the voxel pipeline's update hook (registered below)
@@ -244,6 +256,15 @@ mod.content.render_pipelines:register("voxel", {
     -- battles and menus, and a CYCLE evening falls mid-fight exactly as it
     -- would mid-walk
     DayNight.update(dt)
+    -- Companion work is additive and fault-contained. It runs with the mode
+    -- off so a newly selected voxel rung can use an already compiled scene.
+    local companionOk, companionError = pcall(Companion.update, Companion, dt,
+      Game and Game.overworld)
+    if not companionOk and not companionUpdateFault
+        and mod.log and mod.log.error then
+      companionUpdateFault = true
+      mod.log:error("Voxel Companion update failed: %s", tostring(companionError))
+    end
     -- The overworld battle rides this hook rather than owning a pipeline of
     -- its own, because it owns no pass of the FRAME: it draws under a battle
     -- screen the engine composites, which is not a stage the registry has.
@@ -351,6 +372,7 @@ mod.content.render_pipelines:register("voxel", {
     AntiAlias.invalidate()
     VoxelLoadingVeil.invalidate()
     ChunkMesher.invalidate()   -- no map id = every cached mesh
+    pcall(Companion.invalidate, Companion, "render_pipeline")
   end,
 })
 
@@ -1062,7 +1084,10 @@ end)
 -- instead of blinking the whole scene down to the flat 2D path
 mod.events:on("world.block_replaced", function(payload)
   local mapId = payload and (payload.mapId or (payload.map and payload.map.id))
-  if mapId then ChunkMesher.refresh(mapId) end
+  if mapId then
+    ChunkMesher.refresh(mapId)
+    Companion:worldChanged("world.block_replaced")
+  end
 end)
 
 -- The event above is the ANNOUNCED edit -- OverworldState:replaceBlock
@@ -1099,6 +1124,7 @@ do
       setBlock(self, bx, by, block)
       if self.id and self:blockAt(bx, by) ~= before then
         ChunkMesher.refresh(self.id)
+        Companion:worldChanged("map.setBlock")
       end
     end
     Map.dramaticShapeBlockHook = true
@@ -1126,6 +1152,7 @@ end
 -- new colours land on the diorama already on screen, in one frame, which is
 -- what a palette toggle should look like from inside voxel mode.
 mod.events:on("map.reloaded", function(payload)
+  Companion:worldChanged("map.reloaded")
   if payload and payload.reason == "colors" then return end
   local mapId = payload and (payload.mapId or (payload.map and payload.map.id))
   if mapId then ChunkMesher.evictRuntime(mapId) end
@@ -1368,6 +1395,7 @@ end)
 mod.exports.version = "1.9.7"
 mod.exports.battlePresentation = BattlePresentation.export()
 mod.exports.battleStage = BattleStage.export(OverworldBattle)
+mod.exports.voxel_companion = Companion.provider
 -- exposed so a companion mod can pin its own tiles' shapes or read the
 -- camera without reaching into this mod's file layout
 mod.exports.lib = V

--- a/tests/companion_lifecycle_test.lua
+++ b/tests/companion_lifecycle_test.lua
@@ -1,0 +1,73 @@
+-- Regression for delayed overworld readiness through the public core hook.
+
+local checks = 0
+
+local function check(value, message)
+  checks = checks + 1
+  if not value then error("FAIL: " .. message, 0) end
+end
+
+local function equal(actual, expected, message)
+  checks = checks + 1
+  if actual ~= expected then
+    error(("FAIL: %s (expected %s, got %s)")
+      :format(message, tostring(expected), tostring(actual)), 0)
+  end
+end
+
+local Lifecycle = assert(loadfile("lib/CompanionLifecycle.lua"))()
+
+local wrappedName, wrapped
+local messages = {}
+local mod = {
+  hooks = {
+    wrap = function(_, name, callback)
+      wrappedName, wrapped = name, callback
+      return function() end
+    end,
+  },
+  log = {
+    error = function(_, format, value)
+      messages[#messages + 1] = tostring(format):format(value)
+    end,
+  },
+}
+
+local calls = {}
+local companion = {
+  updateFromGame = function(_, dt, game)
+    calls[#calls + 1] = { dt = dt, game = game, ready = game.overworld ~= nil }
+  end,
+}
+
+check(type(Lifecycle.install(mod, companion)) == "function",
+  "install returns the public hook removal handle")
+equal(wrappedName, "core.update", "lifecycle binds only to public core.update")
+
+local game = {}
+local order = {}
+local first, second = wrapped(function(actualGame, dt)
+  order[#order + 1] = "engine"
+  equal(actualGame, game, "the engine receives the public game object")
+  equal(dt, 0.016, "the engine receives the original delta")
+  return "engine-result", nil
+end, game, 0.016)
+order[#order + 1] = "returned"
+
+equal(first, "engine-result", "the hook preserves the engine return value")
+equal(second, nil, "the hook preserves trailing nil return values")
+equal(calls[1].game, game, "the adapter receives the same public game object")
+equal(calls[1].ready, false, "startup can run before an overworld exists")
+equal(order[1], "engine", "the engine update runs before companion observation")
+
+game.overworld = { map = { id = "PALLET_TOWN" } }
+wrapped(function() order[#order + 1] = "engine-ready" end, game, 0.016)
+equal(calls[2].ready, true,
+  "a later core update exposes the ready overworld to the adapter")
+
+companion.updateFromGame = function() error("synthetic lifecycle fault", 0) end
+wrapped(function() end, game, 0.016)
+wrapped(function() end, game, 0.016)
+equal(#messages, 1, "a repeated lifecycle fault is logged once")
+
+io.write(('%d checks passed (Voxel Companion core lifecycle)\n'):format(checks))

--- a/tests/fixtures/voxel_companion_draw_v1.lua
+++ b/tests/fixtures/voxel_companion_draw_v1.lua
@@ -1,0 +1,113 @@
+-- Shared ROM-free golden fixture for the Voxel Companion draw schema v1.
+
+local INSTANCE_PRIMITIVES = {
+  "box", "plane", "door_frame", "window", "poster", "rail", "fixture",
+  "sconce", "cave_roof", "grass_clump", "canopy", "vine", "umbrella",
+  "mountain", "hood",
+}
+
+local INSTANCE_PROTOTYPES = {
+  box = { primitive = "box", width = 4, height = 6, depth = 4 },
+  plane = { primitive = "plane", width = 4, depth = 4 },
+  door_frame = { primitive = "door_frame", role = "door" },
+  window = { primitive = "window", role = "window" },
+  poster = { primitive = "poster", role = "poster" },
+  rail = { primitive = "rail", role = "rail" },
+  fixture = { primitive = "fixture", role = "light_fixture" },
+  sconce = { primitive = "sconce", role = "sconce" },
+  cave_roof = { primitive = "cave_roof", width = 4, depth = 4,
+    role = "cave_roof" },
+  grass_clump = { primitive = "grass_clump", width = 4, wind = "BREEZE" },
+  canopy = { primitive = "canopy", width = 4, cutaway = true },
+  vine = { primitive = "vine", animated = true },
+  umbrella = { primitive = "umbrella" },
+  mountain = { primitive = "mountain", role = "mountain", shadow = true },
+  hood = { primitive = "hood", role = "boulder_tree", shadow = true },
+}
+
+local GOLDEN_TEXTURE = { fixture = "callback_borrowed_texture" }
+
+local phases = {
+  background = {},
+  opaque_after_terrain = {},
+  translucent_after_actors = {},
+}
+
+local phaseIds = {
+  background = 1,
+  opaque_after_terrain = 2,
+  translucent_after_actors = 3,
+}
+
+local sequence = 0
+local function add(phase, command)
+  sequence = sequence + 1
+  command.schemaVersion = 1
+  command.cacheKey = table.concat({
+    "kfp1", "0123abcd", "1", tostring(phaseIds[phase]), tostring(sequence),
+    string.format("%016x", sequence),
+  }, ":")
+  command.sequence = sequence
+  command.phase = phase
+  command.owner = "golden"
+  command.sortKey = string.format("%02d:%s", sequence, command.kind)
+  phases[phase][#phases[phase] + 1] = command
+end
+
+add("background", {
+  kind = "mesh",
+  material = "golden:box",
+  geometry = { primitive = "box", x = 4, y = 2, z = 4,
+    width = 4, height = 4, depth = 4 },
+})
+
+add("background", {
+  kind = "mesh",
+  material = "golden:plane",
+  geometry = { primitive = "plane", x = 8, y = 0, z = 8,
+    width = 16, depth = 16 },
+})
+
+add("opaque_after_terrain", {
+  kind = "mesh",
+  material = "golden:apron",
+  geometry = { primitive = "world_apron", width = 32, depth = 32,
+    skirtDepth = 16 },
+})
+
+for index, primitive in ipairs(INSTANCE_PRIMITIVES) do
+  local command = {
+    kind = "instances",
+    material = "golden:" .. primitive,
+    prototype = INSTANCE_PROTOTYPES[primitive],
+    items = { { x = index * 2, y = 3, z = 12 } },
+  }
+  if primitive == "poster" then command.texture = GOLDEN_TEXTURE end
+  add("opaque_after_terrain", command)
+end
+
+add("translucent_after_actors", {
+  kind = "billboards",
+  material = "golden:particles",
+  items = {
+    { x = 6, y = 8, z = 6, width = 2, height = 3 },
+    { x = 10, y = 9, z = 10, width = 2, height = 3 },
+  },
+})
+
+return {
+  schemaVersion = 1,
+  context = {
+    world = {
+      id = "golden",
+      key = "golden",
+      width = 2,
+      height = 2,
+      cellSize = 16,
+      atlasRevision = 0,
+    },
+  },
+  phases = phases,
+  instancePrimitives = INSTANCE_PRIMITIVES,
+  commandCount = sequence,
+}

--- a/tests/fixtures/voxel_companion_draw_v1.lua
+++ b/tests/fixtures/voxel_companion_draw_v1.lua
@@ -79,6 +79,7 @@ add("background", {
 add("background", {
   kind = "mesh",
   material = "golden:clouds",
+  texture = GOLDEN_TEXTURE,
   geometry = { primitive = "cloud_layer", layer = 2, parallax = 0.2,
     density = 0.6, seed = 42 },
 })

--- a/tests/fixtures/voxel_companion_draw_v1.lua
+++ b/tests/fixtures/voxel_companion_draw_v1.lua
@@ -1,4 +1,4 @@
--- Shared ROM-free golden fixture for the Voxel Companion draw schema v1.
+-- Shared ROM-free golden fixture for the complete Voxel Companion draw schema v1.
 
 local INSTANCE_PRIMITIVES = {
   "box", "plane", "door_frame", "window", "poster", "rail", "fixture",
@@ -68,6 +68,27 @@ add("background", {
     width = 16, depth = 16 },
 })
 
+add("background", {
+  kind = "mesh",
+  material = "golden:panorama",
+  texture = GOLDEN_TEXTURE,
+  geometry = { primitive = "panorama", sourceWidth = 4096,
+    targetWidth = 2048, deepSkirt = true, distanceHaze = true },
+})
+
+add("background", {
+  kind = "mesh",
+  material = "golden:clouds",
+  geometry = { primitive = "cloud_layer", layer = 2, parallax = 0.2,
+    density = 0.6, seed = 42 },
+})
+
+add("background", {
+  kind = "mesh",
+  material = "golden:rainbow",
+  geometry = { primitive = "rainbow", seed = 43 },
+})
+
 add("opaque_after_terrain", {
   kind = "mesh",
   material = "golden:apron",
@@ -95,9 +116,23 @@ add("translucent_after_actors", {
   },
 })
 
+add("background", {
+  kind = "billboards",
+  material = "golden:stars",
+  procedural = {
+    kind = "stars",
+    count = 24,
+    seed = 44,
+    twinkle = true,
+    nebula = true,
+    shootingStars = true,
+  },
+})
+
 return {
   schemaVersion = 1,
   context = {
+    phase = "background",
     world = {
       id = "golden",
       key = "golden",

--- a/tests/voxel_companion_api_v1_test.lua
+++ b/tests/voxel_companion_api_v1_test.lua
@@ -288,6 +288,68 @@ local mod = cleanMod()
 local companion = VoxelCompanion.new({ mod = mod })
 local provider = companion.provider
 
+do
+  local delayedMod = cleanMod()
+  local delayed = VoxelCompanion.new({ mod = delayedMod })
+  local delayedWorlds, delayedUpdates = {}, 0
+  local delayedHandle, delayedError = delayed.provider.register({
+    api = 1,
+    id = "test.delayed-world-readiness",
+    requires = { "world_snapshot" },
+    worldChanged = function(snapshot)
+      delayedWorlds[#delayedWorlds + 1] = {
+        id = snapshot.id,
+        revision = snapshot.revision,
+      }
+    end,
+    update = function() delayedUpdates = delayedUpdates + 1 end,
+  })
+  check(delayedHandle, delayedError or "delayed-world extension registers")
+  check(delayed:start(), "delayed-world host starts before the overworld")
+
+  local game = {}
+  check(delayed:updateFromGame(0.016, game),
+    "a missing startup overworld does not fault the dispatcher")
+  equal(#delayedWorlds, 0,
+    "no worldChanged callback is sent before a real map exists")
+  check(delayed.worldPending,
+    "missing startup state keeps one world snapshot pending")
+
+  game.overworld = worldState()
+  check(delayed:updateFromGame(0.016, game),
+    "the public game object supplies a later ready overworld")
+  equal(#delayedWorlds, 1,
+    "the first ready overworld dispatches one normalized snapshot")
+  equal(delayedWorlds[1].id, "PALLET_TOWN",
+    "the delayed snapshot reports the live map identity")
+  check(not delayed.worldPending,
+    "a successful delayed snapshot clears the pending state")
+
+  local firstRevision = delayedWorlds[1].revision
+  game.overworld = worldState()
+  game.overworld.map.id = "VIRIDIAN_CITY"
+  check(delayed:updateFromGame(0.016, game),
+    "a replacement overworld remains observable through the same game object")
+  equal(#delayedWorlds, 2,
+    "a later map identity dispatches one replacement snapshot")
+  equal(delayedWorlds[2].id, "VIRIDIAN_CITY",
+    "the replacement snapshot reports the new live map")
+  check(delayedWorlds[2].revision > firstRevision,
+    "the replacement snapshot advances the adapter revision")
+
+  delayed:worldChanged("synthetic-block-edit")
+  check(delayed:updateFromGame(0.016, game),
+    "an announced map revision is pumped by core lifecycle updates")
+  equal(#delayedWorlds, 3,
+    "an announced revision dispatches one refreshed snapshot")
+  check(delayedWorlds[3].revision > delayedWorlds[2].revision,
+    "the refreshed snapshot carries the newer revision")
+  check(delayedUpdates >= 4,
+    "extension updates continue before and after world readiness")
+  check(delayed:dispose("delayed-world-test"),
+    "delayed-world host disposes cleanly")
+end
+
 local function wireCommand(kind, phase, sequence, fields)
   local command = fields or {}
   command.schemaVersion = 1

--- a/tests/voxel_companion_api_v1_test.lua
+++ b/tests/voxel_companion_api_v1_test.lua
@@ -85,23 +85,13 @@ love = {
   graphics = {},
 }
 
-function love.image.newImageData(width, height)
-  local data = { width = width or 1, height = height or 1, pixels = 0,
-    minAlpha = 1, maxAlpha = 0 }
-  function data:setPixel(_, _, _, _, _, alpha)
-    alpha = alpha == nil and 1 or alpha
-    self.pixels = self.pixels + 1
-    self.minAlpha = math.min(self.minAlpha, alpha)
-    self.maxAlpha = math.max(self.maxAlpha, alpha)
-  end
-  return data
+function love.image.newImageData()
+  return { setPixel = function() end }
 end
 
-function love.graphics.newImage(data)
+function love.graphics.newImage()
   return {
-    sourceData = data,
     setFilter = function() end,
-    setWrap = function() end,
     release = function(self) self.released = true end,
   }
 end
@@ -826,6 +816,11 @@ local invalidBaseline = {
     geometry = { primitive = "cloud_layer", layer = 1, parallax = 0.2,
       density = 2, seed = 1 },
   }),
+  wireCommand("mesh", "background", 251, {
+    cacheKey = "other.extension:cloud-no-texture",
+    geometry = { primitive = "cloud_layer", layer = 1, parallax = 0.2,
+      density = 0.5, seed = 1 },
+  }),
   wireCommand("mesh", "background", 26, {
     cacheKey = "other.extension:rainbow-bad-seed",
     geometry = { primitive = "rainbow", seed = 0 / 0 },
@@ -841,6 +836,10 @@ for _, command in ipairs(invalidBaseline) do
   equal(accepted, false, "invalid complete-baseline command returns exactly false")
   check(type(rejection) == "string" and rejection ~= "",
     "invalid complete-baseline command explains its rejection")
+  if command.cacheKey == "other.extension:cloud-no-texture" then
+    contains(rejection, "texture is required for cloud_layer",
+      "untextured cloud fails closed at the shared validator")
+  end
 end
 equal(fakeVoxel3D.draws, rejectedDraws,
   "invalid complete-baseline commands never reach Voxel3D.draw")
@@ -1057,6 +1056,9 @@ for _, phase in ipairs({
         if primitive == "panorama" then
           calls.panoramaTextureUsed = fakeVoxel3D.drawLog[#fakeVoxel3D.drawLog]
             .texture == command.texture
+        elseif primitive == "cloud_layer" then
+          calls.cloudTextureUsed = fakeVoxel3D.drawLog[#fakeVoxel3D.drawLog]
+            .texture == command.texture
         end
       end
     end
@@ -1095,12 +1097,14 @@ equal(calls.fixtureStarsExpanded, 48,
   "the fixture expands 24 deterministic stars on each pass")
 equal(calls.panoramaTextureUsed, true,
   "panorama uses its callback-borrowed texture")
+equal(calls.cloudTextureUsed, true,
+  "cloud layer uses its callback-borrowed texture")
 equal(calls.fixtureTextureCleared, true,
-  "shared panorama and poster textures are unbound before return")
+  "shared panorama, cloud, and poster textures are unbound before return")
 check(companion.texture ~= fixtureTexture,
   "shared fixture texture is not retained as a host fallback")
 equal(fixtureTexture.releases, 0,
-  "shared panorama and poster texture is not released")
+  "shared panorama, cloud, and poster texture is not released")
 check(#companion.meshes.panorama.vertices <= 128,
   "panorama uses bounded host-owned geometry")
 check(#companion.meshes.cloud_layer.vertices <= 32,
@@ -1127,22 +1131,14 @@ check(cloudScale[2] <= 192 and cloudScale[4] <= 192,
   "cloud decks stay inside the subtle bounded physical span")
 equal(calls.fixtureDraws.cloud_layer.depth, "lequal:false",
   "cloud decks never occlude later world geometry through depth writes")
-check(companion.cloudTexture and companion.cloudTexture ~= companion.texture,
-  "clouds use a dedicated host-owned alpha mask instead of the white fallback")
-equal(companion.cloudTexture.sourceData.width, 32,
-  "cloud alpha mask has a bounded width")
-equal(companion.cloudTexture.sourceData.pixels, 32 * 32,
-  "cloud alpha mask initializes every bounded texel")
-check(companion.cloudTexture.sourceData.minAlpha < 0.5
-    and companion.cloudTexture.sourceData.maxAlpha >= 0.5,
-  "cloud alpha mask cuts away quad corners and retains a cloud body")
 check(calls.fixtureDraws.panorama.color:match(":1$") ~= nil,
   "distance haze does not turn panorama alpha into checker coverage")
 equal(calls.fixtureDraws.panorama.depth, "lequal:false",
   "panorama retains depth testing without occluding later world geometry")
 check(calls.fixtureDraws.cloud_layer.color:match(":1$") ~= nil,
   "cloud material uses binary texture coverage without alpha dithering")
-local hostCloudTexture = companion.cloudTexture
+equal(calls.fixtureDraws.cloud_layer.mesh.texture, nil,
+  "cloud layer unbinds its borrowed texture after each draw")
 
 local panoramaModels = {}
 for index, width in ipairs({ 4096, 1024 }) do
@@ -1299,11 +1295,9 @@ equal(borrowedTexture.releases, 0,
 equal(starTexture.releases, 0,
   "adapter never releases a procedural-star texture during disposal")
 equal(fixtureTexture.releases, 0,
-  "adapter never releases shared panorama/poster texture during disposal")
+  "adapter never releases shared panorama/cloud/poster texture during disposal")
 equal(companion.state, nil, "adapter drops retained world state on dispose")
 equal(companion.startContext, nil, "adapter drops retained activation context on dispose")
-check(hostCloudTexture.released,
-  "adapter releases its host-owned cloud alpha mask during disposal")
 equal(love.update, sentinelUpdate, "adapter does not replace global callbacks")
 
 local legacyMod = cleanMod()

--- a/tests/voxel_companion_api_v1_test.lua
+++ b/tests/voxel_companion_api_v1_test.lua
@@ -21,6 +21,7 @@ end
 
 local API = assert(loadfile("lib/VoxelCompanionAPI.lua"))()
 equal(API.VERSION, 1, "vendored dispatcher reports API v1")
+local DrawFixture = assert(loadfile("tests/fixtures/voxel_companion_draw_v1.lua"))()
 
 local graphicsState = { color = "host", depth = "host", blend = "host" }
 local graphicsStack = {}
@@ -85,6 +86,7 @@ local fakeVoxel3D = {
     fov = math.rad(65),
   },
   draws = 0,
+  drawLog = {},
   glassState = true,
   failNextDraw = false,
 }
@@ -104,6 +106,7 @@ function fakeVoxel3D.newMesh(vertices, indices)
   return {
     vertices = vertices,
     indices = indices,
+    setTexture = function(self, texture) self.texture = texture end,
     release = function(self) self.released = true end,
   }
 end
@@ -112,8 +115,14 @@ function fakeVoxel3D.glass(enabled)
   fakeVoxel3D.glassState = enabled
 end
 
-function fakeVoxel3D.draw()
+function fakeVoxel3D.draw(mesh, texture, model)
   fakeVoxel3D.draws = fakeVoxel3D.draws + 1
+  if texture then mesh:setTexture(texture) end
+  fakeVoxel3D.drawLog[#fakeVoxel3D.drawLog + 1] = {
+    mesh = mesh,
+    texture = texture,
+    model = model,
+  }
   if fakeVoxel3D.failNextDraw then
     fakeVoxel3D.failNextDraw = false
     error("synthetic GPU draw failure", 0)
@@ -228,6 +237,19 @@ local mod = cleanMod()
 local companion = VoxelCompanion.new({ mod = mod })
 local provider = companion.provider
 
+local function wireCommand(kind, phase, sequence, fields)
+  local command = fields or {}
+  command.schemaVersion = 1
+  command.cacheKey = command.cacheKey or ("other.extension:%s:%d"):format(kind, sequence)
+  command.kind = kind
+  command.owner = command.owner or "test.extension"
+  command.phase = phase
+  command.sequence = sequence
+  command.sortKey = command.sortKey or command.cacheKey
+  command.material = command.material or "test:material"
+  return command
+end
+
 equal(provider.api, 1, "provider reports API v1")
 equal(provider.host.id, "BATTLE_ART_VOXEL_FORK", "provider reports stable host id")
 equal(provider.host.version, "1.9.7", "provider preserves upstream version")
@@ -254,6 +276,11 @@ local calls = {
   disposed = 0,
 }
 
+local borrowedTexture = {
+  releases = 0,
+  release = function(self) self.releases = self.releases + 1 end,
+}
+
 local faulty, err = provider.register({
   api = 1,
   id = "test.draw-fault",
@@ -263,10 +290,11 @@ local faulty, err = provider.register({
     background = function(context)
       love.graphics.setColor(0.1, 0.2, 0.3, 0.4)
       fakeVoxel3D.failNextDraw = true
-      context.draw:mesh({
+      local accepted, drawError = context.draw.mesh(wireCommand("mesh", "background", 1, {
         geometry = { primitive = "box", width = 1, height = 1, depth = 1 },
         material = "test:fault",
-      })
+      }), context)
+      if not accepted then error(drawError, 0) end
     end,
   },
   dispose = function() calls.faultyDispose = calls.faultyDispose + 1 end,
@@ -311,16 +339,20 @@ healthy, err = provider.register({
   render = {
     background = function(context)
       calls.healthyRender = calls.healthyRender + 1
-      context.draw:mesh({
+      local accepted, drawError = context.draw.mesh(wireCommand("mesh", "background", 2, {
         geometry = { primitive = "box", x = 8, y = 4, z = 8,
           width = 2, height = 3, depth = 2 },
         material = "test:healthy",
-      })
-      context.draw:mesh({
+        texture = borrowedTexture,
+      }), context)
+      if not accepted then error(drawError, 0) end
+      calls.borrowedMeshCleared = fakeVoxel3D.drawLog[#fakeVoxel3D.drawLog].mesh.texture == nil
+      accepted, drawError = context.draw.mesh(wireCommand("mesh", "background", 3, {
         geometry = { primitive = "world_apron", width = 32, depth = 32,
           skirtDepth = 16 },
         material = "world:apron",
-      })
+      }), context)
+      if not accepted then error(drawError, 0) end
     end,
   },
   invalidate = function(reason)
@@ -330,6 +362,36 @@ healthy, err = provider.register({
   dispose = function() calls.disposed = calls.disposed + 1 end,
 })
 check(healthy, err or "KFP-like extension registers")
+
+local collisionProbe
+collisionProbe, err = provider.register({
+  api = 1,
+  id = "test.no-command-cache",
+  priority = 20,
+  requires = { "render_phases" },
+  render = {
+    background = function(context)
+      local first = wireCommand("mesh", "background", 4, {
+        cacheKey = "other.extension:shared",
+        geometry = { primitive = "box", width = 1, height = 1, depth = 1 },
+      })
+      local second = wireCommand("mesh", "background", 5, {
+        cacheKey = "other.extension:shared",
+        geometry = { primitive = "box", width = 7, height = 1, depth = 1 },
+      })
+      local accepted, drawError = context.draw.mesh(first, context)
+      calls.collisionFirst = accepted
+      if not accepted then error(drawError, 0) end
+      accepted, drawError = context.draw.mesh(first, context)
+      calls.collisionRepeat = accepted
+      if not accepted then error(drawError, 0) end
+      accepted, drawError = context.draw.mesh(second, context)
+      calls.collisionSecond = accepted
+      calls.collisionError = drawError
+    end,
+  },
+})
+check(collisionProbe, err or "no-cache probe extension registers")
 
 local shadow
 shadow, err = provider.register({
@@ -360,6 +422,40 @@ contains(err, "shadow_pass", "nested shadow refusal explains the missing capabil
 
 check(companion:start(), "host dispatcher starts")
 local state = worldState()
+
+local rejectedDraws = fakeVoxel3D.draws
+local rejected = wireCommand("mesh", "background", 20, {
+  geometry = { primitive = "plane", width = 1, depth = 1 },
+})
+rejected.schemaVersion = 0
+local accepted, rejection = companion.draw.mesh(rejected, companion:_context())
+equal(accepted, false, "wrong draw schema returns exactly false")
+contains(rejection, "schemaVersion", "wrong draw schema explains the rejection")
+
+rejected = wireCommand("mesh", "background", 21, {
+  cacheKey = "unsafe key",
+  geometry = { primitive = "plane", width = 1, depth = 1 },
+})
+accepted, rejection = companion.draw.mesh(rejected, companion:_context())
+equal(accepted, false, "unsafe cache key returns exactly false")
+contains(rejection, "safe ASCII", "unsafe cache key explains the rejection")
+
+rejected = wireCommand("mesh", "background", 22, {
+  geometry = { primitive = "plane", width = 1, depth = 1 },
+  texture = "assets/foreign/texture.png",
+})
+accepted, rejection = companion.draw.mesh(rejected, companion:_context())
+equal(accepted, false, "texture path returns exactly false")
+contains(rejection, "path string", "texture path explains the rejection")
+
+rejected = wireCommand("mesh", "background", 23, {
+  geometry = { primitive = "plane", width = 1, depth = 1 },
+})
+accepted, rejection = companion.draw.mesh(rejected, nil)
+equal(accepted, false, "missing callback context returns exactly false")
+contains(rejection, "borrowed render context", "missing context explains the rejection")
+equal(fakeVoxel3D.draws, rejectedDraws, "rejected commands never reach Voxel3D.draw")
+
 local updateReport = companion:update(0.016, state)
 check(updateReport and updateReport.succeeded >= 1, "canonical update dispatch succeeds")
 equal(calls.world, 1, "initial world identity dispatches one snapshot")
@@ -398,17 +494,111 @@ equal(delta.fovDelta, 0.04, "camera FOV delta remains in radians")
 
 local renderReport = companion:render("background", state)
 check(renderReport, "background render dispatch returns a report")
-equal(renderReport.called, 2, "both active render extensions are called")
+equal(renderReport.called, 3, "all active render extensions are called")
 equal(renderReport.failed, 1, "one extension draw fault is contained")
-equal(renderReport.succeeded, 1, "later extension renders after an earlier fault")
+equal(renderReport.succeeded, 2, "later extensions render after an earlier fault")
 equal(calls.faultyDispose, 1, "faulted extension is disposed exactly once")
 equal(calls.healthyRender, 1, "healthy extension rendered")
+equal(fakeVoxel3D.drawLog[2].texture, borrowedTexture,
+  "extension texture is passed directly to Voxel3D.draw")
+equal(calls.borrowedMeshCleared, true,
+  "borrowed texture is unbound before draw.mesh returns")
+check(companion.texture ~= borrowedTexture,
+  "extension texture is not retained as the adapter fallback")
+equal(borrowedTexture.releases, 0, "adapter does not release the borrowed texture")
+equal(fakeVoxel3D.drawLog[4].model[2][2], 1,
+  "first same-key command uses its own declarative width")
+equal(fakeVoxel3D.drawLog[5].model[2][2], 1,
+  "an identical same-key command remains valid")
+equal(calls.collisionFirst, true, "first key and content pair is accepted")
+equal(calls.collisionRepeat, true, "same key and content pair is accepted again")
+equal(calls.collisionSecond, false, "same key with different content fails closed")
+contains(calls.collisionError, "content collision",
+  "same-key content mismatch reports a collision")
+equal(#fakeVoxel3D.drawLog, 5, "colliding declarative content is not drawn")
 equal(fakeVoxel3D.glassState, true, "host shader selector is restored after draw fault")
 equal(pushCount, 1, "graphics state is pushed once for the phase")
 equal(popCount, 1, "graphics state is popped once for the phase")
 equal(graphicsState.color, "host", "graphics color state is restored")
 equal(graphicsState.depth, "host", "graphics depth state is restored")
 equal(graphicsState.blend, "host", "graphics blend state is restored")
+
+local fixturePhaseIds = {
+  background = "1",
+  opaque_after_terrain = "2",
+  translucent_after_actors = "3",
+}
+local fixtureTexture
+local fixtureValidated = 0
+for _, phase in ipairs({
+  "background", "opaque_after_terrain", "translucent_after_actors",
+}) do
+  for _, command in ipairs(DrawFixture.phases[phase]) do
+    local valid, validationError = API.validate_draw_command(command, command.kind)
+    check(valid, validationError or "shared baseline command validates")
+    local scene, generation, phaseId, wireSequence, content = command.cacheKey:match(
+      "^kfp1:([0-9a-f]+):([0-9]+):([1-5]):([0-9]+):([0-9a-f]+)$")
+    check(scene ~= nil, "KFP fixture key uses the exact producer profile")
+    equal(#scene, 8, "KFP fixture scene digest has eight lowercase hex digits")
+    check(generation == "0" or not generation:match("^0"),
+      "KFP fixture generation is canonical unsigned decimal")
+    equal(phaseId, fixturePhaseIds[phase], "KFP fixture key phase matches command phase")
+    equal(wireSequence, tostring(command.sequence),
+      "KFP fixture key sequence matches command sequence")
+    equal(#content, 16, "KFP fixture content digest has sixteen lowercase hex digits")
+    check(#command.cacheKey <= 64, "KFP fixture key stays within the host limit")
+    if command.texture then fixtureTexture = command.texture end
+    fixtureValidated = fixtureValidated + 1
+  end
+end
+equal(fixtureValidated, DrawFixture.commandCount,
+  "shared fixture covers every declared baseline command")
+equal(#DrawFixture.instancePrimitives, 15,
+  "shared fixture covers every common instance primitive")
+check(fixtureTexture, "shared fixture includes an opaque poster texture")
+
+local fixtureRender = {}
+for _, phase in ipairs({
+  "background", "opaque_after_terrain", "translucent_after_actors",
+}) do
+  local phaseName = phase
+  fixtureRender[phaseName] = function(context)
+    for _, command in ipairs(DrawFixture.phases[phaseName]) do
+      local accepted, drawError = context.draw[command.kind](command, context)
+      if accepted ~= true then error(drawError or "fixture draw rejected", 0) end
+      calls.fixtureAccepted = (calls.fixtureAccepted or 0) + 1
+      if command.texture then
+        calls.fixtureTextureCleared = fakeVoxel3D.drawLog[#fakeVoxel3D.drawLog]
+          .mesh.texture == nil
+      end
+    end
+  end
+end
+
+local fixtureHandle
+fixtureHandle, err = provider.register({
+  api = 1,
+  id = "test.shared-draw-fixture",
+  priority = 30,
+  requires = { "render_phases" },
+  render = fixtureRender,
+})
+check(fixtureHandle, err or "shared fixture extension registers")
+local fixtureBackground = companion:render("background", state)
+local fixtureOpaque = companion:render("opaque_after_terrain", state)
+local fixtureTranslucent = companion:render("translucent_after_actors", state)
+check(fixtureBackground and fixtureBackground.failed == 0,
+  "shared background mesh commands render")
+check(fixtureOpaque and fixtureOpaque.failed == 0,
+  "shared world apron and instance commands render")
+check(fixtureTranslucent and fixtureTranslucent.failed == 0,
+  "shared explicit billboard command renders")
+equal(calls.fixtureAccepted, DrawFixture.commandCount,
+  "host accepts every shared baseline fixture command")
+equal(calls.fixtureTextureCleared, true,
+  "shared poster texture is unbound before the draw call returns")
+check(companion.texture ~= fixtureTexture,
+  "shared fixture texture is not retained as a host fallback")
 
 local lateUpdates = 0
 local late
@@ -430,6 +620,8 @@ equal(calls.invalidated, 1, "host invalidation reaches the healthy extension")
 equal(calls.invalidateReason, "test-invalidate", "invalidation reason is canonical")
 companion:dispose("test-dispose")
 equal(calls.disposed, 1, "healthy extension is disposed exactly once")
+equal(borrowedTexture.releases, 0,
+  "adapter never releases a borrowed texture during invalidation or disposal")
 equal(companion.state, nil, "adapter drops retained world state on dispose")
 equal(companion.startContext, nil, "adapter drops retained activation context on dispose")
 equal(love.update, sentinelUpdate, "adapter does not replace global callbacks")

--- a/tests/voxel_companion_api_v1_test.lua
+++ b/tests/voxel_companion_api_v1_test.lua
@@ -1139,31 +1139,46 @@ equal(fixtureTexture.releases, 0,
 check(#companion.meshes.panorama_deep.vertices <= 256,
   "deep panorama uses bounded host-owned band and skirt geometry")
 local cloudMesh = companion.meshes.cloud_layer
-equal(#cloudMesh.vertices, 33,
-  "cloud layer uses one center and one bounded circular perimeter")
-equal(#cloudMesh.indices, 32 * 3,
-  "cloud layer uses one continuous 32-triangle fan")
-for segment = 0, 31 do
-  local base = segment * 3
-  equal(cloudMesh.indices[base + 1], 1,
-    "each cloud triangle shares the center vertex")
-  equal(cloudMesh.indices[base + 2], segment + 2,
-    "each cloud triangle starts at its perimeter vertex")
-  equal(cloudMesh.indices[base + 3], ((segment + 1) % 32) + 2,
-    "the cloud perimeter is continuous and closes without detached facets")
+equal(#cloudMesh.vertices, 2 + 15 * 32,
+  "cloud layer uses one bounded closed-shell vertex set")
+equal(#cloudMesh.indices, 960 * 3,
+  "cloud layer uses a finite closed-shell triangle set")
+local cloudEdges, cloudVertexUses = {}, {}
+local function useCloudEdge(a, b)
+  local low, high = math.min(a, b), math.max(a, b)
+  local key = tostring(low) .. ":" .. tostring(high)
+  local edge = cloudEdges[key] or { count = 0, orientation = 0 }
+  edge.count = edge.count + 1
+  edge.orientation = edge.orientation + (a < b and 1 or -1)
+  cloudEdges[key] = edge
 end
-equal(cloudMesh.vertices[1][1], 0,
-  "cloud fan center has a centered local X position")
-equal(cloudMesh.vertices[1][3], 0,
-  "cloud fan center has a centered local Z position")
-for index = 2, #cloudMesh.vertices do
-  local vertex = cloudMesh.vertices[index]
-  check(math.abs(vertex[1] * vertex[1] + vertex[3] * vertex[3] - 0.25)
-      <= 1e-12,
-    "cloud perimeter stays on the fixed half-unit radius")
+for index = 1, #cloudMesh.indices, 3 do
+  local a, b, c = cloudMesh.indices[index], cloudMesh.indices[index + 1],
+    cloudMesh.indices[index + 2]
+  cloudVertexUses[a], cloudVertexUses[b], cloudVertexUses[c] = true, true, true
+  useCloudEdge(a, b)
+  useCloudEdge(b, c)
+  useCloudEdge(c, a)
+end
+local cloudEdgeCount, badCloudEdge = 0, nil
+for key, edge in pairs(cloudEdges) do
+  cloudEdgeCount = cloudEdgeCount + 1
+  if edge.count ~= 2 or edge.orientation ~= 0 then badCloudEdge = key end
+end
+equal(badCloudEdge, nil,
+  "every cloud-shell edge has two oppositely wound faces and no boundary")
+equal(cloudEdgeCount, #cloudMesh.indices / 2,
+  "closed cloud-shell edges have exactly two triangle uses")
+equal(#cloudMesh.vertices - cloudEdgeCount + #cloudMesh.indices / 3, 2,
+  "cloud shell has the Euler characteristic of one closed sphere")
+for index, vertex in ipairs(cloudMesh.vertices) do
+  check(cloudVertexUses[index], "every cloud-shell vertex belongs to a face")
+  check(math.abs(vertex[1] * vertex[1] + vertex[2] * vertex[2]
+      + vertex[3] * vertex[3] - 0.25) <= 1e-12,
+    "cloud-shell vertices stay on the fixed half-unit sphere")
   check(math.abs(vertex[4] - (vertex[1] + 0.5)) <= 1e-12
       and math.abs(vertex[5] - (vertex[3] + 0.5)) <= 1e-12,
-    "cloud UVs stay continuous with local deck coordinates")
+    "cloud UVs are a continuous projection of shared shell coordinates")
 end
 check(#companion.meshes.rainbow.vertices <= 96,
   "rainbow uses bounded host-owned geometry")
@@ -1194,29 +1209,64 @@ for index, vertex in ipairs(deepVertices) do
       "deep panorama skirt samples only the texture bottom row")
   end
 end
-local cloudTranslation = findTagged(calls.fixtureModels.cloud_layer, "translate")[1]
-local cloudScale = findTagged(calls.fixtureModels.cloud_layer, "scale")[1]
-local cloudRotation = findTagged(calls.fixtureModels.cloud_layer, "rotateY")[1]
-check(cloudTranslation[3] >= 200,
-  "cloud decks stay high above the first-person eye")
-check(cloudScale[2] <= 192 and cloudScale[4] <= 192,
-  "cloud decks stay inside the subtle bounded physical span")
-local minCloudX, maxCloudX = math.huge, -math.huge
-local minCloudZ, maxCloudZ = math.huge, -math.huge
-local cosine, sine = math.cos(cloudRotation[2]), math.sin(cloudRotation[2])
-for _, vertex in ipairs(cloudMesh.vertices) do
-  local x, z = vertex[1] * cloudScale[2], vertex[3] * cloudScale[4]
-  local transformedX = x * cosine - z * sine + cloudTranslation[2]
-  local transformedZ = x * sine + z * cosine + cloudTranslation[4]
-  minCloudX, maxCloudX = math.min(minCloudX, transformedX),
-    math.max(maxCloudX, transformedX)
-  minCloudZ, maxCloudZ = math.min(minCloudZ, transformedZ),
-    math.max(maxCloudZ, transformedZ)
+local function assertCloudEnclosure(model, eye, label)
+  local translation = findTagged(model, "translate")[1]
+  local scale = findTagged(model, "scale")[1]
+  local rotation = findTagged(model, "rotateY")[1]
+  check(scale[2] >= 120 and scale[2] <= 192
+      and scale[4] >= 120 and scale[4] <= 192,
+    label .. " stays inside the bounded horizontal diameter")
+  check(scale[3] >= 544 and scale[3] <= 736,
+    label .. " stays inside the bounded vertical diameter")
+  equal(translation[2], eye[1],
+    label .. " remains centered on the public eye X position")
+  equal(translation[4], eye[3],
+    label .. " remains centered on the public eye Z position")
+  local top = translation[3] + scale[3] * 0.5
+  check(top >= eye[2] + 200,
+    label .. " retains a high overhead deck")
+  local localX = (eye[1] - translation[2]) / scale[2]
+  local localY = (eye[2] - translation[3]) / scale[3]
+  local localZ = (eye[3] - translation[4]) / scale[4]
+  check(localX * localX + localY * localY + localZ * localZ < 0.25,
+    label .. " strictly encloses the public eye")
+
+  local minX, maxX, minZ, maxZ = math.huge, -math.huge,
+    math.huge, -math.huge
+  local cosine, sine = math.cos(rotation[2]), math.sin(rotation[2])
+  for _, vertex in ipairs(cloudMesh.vertices) do
+    local x, z = vertex[1] * scale[2], vertex[3] * scale[4]
+    local transformedX = x * cosine - z * sine + translation[2]
+    local transformedZ = x * sine + z * cosine + translation[4]
+    minX, maxX = math.min(minX, transformedX), math.max(maxX, transformedX)
+    minZ, maxZ = math.min(minZ, transformedZ), math.max(maxZ, transformedZ)
+  end
+  check(maxX - minX <= 192 + 1e-9,
+    label .. " cannot exceed its claimed transformed X span")
+  check(maxZ - minZ <= 192 + 1e-9,
+    label .. " cannot exceed its claimed transformed Z span")
 end
-check(maxCloudX - minCloudX <= 192 + 1e-9,
-  "rotated cloud geometry cannot exceed its claimed X span")
-check(maxCloudZ - minCloudZ <= 192 + 1e-9,
-  "rotated cloud geometry cannot exceed its claimed Z span")
+
+assertCloudEnclosure(calls.fixtureModels.cloud_layer, fakeVoxel3D.eye,
+  "fixture cloud shell")
+for index, geometry in ipairs({
+  { primitive = "cloud_layer", layer = 1, parallax = -2,
+    density = 0, seed = 1 },
+  { primitive = "cloud_layer", layer = 16, parallax = 2,
+    density = 1, seed = 1 },
+}) do
+  local command = wireCommand("mesh", "background", 216 + index, {
+    cacheKey = "test.cloud.enclosure:" .. tostring(index),
+    material = "sky:clouds:enclosure-probe",
+    texture = fixtureTexture,
+    geometry = geometry,
+  })
+  local accepted, enclosureError = companion.draw.mesh(
+    command, companion:_context())
+  check(accepted, enclosureError or "cloud enclosure extreme is accepted")
+  assertCloudEnclosure(fakeVoxel3D.drawLog[#fakeVoxel3D.drawLog].model,
+    fakeVoxel3D.eye, "cloud enclosure extreme " .. tostring(index))
+end
 equal(calls.fixtureDraws.cloud_layer.depth, "lequal:false",
   "cloud decks never occlude later world geometry through depth writes")
 check(calls.fixtureDraws.panorama.color:match(":1$") ~= nil,

--- a/tests/voxel_companion_api_v1_test.lua
+++ b/tests/voxel_companion_api_v1_test.lua
@@ -156,8 +156,17 @@ function fakeVoxel3D.newMesh(vertices, indices)
   return {
     vertices = vertices,
     indices = indices,
-    setTexture = function(self, texture) self.texture = texture end,
-    release = function(self) self.released = true end,
+    releaseCount = 0,
+    setTexture = function(self, texture)
+      if texture == nil and self.failDetach then
+        error("synthetic borrowed texture detach failure", 0)
+      end
+      self.texture = texture
+    end,
+    release = function(self)
+      self.releaseCount = self.releaseCount + 1
+      self.released = true
+    end,
   }
 end
 
@@ -402,6 +411,28 @@ do
   contains(validationError, "<table key>",
     "dispatch labels a hostile phase without converting it")
   equal(conversionCalls, 0, "untrusted key conversion callbacks never run")
+end
+
+do
+  local command = wireCommand("mesh", "background", 91, {
+    mesh = { id = "extension-owned-mesh" },
+    texture = { id = "extension-owned-texture" },
+  })
+  local ok, validationError = API.validate_draw_command(command, "mesh")
+  equal(ok, nil,
+    "direct opaque mesh and borrowed texture cannot be combined")
+  contains(validationError,
+    "cannot combine an opaque mesh/resource with a texture",
+    "direct mesh and texture rejection explains the unsafe ownership mix")
+
+  command.mesh = nil
+  command.resource = { id = "extension-owned-resource" }
+  ok, validationError = API.validate_draw_command(command, "mesh")
+  equal(ok, nil,
+    "direct opaque resource and borrowed texture cannot be combined")
+  contains(validationError,
+    "cannot combine an opaque mesh/resource with a texture",
+    "direct resource and texture rejection explains the unsafe ownership mix")
 end
 
 do
@@ -1107,8 +1138,33 @@ equal(fixtureTexture.releases, 0,
   "shared panorama, cloud, and poster texture is not released")
 check(#companion.meshes.panorama_deep.vertices <= 256,
   "deep panorama uses bounded host-owned band and skirt geometry")
-check(#companion.meshes.cloud_layer.vertices <= 32,
-  "cloud layer uses bounded host-owned geometry")
+local cloudMesh = companion.meshes.cloud_layer
+equal(#cloudMesh.vertices, 33,
+  "cloud layer uses one center and one bounded circular perimeter")
+equal(#cloudMesh.indices, 32 * 3,
+  "cloud layer uses one continuous 32-triangle fan")
+for segment = 0, 31 do
+  local base = segment * 3
+  equal(cloudMesh.indices[base + 1], 1,
+    "each cloud triangle shares the center vertex")
+  equal(cloudMesh.indices[base + 2], segment + 2,
+    "each cloud triangle starts at its perimeter vertex")
+  equal(cloudMesh.indices[base + 3], ((segment + 1) % 32) + 2,
+    "the cloud perimeter is continuous and closes without detached facets")
+end
+equal(cloudMesh.vertices[1][1], 0,
+  "cloud fan center has a centered local X position")
+equal(cloudMesh.vertices[1][3], 0,
+  "cloud fan center has a centered local Z position")
+for index = 2, #cloudMesh.vertices do
+  local vertex = cloudMesh.vertices[index]
+  check(math.abs(vertex[1] * vertex[1] + vertex[3] * vertex[3] - 0.25)
+      <= 1e-12,
+    "cloud perimeter stays on the fixed half-unit radius")
+  check(math.abs(vertex[4] - (vertex[1] + 0.5)) <= 1e-12
+      and math.abs(vertex[5] - (vertex[3] + 0.5)) <= 1e-12,
+    "cloud UVs stay continuous with local deck coordinates")
+end
 check(#companion.meshes.rainbow.vertices <= 96,
   "rainbow uses bounded host-owned geometry")
 equal(companion.meshes.panorama_deep.texture, nil,
@@ -1140,10 +1196,27 @@ for index, vertex in ipairs(deepVertices) do
 end
 local cloudTranslation = findTagged(calls.fixtureModels.cloud_layer, "translate")[1]
 local cloudScale = findTagged(calls.fixtureModels.cloud_layer, "scale")[1]
+local cloudRotation = findTagged(calls.fixtureModels.cloud_layer, "rotateY")[1]
 check(cloudTranslation[3] >= 200,
   "cloud decks stay high above the first-person eye")
 check(cloudScale[2] <= 192 and cloudScale[4] <= 192,
   "cloud decks stay inside the subtle bounded physical span")
+local minCloudX, maxCloudX = math.huge, -math.huge
+local minCloudZ, maxCloudZ = math.huge, -math.huge
+local cosine, sine = math.cos(cloudRotation[2]), math.sin(cloudRotation[2])
+for _, vertex in ipairs(cloudMesh.vertices) do
+  local x, z = vertex[1] * cloudScale[2], vertex[3] * cloudScale[4]
+  local transformedX = x * cosine - z * sine + cloudTranslation[2]
+  local transformedZ = x * sine + z * cosine + cloudTranslation[4]
+  minCloudX, maxCloudX = math.min(minCloudX, transformedX),
+    math.max(maxCloudX, transformedX)
+  minCloudZ, maxCloudZ = math.min(minCloudZ, transformedZ),
+    math.max(maxCloudZ, transformedZ)
+end
+check(maxCloudX - minCloudX <= 192 + 1e-9,
+  "rotated cloud geometry cannot exceed its claimed X span")
+check(maxCloudZ - minCloudZ <= 192 + 1e-9,
+  "rotated cloud geometry cannot exceed its claimed Z span")
 equal(calls.fixtureDraws.cloud_layer.depth, "lequal:false",
   "cloud decks never occlude later world geometry through depth writes")
 check(calls.fixtureDraws.panorama.color:match(":1$") ~= nil,
@@ -1154,6 +1227,46 @@ check(calls.fixtureDraws.cloud_layer.color:match(":1$") ~= nil,
   "cloud material uses binary texture coverage without alpha dithering")
 equal(calls.fixtureDraws.cloud_layer.mesh.texture, nil,
   "cloud layer unbinds its borrowed texture after each draw")
+
+local detachTexture = {
+  releases = 0,
+  release = function(self) self.releases = self.releases + 1 end,
+}
+local failedDetachMesh = companion.meshes.cloud_layer
+failedDetachMesh.failDetach = true
+local detachCommand = wireCommand("mesh", "background", 219, {
+  cacheKey = "test.cloud.detach-failure",
+  material = "sky:clouds:detach-probe",
+  texture = detachTexture,
+  geometry = {
+    primitive = "cloud_layer", layer = 1, parallax = 0.14,
+    density = 0.5, seed = 99,
+  },
+})
+local detachAccepted, detachError = companion.draw.mesh(
+  detachCommand, companion:_context())
+equal(detachAccepted, false,
+  "a borrowed cloud texture detach failure fails the draw closed")
+contains(detachError, "could not unbind borrowed extension texture",
+  "detach failure reports the borrowed-texture ownership problem")
+equal(companion.meshes.cloud_layer, nil,
+  "detach failure evicts the mesh that still references borrowed texture")
+equal(failedDetachMesh.releaseCount, 1,
+  "detach failure releases the evicted host-owned mesh exactly once")
+equal(detachTexture.releases, 0,
+  "detach failure never releases the callback-borrowed cloud texture")
+
+detachAccepted, detachError = companion.draw.mesh(
+  detachCommand, companion:_context())
+check(detachAccepted, detachError or "cloud draw retries after safe mesh eviction")
+check(companion.meshes.cloud_layer ~= failedDetachMesh,
+  "a later cloud draw creates a fresh host-owned mesh")
+equal(companion.meshes.cloud_layer.texture, nil,
+  "the replacement cloud mesh unbinds the borrowed texture")
+equal(failedDetachMesh.releaseCount, 1,
+  "the evicted host mesh is not released twice")
+equal(detachTexture.releases, 0,
+  "successful retry still does not release the borrowed cloud texture")
 
 local panoramaModels = {}
 for index, width in ipairs({ 4096, 1024 }) do
@@ -1181,9 +1294,10 @@ check(#companion.meshes.panorama.vertices <= 128,
 equal(companion.meshes.panorama.texture, nil,
   "normal panorama mesh does not retain its borrowed texture")
 
--- KFP marks both its ceiling and synthesized room walls with one cutaway
--- intent. The host applies that intent only in first person and only near the
--- player. The public callback camera mode is the authoritative mode source.
+-- KFP emits explicit ceiling and wall cutaway intent for every camera mode.
+-- Ceiling intent opens a bounded player area. Wall intent opens only the
+-- camera-near shell, so a small room keeps a useful far cross-section.
+-- Canopy cutaway remains first-person-only.
 local cutawayResults = {}
 local cutawayHandle
 cutawayHandle, err = provider.register({
@@ -1194,7 +1308,10 @@ cutawayHandle, err = provider.register({
   render = {
     opaque_after_terrain = function(context)
       local mode = context.camera.mode
-      local result = { contextMode = mode }
+      local result = {
+        contextMode = mode,
+        contextEyeX = context.camera.eye and context.camera.eye[1] or nil,
+      }
       cutawayResults[mode] = result
 
       local function draw(label, sequence, prototype, items)
@@ -1245,13 +1362,30 @@ cutawayHandle, err = provider.register({
         { x = 80, y = 24, z = 80 },
         { x = 96, y = 24, z = 16 },
       })
+      draw("wall-cross-section", 108, {
+        primitive = "box", width = 1, height = 24, depth = 16,
+        cutaway = true, role = "wall",
+      }, {
+        { x = 16, y = 24, z = 24, cellX = 1, cellZ = 1 },
+        { x = 32, y = 24, z = 24, cellX = 1, cellZ = 1 },
+        { x = 24, y = 24, z = 16, cellX = 1, cellZ = 1 },
+        { x = 24, y = 24, z = 32, cellX = 1, cellZ = 1 },
+      })
     end,
   },
 })
 check(cutawayHandle, err or "KFP cutaway probe registers")
 
+local savedCamera, savedEye = fakeVoxel3D.camera, fakeVoxel3D.eye
 for _, mode in ipairs({ "first_person", "third_person", "diorama" }) do
   fakeCameraMode = mode
+  if mode == "diorama" then
+    fakeVoxel3D.camera = nil
+    fakeVoxel3D.eye = { 8, 16, 24 }
+  else
+    fakeVoxel3D.camera = savedCamera
+    fakeVoxel3D.eye = savedEye
+  end
   local report = companion:render("opaque_after_terrain", state)
   local cutawayStatus = cutawayHandle:status()
   check(report and report.failed == 0,
@@ -1259,31 +1393,30 @@ for _, mode in ipairs({ "first_person", "third_person", "diorama" }) do
       .. tostring(cutawayStatus.fault and cutawayStatus.fault.message))
   equal(cutawayResults[mode].contextMode, mode,
     "cutaway reads the public callback camera mode in " .. mode)
+  equal(cutawayResults[mode].contextEyeX, 8,
+    "cutaway reads a public host eye in " .. mode)
 end
+fakeVoxel3D.camera, fakeVoxel3D.eye = savedCamera, savedEye
 
-equal(cutawayResults.first_person.ceiling, 1,
-  "first-person cutaway removes nearby and radius-boundary ceilings")
-equal(cutawayResults.first_person.wall, 1,
-  "first-person cutaway removes nearby and radius-boundary walls")
-equal(cutawayResults.first_person["ceiling-disabled"], 1,
-  "cutaway=false preserves a nearby first-person ceiling")
-equal(cutawayResults.first_person["wall-disabled"], 1,
-  "cutaway=false preserves a nearby first-person wall")
-equal(cutawayResults.first_person["other-role"], 1,
-  "cutaway does not suppress a different semantic role")
-equal(cutawayResults.first_person["missing-cell"], 1,
-  "cutaway fails open when an item has no cell position")
-equal(cutawayResults.first_person["canopy-derived-cell"], 1,
-  "first-person cutaway derives released canopy cell positions")
-for _, mode in ipairs({ "third_person", "diorama" }) do
-  equal(cutawayResults[mode].ceiling, 3,
-    mode .. " preserves all ceiling cells")
-  equal(cutawayResults[mode].wall, 3,
-    mode .. " preserves all wall cells")
+for _, mode in ipairs({ "first_person", "third_person", "diorama" }) do
+  equal(cutawayResults[mode].ceiling, 1,
+    mode .. " applies emitted ceiling intent at the inclusive radius")
+  equal(cutawayResults[mode].wall, 2,
+    mode .. " removes only the camera-near wall and keeps the far shell")
+  equal(cutawayResults[mode]["wall-cross-section"], 3,
+    mode .. " keeps far and side walls in a one-cell room")
   equal(cutawayResults[mode]["ceiling-disabled"], 1,
     mode .. " preserves cutaway=false ceilings")
   equal(cutawayResults[mode]["wall-disabled"], 1,
     mode .. " preserves cutaway=false walls")
+  equal(cutawayResults[mode]["other-role"], 1,
+    mode .. " does not suppress a different semantic role")
+  equal(cutawayResults[mode]["missing-cell"], 1,
+    mode .. " fails open when an item has no cell position")
+end
+equal(cutawayResults.first_person["canopy-derived-cell"], 1,
+  "first-person cutaway derives released canopy cell positions")
+for _, mode in ipairs({ "third_person", "diorama" }) do
   equal(cutawayResults[mode]["canopy-derived-cell"], 3,
     mode .. " preserves all canopy cells")
 end

--- a/tests/voxel_companion_api_v1_test.lua
+++ b/tests/voxel_companion_api_v1_test.lua
@@ -85,13 +85,23 @@ love = {
   graphics = {},
 }
 
-function love.image.newImageData()
-  return { setPixel = function() end }
+function love.image.newImageData(width, height)
+  local data = { width = width or 1, height = height or 1, pixels = 0,
+    minAlpha = 1, maxAlpha = 0 }
+  function data:setPixel(_, _, _, _, _, alpha)
+    alpha = alpha == nil and 1 or alpha
+    self.pixels = self.pixels + 1
+    self.minAlpha = math.min(self.minAlpha, alpha)
+    self.maxAlpha = math.max(self.maxAlpha, alpha)
+  end
+  return data
 end
 
-function love.graphics.newImage()
+function love.graphics.newImage(data)
   return {
+    sourceData = data,
     setFilter = function() end,
+    setWrap = function() end,
     release = function(self) self.released = true end,
   }
 end
@@ -172,6 +182,8 @@ function fakeVoxel3D.draw(mesh, texture, model)
     mesh = mesh,
     texture = texture,
     model = model,
+    color = graphicsState.color,
+    depth = graphicsState.depth,
   }
   if fakeVoxel3D.failNextDraw then
     fakeVoxel3D.failNextDraw = false
@@ -1013,6 +1025,8 @@ fixtureTexture.release = function(self) self.releases = self.releases + 1 end
 local fixtureRender = {}
 calls.fixturePrimitiveAccepted = {}
 calls.fixtureTextureCleared = true
+calls.fixtureModels = {}
+calls.fixtureDraws = {}
 for _, phase in ipairs({
   "background", "opaque_after_terrain", "translucent_after_actors",
 }) do
@@ -1029,6 +1043,10 @@ for _, phase in ipairs({
         or "explicit_billboards"
       calls.fixturePrimitiveAccepted[primitive] =
         (calls.fixturePrimitiveAccepted[primitive] or 0) + 1
+      if command.kind == "mesh" then
+        calls.fixtureModels[primitive] = fakeVoxel3D.drawLog[#fakeVoxel3D.drawLog].model
+        calls.fixtureDraws[primitive] = fakeVoxel3D.drawLog[#fakeVoxel3D.drawLog]
+      end
       if command.procedural then
         calls.fixtureStarsExpanded = (calls.fixtureStarsExpanded or 0)
           + (#fakeVoxel3D.drawLog - beforeDraws)
@@ -1091,6 +1109,62 @@ check(#companion.meshes.rainbow.vertices <= 96,
   "rainbow uses bounded host-owned geometry")
 equal(companion.meshes.panorama.texture, nil,
   "panorama mesh does not retain its borrowed texture")
+local panoramaTranslation = findTagged(calls.fixtureModels.panorama, "translate")[1]
+local panoramaScale = findTagged(calls.fixtureModels.panorama, "scale")[1]
+equal(panoramaTranslation[3], -550,
+  "deep panorama retains the released vertical midpoint")
+equal(panoramaScale[2], 1800,
+  "panorama diameter is fixed physical geometry, not texture resolution")
+equal(panoramaScale[3], 1700,
+  "deep panorama retains the released top and skirt bounds")
+equal(panoramaScale[4], 1800,
+  "panorama depth uses the fixed physical diameter")
+local cloudTranslation = findTagged(calls.fixtureModels.cloud_layer, "translate")[1]
+local cloudScale = findTagged(calls.fixtureModels.cloud_layer, "scale")[1]
+check(cloudTranslation[3] >= 200,
+  "cloud decks stay high above the first-person eye")
+check(cloudScale[2] <= 192 and cloudScale[4] <= 192,
+  "cloud decks stay inside the subtle bounded physical span")
+equal(calls.fixtureDraws.cloud_layer.depth, "lequal:false",
+  "cloud decks never occlude later world geometry through depth writes")
+check(companion.cloudTexture and companion.cloudTexture ~= companion.texture,
+  "clouds use a dedicated host-owned alpha mask instead of the white fallback")
+equal(companion.cloudTexture.sourceData.width, 32,
+  "cloud alpha mask has a bounded width")
+equal(companion.cloudTexture.sourceData.pixels, 32 * 32,
+  "cloud alpha mask initializes every bounded texel")
+check(companion.cloudTexture.sourceData.minAlpha < 0.5
+    and companion.cloudTexture.sourceData.maxAlpha >= 0.5,
+  "cloud alpha mask cuts away quad corners and retains a cloud body")
+check(calls.fixtureDraws.panorama.color:match(":1$") ~= nil,
+  "distance haze does not turn panorama alpha into checker coverage")
+equal(calls.fixtureDraws.panorama.depth, "lequal:false",
+  "panorama retains depth testing without occluding later world geometry")
+check(calls.fixtureDraws.cloud_layer.color:match(":1$") ~= nil,
+  "cloud material uses binary texture coverage without alpha dithering")
+local hostCloudTexture = companion.cloudTexture
+
+local panoramaModels = {}
+for index, width in ipairs({ 4096, 1024 }) do
+  local command = wireCommand("mesh", "background", 200 + index, {
+    cacheKey = "test.panorama.physical:" .. tostring(width),
+    material = "horizon:quality-probe",
+    texture = fixtureTexture,
+    geometry = {
+      primitive = "panorama", sourceWidth = width, targetWidth = width,
+      deepSkirt = true, distanceHaze = true,
+    },
+  })
+  local before = #fakeVoxel3D.drawLog
+  local panoramaAccepted, panoramaError = companion.draw.mesh(
+    command, companion:_context())
+  check(panoramaAccepted, panoramaError or "panorama quality probe is accepted")
+  equal(#fakeVoxel3D.drawLog, before + 1,
+    "panorama quality probe emits one bounded draw")
+  panoramaModels[index] = fakeVoxel3D.drawLog[#fakeVoxel3D.drawLog].model
+end
+equal(treeSignature(panoramaModels[1]), treeSignature(panoramaModels[2]),
+  "panorama world geometry is independent of texture quality width")
 
 -- KFP marks both its ceiling and synthesized room walls with one cutaway
 -- intent. The host applies that intent only in first person and only near the
@@ -1149,6 +1223,13 @@ cutawayHandle, err = provider.register({
         primitive = "box", width = 1, height = 24, depth = 16,
         cutaway = true, role = "wall",
       }, { { x = 16, y = 24, z = 16 } })
+      draw("canopy-derived-cell", 107, {
+        primitive = "canopy", width = 16, cutaway = true,
+      }, {
+        { x = 16, y = 24, z = 16 },
+        { x = 80, y = 24, z = 80 },
+        { x = 96, y = 24, z = 16 },
+      })
     end,
   },
 })
@@ -1177,6 +1258,8 @@ equal(cutawayResults.first_person["other-role"], 1,
   "cutaway does not suppress a different semantic role")
 equal(cutawayResults.first_person["missing-cell"], 1,
   "cutaway fails open when an item has no cell position")
+equal(cutawayResults.first_person["canopy-derived-cell"], 1,
+  "first-person cutaway derives released canopy cell positions")
 for _, mode in ipairs({ "third_person", "diorama" }) do
   equal(cutawayResults[mode].ceiling, 3,
     mode .. " preserves all ceiling cells")
@@ -1186,6 +1269,8 @@ for _, mode in ipairs({ "third_person", "diorama" }) do
     mode .. " preserves cutaway=false ceilings")
   equal(cutawayResults[mode]["wall-disabled"], 1,
     mode .. " preserves cutaway=false walls")
+  equal(cutawayResults[mode]["canopy-derived-cell"], 3,
+    mode .. " preserves all canopy cells")
 end
 fakeCameraMode = "first_person"
 
@@ -1217,6 +1302,8 @@ equal(fixtureTexture.releases, 0,
   "adapter never releases shared panorama/poster texture during disposal")
 equal(companion.state, nil, "adapter drops retained world state on dispose")
 equal(companion.startContext, nil, "adapter drops retained activation context on dispose")
+check(hostCloudTexture.released,
+  "adapter releases its host-owned cloud alpha mask during disposal")
 equal(love.update, sentinelUpdate, "adapter does not replace global callbacks")
 
 local legacyMod = cleanMod()

--- a/tests/voxel_companion_api_v1_test.lua
+++ b/tests/voxel_companion_api_v1_test.lua
@@ -953,6 +953,157 @@ firstSnapshot.cells[1].kind = "corrupted-copy"
 equal(companion.world.snapshot().cells[1].kind, "grass",
   "snapshot facade returns defensive copies")
 
+do
+  -- ROM-free semantic fixture. Tile ids match the public KFP 1.60 authored
+  -- OVERWORLD policy; all map, collision, roof, door, and connection facts are
+  -- synthetic host inputs.
+  local previousShapes = fakeShapes
+  fakeShapes = {
+    [0] = { class = "ground", h = 0 },
+    [2] = { class = "wall", h = 16 },
+    [9] = { class = "cliff", h = 32 },
+    [10] = { class = "wall", h = 16 },
+    [36] = { class = "wall", h = 16 },
+    [42] = { class = "cylinder", h = 16 },
+    [64] = { class = "cylinder", h = 16 },
+    [90] = { class = "cylinder", h = 16 },
+    [100] = { class = "roof", h = 28 },
+  }
+
+  local width, height = 12, 7
+  local tiles = {}
+  local function key(x, z) return x .. ":" .. z end
+  local function put(x, z, tile) tiles[key(x, z)] = tile end
+  put(0, 0, 64)   -- verified tree cylinder
+  put(1, 0, 42)   -- verified boulder cylinder
+  put(2, 0, 64)   -- walkable seam ghost
+  put(3, 0, 90)   -- unknown cylinder
+  put(4, 0, 42)   -- water-shaped boulder id
+  put(11, 0, 2)   -- rock seed inside an active north connection band
+  put(9, 3, 100)  -- roof that vetoes the nearby seed below
+  put(9, 4, 36)   -- authored rock id, but part of a building context
+  put(0, 4, 2)    -- valid mountain seed
+  put(1, 4, 9)    -- first support cell
+  put(2, 4, 10)   -- second support cell, at the exact reach limit
+  put(3, 4, 10)   -- third cell, beyond the bounded seed reach
+  put(5, 5, 36)   -- valid seed beside a cave-style doorway
+  put(6, 5, 10)   -- non-seed support vetoed by that doorway
+  put(11, 6, 9)   -- isolated generic cliff
+
+  local semanticMap = {
+    id = "SYNTHETIC_SEMANTICS",
+    widthCells = width,
+    heightCells = height,
+    def = {
+      width = 6,
+      height = 4,
+      tileset = "OVERWORLD",
+      connections = { north = {} },
+    },
+    tileset = { id = "OVERWORLD", image = "synthetic-overworld-atlas" },
+  }
+  function semanticMap:cellTile(x, z) return tiles[key(x, z)] or 0 end
+  function semanticMap:isWalkableCell(x, z)
+    return self:cellTile(x, z) == 0 or (x == 2 and z == 0)
+      or (x == 7 and z == 5)
+  end
+  function semanticMap:isWaterCell(x, z) return x == 4 and z == 0 end
+  function semanticMap:isGrassCell() return false end
+  function semanticMap:warpAtCell(x, z)
+    return x == 7 and z == 5 and { target = "SYNTHETIC_CAVE" } or nil
+  end
+  function semanticMap:isWarpTileCell() return false end
+
+  local semanticPlayer = { id = "player", px = 0, py = 0,
+    cellX = 0, cellY = 0, facing = "down", gh = 0 }
+  local semanticState = {
+    map = semanticMap,
+    player = semanticPlayer,
+    entities = { semanticPlayer },
+    neighbors = {},
+  }
+  local semanticCompanion = VoxelCompanion.new({ mod = cleanMod() })
+  local callbackWorldId, callbackTreeSupport
+  local semanticHandle, semanticError = semanticCompanion.provider.register({
+    api = 1,
+    id = "test.semantic-world-output",
+    requires = { "world_snapshot" },
+    worldChanged = function(snapshot)
+      callbackWorldId = snapshot.id
+      callbackTreeSupport = snapshot.cells[1].tags.tree_support
+    end,
+  })
+  check(semanticHandle,
+    semanticError or "semantic world-output extension registers")
+  check(semanticCompanion:start(), "semantic world-output host starts")
+  check(semanticCompanion:update(0.016, semanticState),
+    "semantic fixture dispatches through the normal world lifecycle")
+  equal(callbackWorldId, "SYNTHETIC_SEMANTICS",
+    "worldChanged receives the semantic fixture")
+
+  local semanticSnapshot = assert(semanticCompanion.world.snapshot())
+  local function cell(x, z)
+    return semanticSnapshot.cells[z * width + x + 1]
+  end
+  check(cell(0, 0).tags.tree_support,
+    "known OVERWORLD tree cylinder receives tree_support")
+  check(cell(0, 0).tags.tree and cell(0, 0).tags.object,
+    "verified tree support retains truthful broad tags")
+  check(not cell(0, 0).tags.boulder_tree,
+    "tree cylinder is not mislabeled as a boulder")
+  check(cell(1, 0).tags.boulder_tree and cell(1, 0).tags.boulder,
+    "known OVERWORLD boulder cylinder receives boulder_tree")
+  check(not cell(1, 0).tags.tree,
+    "boulder cylinder does not retain the old generic tree guess")
+  check(not cell(2, 0).tags.tree_support
+      and not cell(2, 0).tags.boulder_tree
+      and not cell(2, 0).tags.tree,
+    "walkable cylinder ghost fails closed")
+  check(cell(2, 0).walkable and cell(2, 0).tags.cylinder,
+    "walkable ghost keeps only its truthful raw shape facts")
+  check(not cell(3, 0).tags.tree_support
+      and not cell(3, 0).tags.boulder_tree
+      and not cell(3, 0).tags.tree,
+    "unknown cylinder fails closed")
+  check(not cell(4, 0).tags.boulder_tree,
+    "water suppresses an otherwise known boulder id")
+
+  check(cell(0, 4).tags.mountain_seed
+      and cell(0, 4).tags.mountain_support,
+    "authored rock seed is also a mountain support cell")
+  check(cell(0, 4).tags.mountain and cell(0, 4).tags.object,
+    "verified mountain seed retains truthful broad tags")
+  check(cell(1, 4).tags.mountain_support
+      and not cell(1, 4).tags.mountain_seed,
+    "adjacent upright rock receives support but not seed")
+  check(cell(2, 4).tags.mountain_support,
+    "upright rock at the exact two-cell reach limit receives support")
+  check(not cell(3, 4).tags.mountain_support
+      and not cell(3, 4).tags.mountain,
+    "upright rock beyond the seed reach fails closed")
+  check(cell(5, 5).tags.mountain_seed,
+    "authored rock seed survives a nearby cave doorway")
+  check(not cell(6, 5).tags.mountain_support,
+    "door proximity vetoes non-seed mountain support")
+  check(not cell(9, 4).tags.mountain_seed
+      and not cell(9, 4).tags.mountain_support,
+    "roof proximity vetoes an authored rock id")
+  check(not cell(11, 0).tags.mountain_seed,
+    "active connection band suppresses a mountain seed")
+  check(not cell(11, 6).tags.mountain_support
+      and not cell(11, 6).tags.mountain,
+    "isolated generic cliff is not guessed to be a mountain")
+
+  check(callbackTreeSupport,
+    "worldChanged output contains the normalized tree_support tag")
+  semanticSnapshot.cells[1].tags.tree_support = false
+  check(semanticCompanion.world.snapshot().cells[1].tags.tree_support,
+    "semantic tags survive defensive snapshot copying")
+  check(semanticCompanion:dispose("semantic-fixture"),
+    "semantic fixture disposes cleanly")
+  fakeShapes = previousShapes
+end
+
 state.player.px, state.player.py = 16, 16
 state.player.cellX, state.player.cellY = 1, 1
 companion:update(0.016, state)

--- a/tests/voxel_companion_api_v1_test.lua
+++ b/tests/voxel_companion_api_v1_test.lua
@@ -42,6 +42,37 @@ local API = assert(loadfile("lib/VoxelCompanionAPI.lua"))()
 equal(API.VERSION, 1, "vendored dispatcher reports API v1")
 local DrawFixture = assert(loadfile("tests/fixtures/voxel_companion_draw_v1.lua"))()
 
+local function newRunningDispatcher()
+  local dispatcher = API.new({ capabilities = {} })
+  check(dispatcher:attach({}), "fault-cleanup dispatcher attaches")
+  check(dispatcher:start({}), "fault-cleanup dispatcher starts")
+  return dispatcher
+end
+
+local function attemptCleanupReentry(dispatcher, id)
+  local attempts = {}
+  attempts.dispatch, attempts.dispatchError = dispatcher:dispatch("update", {})
+  attempts.register, attempts.registerError = dispatcher:register({
+    api = 1,
+    id = "cleanup.reentry." .. id,
+    lifecycle = { start = function() end },
+  }, {})
+  attempts.dispose, attempts.disposeError = dispatcher:dispose({}, "cleanup-reentry")
+  return attempts
+end
+
+local function expectCleanupReentryBlocked(attempts)
+  equal(attempts.dispatch, nil, "fault cleanup cannot reenter dispatch")
+  contains(attempts.dispatchError, "reentrant dispatch",
+    "fault cleanup reports blocked dispatch reentry")
+  equal(attempts.register, nil, "fault cleanup cannot register an extension")
+  contains(attempts.registerError, "register during dispatch",
+    "fault cleanup reports blocked registration")
+  equal(attempts.dispose, nil, "fault cleanup cannot dispose the dispatcher")
+  contains(attempts.disposeError, "dispose during dispatch",
+    "fault cleanup reports blocked dispatcher disposal")
+end
+
 local graphicsState = { color = "host", depth = "host", blend = "host" }
 local graphicsStack = {}
 local pushCount, popCount = 0, 0
@@ -333,6 +364,76 @@ do
   equal(#lifecycleCalls, 2, "only the captured lifecycle callbacks run")
   equal(lifecycleCalls[1], "invalidate:map", "captured invalidate receives its reason")
   equal(lifecycleCalls[2], "dispose", "captured dispose runs exactly once")
+end
+
+do
+  local dispatcher = newRunningDispatcher()
+  local attempts
+  local handle, registerError = dispatcher:register({
+    api = 1,
+    id = "test.fault-guard-hot-attach",
+    lifecycle = {
+      attach = function() error("expected hot attach fault", 0) end,
+      dispose = function()
+        attempts = attemptCleanupReentry(dispatcher, "hot.attach")
+      end,
+    },
+  }, {})
+  check(handle, registerError or "hot attach fault registration returns its handle")
+  check(handle:status().faulted, "hot attach failure faults only its extension")
+  expectCleanupReentryBlocked(attempts)
+  equal(dispatcher:status().state, "running",
+    "hot attach fault cleanup leaves the dispatcher running")
+  check(dispatcher:dispose({}, "test-end"),
+    "hot attach fault-cleanup dispatcher disposes normally")
+end
+
+do
+  local dispatcher = newRunningDispatcher()
+  local attempts
+  local handle, registerError = dispatcher:register({
+    api = 1,
+    id = "test.fault-guard-hot-start",
+    lifecycle = {
+      start = function() error("expected hot start fault", 0) end,
+      dispose = function()
+        attempts = attemptCleanupReentry(dispatcher, "hot.start")
+      end,
+    },
+  }, {})
+  check(handle, registerError or "hot start fault registration returns its handle")
+  check(handle:status().faulted, "hot start failure faults only its extension")
+  expectCleanupReentryBlocked(attempts)
+  equal(dispatcher:status().state, "running",
+    "hot start fault cleanup leaves the dispatcher running")
+  check(dispatcher:dispose({}, "test-end"),
+    "hot start fault-cleanup dispatcher disposes normally")
+end
+
+do
+  local dispatcher = newRunningDispatcher()
+  local attempts
+  local handle, registerError = dispatcher:register({
+    api = 1,
+    id = "test.fault-guard-handle-invalidate",
+    lifecycle = {
+      invalidate = function() error("expected handle invalidate fault", 0) end,
+      dispose = function()
+        attempts = attemptCleanupReentry(dispatcher, "handle.invalidate")
+      end,
+    },
+  }, {})
+  check(handle, registerError or "handle invalidate fault extension registers")
+  local invalidated, invalidateError = handle:invalidate({}, "test")
+  equal(invalidated, nil, "handle invalidate failure is reported")
+  contains(invalidateError, "expected handle invalidate fault",
+    "handle invalidate returns the callback failure")
+  check(handle:status().faulted, "handle invalidate failure faults only its extension")
+  expectCleanupReentryBlocked(attempts)
+  equal(dispatcher:status().state, "running",
+    "handle invalidate fault cleanup leaves the dispatcher running")
+  check(dispatcher:dispose({}, "test-end"),
+    "handle invalidate fault-cleanup dispatcher disposes normally")
 end
 
 do

--- a/tests/voxel_companion_api_v1_test.lua
+++ b/tests/voxel_companion_api_v1_test.lua
@@ -269,6 +269,168 @@ local function wireCommand(kind, phase, sequence, fields)
   return command
 end
 
+do
+  local conversionCalls = 0
+  local hostileKey = setmetatable({}, {
+    __tostring = function()
+      conversionCalls = conversionCalls + 1
+      error("untrusted key conversion ran", 0)
+    end,
+  })
+  local command = wireCommand("mesh", "background", 90, {
+    geometry = { primitive = "plane", width = 1, depth = 1 },
+  })
+  command[hostileKey] = true
+
+  local callOk, valid, validationError = pcall(
+    API.validate_draw_command, command, "mesh")
+  check(callOk, "draw validation contains hostile keys without throwing")
+  equal(valid, nil, "draw validation rejects an unknown hostile key")
+  contains(validationError, "<table key>",
+    "draw validation labels a hostile key without converting it")
+
+  command[hostileKey] = nil
+  command.kind = hostileKey
+  callOk, valid, validationError = pcall(
+    API.validate_draw_command, command, "mesh")
+  check(callOk, "draw kind validation contains hostile values without throwing")
+  equal(valid, nil, "draw validation rejects a hostile kind")
+  contains(validationError, "<table key>",
+    "draw kind validation labels a hostile value without converting it")
+
+  local dispatcher = API.new({ capabilities = {} })
+  callOk, valid, validationError = pcall(
+    dispatcher.dispatch, dispatcher, hostileKey, {})
+  check(callOk, "dispatch phase validation contains hostile values without throwing")
+  equal(valid, nil, "dispatch rejects a hostile phase")
+  contains(validationError, "<table key>",
+    "dispatch labels a hostile phase without converting it")
+  equal(conversionCalls, 0, "untrusted key conversion callbacks never run")
+end
+
+do
+  local lifecycleCalls = {}
+  local spec = {
+    api = 1,
+    id = "test.flat-callback-snapshot",
+    invalidate = function(reason)
+      lifecycleCalls[#lifecycleCalls + 1] = "invalidate:" .. reason
+    end,
+    dispose = function()
+      lifecycleCalls[#lifecycleCalls + 1] = "dispose"
+    end,
+  }
+  local dispatcher = API.new({ capabilities = {} })
+  local handle, registerError = dispatcher:register(spec)
+  check(handle, registerError or "flat callback snapshot registers")
+  spec.invalidate = function() error("mutated invalidate callback ran", 0) end
+  spec.dispose = function() error("mutated dispose callback ran", 0) end
+  check(dispatcher:attach({}), "flat callback snapshot dispatcher attaches")
+  check(dispatcher:start({}), "flat callback snapshot dispatcher starts")
+  local report = dispatcher:invalidate({}, "map")
+  equal(report.succeeded, 1, "captured invalidate callback succeeds")
+  check(dispatcher:dispose({}, "shutdown"), "captured dispose callback succeeds")
+  equal(#lifecycleCalls, 2, "only the captured lifecycle callbacks run")
+  equal(lifecycleCalls[1], "invalidate:map", "captured invalidate receives its reason")
+  equal(lifecycleCalls[2], "dispose", "captured dispose runs exactly once")
+end
+
+do
+  local noDraw = function() return true end
+  local services = {
+    materials = {},
+    draw = { mesh = noDraw, instances = noDraw, billboards = noDraw },
+  }
+  local validContext = {
+    world = {}, camera = {}, frame = {},
+    materials = services.materials, draw = services.draw,
+  }
+  local calls = 0
+  local dispatcher = API.new({ capabilities = { API.CAPABILITIES.RENDER_PHASES } })
+  local handle, registerError = dispatcher:register({
+    api = 1,
+    id = "test.dispatch-validation-recovery",
+    render = { background = function() calls = calls + 1 end },
+  })
+  check(handle, registerError or "dispatch validation recovery registers")
+  check(dispatcher:attach(services), "dispatch validation recovery attaches")
+  check(dispatcher:start(validContext), "dispatch validation recovery starts")
+
+  local report, dispatchError = dispatcher:dispatch("background", {})
+  equal(report, nil, "missing render context is rejected")
+  contains(dispatchError, "world", "missing render context identifies world")
+
+  local hostileContext = setmetatable({}, {
+    __index = function() error("validation proxy access failed", 0) end,
+  })
+  report, dispatchError = dispatcher:dispatch("background", hostileContext)
+  equal(report, nil, "throwing render context is rejected")
+  contains(dispatchError, "validation proxy access failed",
+    "throwing render context reports its validation fault")
+
+  report, dispatchError = dispatcher:dispatch("background", validContext)
+  check(report, dispatchError or "dispatch recovers after validation faults")
+  equal(report.succeeded, 1, "recovered dispatch succeeds")
+  equal(calls, 1, "recovered dispatch invokes its handler once")
+  check(dispatcher:dispose({}, "test"), "dispatch validation recovery disposes")
+end
+
+do
+  local dispatcher = API.new({ capabilities = { API.CAPABILITIES.CAMERA_DELTA } })
+  local first = dispatcher:register({
+    api = 1,
+    id = "test.camera-large-first",
+    priority = 0,
+    camera = function()
+      return {
+        positionDelta = { x = 1e308 },
+        rotationDelta = { yaw = 1e308 },
+        fovDelta = 1e308,
+      }
+    end,
+  })
+  check(first, "first large finite camera contribution registers")
+  local overflow = dispatcher:register({
+    api = 1,
+    id = "test.camera-large-overflow",
+    priority = 1,
+    camera = function()
+      return { positionDelta = { x = 1e308, y = 50 } }
+    end,
+  })
+  check(overflow, "overflowing camera contribution registers")
+  local recovery = dispatcher:register({
+    api = 1,
+    id = "test.camera-large-recovery",
+    priority = 2,
+    camera = function()
+      return {
+        positionDelta = { x = -1e308, y = 2 },
+        rotationDelta = { yaw = -1e308 },
+        fovDelta = -1e308,
+      }
+    end,
+  })
+  check(recovery, "camera recovery contribution registers")
+  check(dispatcher:attach({}), "camera overflow dispatcher attaches")
+  check(dispatcher:start({}), "camera overflow dispatcher starts")
+
+  local result, report = dispatcher:dispatch_camera({})
+  equal(result.positionDelta.x, 0, "finite camera position aggregate is preserved")
+  equal(result.positionDelta.y, 2, "overflowing camera contribution is transactional")
+  equal(result.rotationDelta.yaw, 0, "finite camera rotation aggregate is preserved")
+  equal(result.fovDelta, 0, "finite camera FOV aggregate is preserved")
+  equal(report.succeeded, 2, "two finite camera contributions succeed")
+  equal(report.failed, 1, "only the overflowing camera contribution fails")
+  equal(#report.contributors, 2, "camera report contains only finite contributors")
+  equal(report.contributors[1], "test.camera-large-first",
+    "first finite camera contributor remains")
+  equal(report.contributors[2], "test.camera-large-recovery",
+    "later finite camera contributor still runs")
+  check(overflow:status().faulted, "overflowing camera extension is faulted")
+  check(dispatcher:dispose({}, "test"), "camera overflow dispatcher disposes")
+end
+
 equal(provider.api, 1, "provider reports API v1")
 equal(provider.host.id, "BATTLE_ART_VOXEL_FORK", "provider reports stable host id")
 equal(provider.host.version, "1.9.7", "provider preserves upstream version")

--- a/tests/voxel_companion_api_v1_test.lua
+++ b/tests/voxel_companion_api_v1_test.lua
@@ -19,6 +19,25 @@ local function contains(text, fragment, message)
   check(type(text) == "string" and text:find(fragment, 1, true) ~= nil, message)
 end
 
+local function treeSignature(value)
+  if type(value) ~= "table" then
+    if type(value) == "number" then return string.format("%.12g", value) end
+    return tostring(value)
+  end
+  local out = { "[" }
+  for index = 1, #value do out[#out + 1] = treeSignature(value[index]) end
+  out[#out + 1] = "]"
+  return table.concat(out, ",")
+end
+
+local function findTagged(value, tag, out)
+  out = out or {}
+  if type(value) ~= "table" then return out end
+  if value[1] == tag then out[#out + 1] = value end
+  for index = 1, #value do findTagged(value[index], tag, out) end
+  return out
+end
+
 local API = assert(loadfile("lib/VoxelCompanionAPI.lua"))()
 equal(API.VERSION, 1, "vendored dispatcher reports API v1")
 local DrawFixture = assert(loadfile("tests/fixtures/voxel_companion_draw_v1.lua"))()
@@ -346,7 +365,8 @@ healthy, err = provider.register({
         texture = borrowedTexture,
       }), context)
       if not accepted then error(drawError, 0) end
-      calls.borrowedMeshCleared = fakeVoxel3D.drawLog[#fakeVoxel3D.drawLog].mesh.texture == nil
+      calls.borrowedMeshDraw = fakeVoxel3D.drawLog[#fakeVoxel3D.drawLog]
+      calls.borrowedMeshCleared = calls.borrowedMeshDraw.mesh.texture == nil
       accepted, drawError = context.draw.mesh(wireCommand("mesh", "background", 3, {
         geometry = { primitive = "world_apron", width = 32, depth = 32,
           skirtDepth = 16 },
@@ -381,9 +401,11 @@ collisionProbe, err = provider.register({
       })
       local accepted, drawError = context.draw.mesh(first, context)
       calls.collisionFirst = accepted
+      calls.collisionFirstModel = fakeVoxel3D.drawLog[#fakeVoxel3D.drawLog].model
       if not accepted then error(drawError, 0) end
       accepted, drawError = context.draw.mesh(first, context)
       calls.collisionRepeat = accepted
+      calls.collisionRepeatModel = fakeVoxel3D.drawLog[#fakeVoxel3D.drawLog].model
       if not accepted then error(drawError, 0) end
       accepted, drawError = context.draw.mesh(second, context)
       calls.collisionSecond = accepted
@@ -456,6 +478,95 @@ equal(accepted, false, "missing callback context returns exactly false")
 contains(rejection, "borrowed render context", "missing context explains the rejection")
 equal(fakeVoxel3D.draws, rejectedDraws, "rejected commands never reach Voxel3D.draw")
 
+local invalidBaseline = {
+  wireCommand("mesh", "background", 24, {
+    cacheKey = "other.extension:panorama-no-texture",
+    geometry = { primitive = "panorama", sourceWidth = 4096, targetWidth = 2048 },
+  }),
+  wireCommand("mesh", "background", 25, {
+    cacheKey = "other.extension:cloud-bad-density",
+    geometry = { primitive = "cloud_layer", layer = 1, parallax = 0.2,
+      density = 2, seed = 1 },
+  }),
+  wireCommand("mesh", "background", 26, {
+    cacheKey = "other.extension:rainbow-bad-seed",
+    geometry = { primitive = "rainbow", seed = 0 / 0 },
+  }),
+  wireCommand("billboards", "background", 27, {
+    cacheKey = "other.extension:stars-empty",
+    material = "sky:stars",
+    procedural = { kind = "stars", count = 0, seed = 1 },
+  }),
+}
+for _, command in ipairs(invalidBaseline) do
+  accepted, rejection = companion.draw[command.kind](command, companion:_context())
+  equal(accepted, false, "invalid complete-baseline command returns exactly false")
+  check(type(rejection) == "string" and rejection ~= "",
+    "invalid complete-baseline command explains its rejection")
+end
+equal(fakeVoxel3D.draws, rejectedDraws,
+  "invalid complete-baseline commands never reach Voxel3D.draw")
+
+local starTexture = {
+  releases = 0,
+  release = function(self) self.releases = self.releases + 1 end,
+}
+local stars = wireCommand("billboards", "background", 28, {
+  cacheKey = "other.extension:procedural-stars",
+  material = "sky:stars",
+  texture = starTexture,
+  procedural = {
+    kind = "stars", count = 24, seed = 1234.5,
+    twinkle = true, nebula = true, shootingStars = true,
+  },
+})
+local oldRandom, oldRandomSeed = math.random, math.randomseed
+math.random = function() error("procedural stars touched global random", 0) end
+math.randomseed = function() error("procedural stars reseeded global random", 0) end
+local firstStarStart = #fakeVoxel3D.drawLog + 1
+local callOk, firstAccepted, firstError = pcall(
+  companion.draw.billboards, stars, companion:_context())
+local firstStarEnd = #fakeVoxel3D.drawLog
+local secondStarStart = firstStarEnd + 1
+local secondCallOk, secondAccepted, secondError = pcall(
+  companion.draw.billboards, stars, companion:_context())
+local secondStarEnd = #fakeVoxel3D.drawLog
+math.random, math.randomseed = oldRandom, oldRandomSeed
+check(callOk, firstAccepted or "procedural stars avoid global random")
+check(secondCallOk, secondAccepted or "repeat procedural stars avoid global random")
+equal(firstAccepted, true, firstError or "procedural stars are accepted")
+equal(secondAccepted, true, secondError or "repeat procedural stars are accepted")
+equal(firstStarEnd - firstStarStart + 1, 24,
+  "star procedure expands to the requested bounded item count")
+equal(secondStarEnd - secondStarStart + 1, 24,
+  "repeat star procedure keeps the requested item count")
+for offset = 0, 23 do
+  local firstDraw = fakeVoxel3D.drawLog[firstStarStart + offset]
+  local secondDraw = fakeVoxel3D.drawLog[secondStarStart + offset]
+  equal(treeSignature(firstDraw.model), treeSignature(secondDraw.model),
+    "star expansion is repeatable for item " .. tostring(offset + 1))
+  local translations = findTagged(firstDraw.model, "translate")
+  local scales = findTagged(firstDraw.model, "scale")
+  equal(#translations, 1, "star model has one bounded translation")
+  equal(#scales, 1, "star model has one bounded scale")
+  for coordinate = 2, 4 do
+    check(translations[1][coordinate] >= -65536
+      and translations[1][coordinate] <= 65536,
+      "star coordinate stays inside the host world bound")
+  end
+  check(scales[1][2] >= 0.25 and scales[1][2] <= 8,
+    "star width stays inside the host primitive bound")
+  check(scales[1][3] >= 0.25 and scales[1][3] <= 8,
+    "star height stays inside the host primitive bound")
+  equal(firstDraw.texture, starTexture,
+    "procedural star draw uses the callback-borrowed texture")
+  equal(firstDraw.mesh.texture, nil,
+    "procedural star texture is unbound before callback return")
+end
+equal(starTexture.releases, 0,
+  "procedural star texture is neither retained nor released")
+graphicsState = { color = "host", depth = "host", blend = "host" }
+
 local updateReport = companion:update(0.016, state)
 check(updateReport and updateReport.succeeded >= 1, "canonical update dispatch succeeds")
 equal(calls.world, 1, "initial world identity dispatches one snapshot")
@@ -492,6 +603,7 @@ equal(delta.positionDelta.y, 2, "canonical camera delta is returned")
 equal(delta.rotationDelta.yaw, 0.1, "camera rotation remains in radians")
 equal(delta.fovDelta, 0.04, "camera FOV delta remains in radians")
 
+local renderLogStart = #fakeVoxel3D.drawLog
 local renderReport = companion:render("background", state)
 check(renderReport, "background render dispatch returns a report")
 equal(renderReport.called, 3, "all active render extensions are called")
@@ -499,23 +611,24 @@ equal(renderReport.failed, 1, "one extension draw fault is contained")
 equal(renderReport.succeeded, 2, "later extensions render after an earlier fault")
 equal(calls.faultyDispose, 1, "faulted extension is disposed exactly once")
 equal(calls.healthyRender, 1, "healthy extension rendered")
-equal(fakeVoxel3D.drawLog[2].texture, borrowedTexture,
+equal(calls.borrowedMeshDraw.texture, borrowedTexture,
   "extension texture is passed directly to Voxel3D.draw")
 equal(calls.borrowedMeshCleared, true,
   "borrowed texture is unbound before draw.mesh returns")
 check(companion.texture ~= borrowedTexture,
   "extension texture is not retained as the adapter fallback")
 equal(borrowedTexture.releases, 0, "adapter does not release the borrowed texture")
-equal(fakeVoxel3D.drawLog[4].model[2][2], 1,
+equal(calls.collisionFirstModel[2][2], 1,
   "first same-key command uses its own declarative width")
-equal(fakeVoxel3D.drawLog[5].model[2][2], 1,
+equal(calls.collisionRepeatModel[2][2], 1,
   "an identical same-key command remains valid")
 equal(calls.collisionFirst, true, "first key and content pair is accepted")
 equal(calls.collisionRepeat, true, "same key and content pair is accepted again")
 equal(calls.collisionSecond, false, "same key with different content fails closed")
 contains(calls.collisionError, "content collision",
   "same-key content mismatch reports a collision")
-equal(#fakeVoxel3D.drawLog, 5, "colliding declarative content is not drawn")
+equal(#fakeVoxel3D.drawLog - renderLogStart, 5,
+  "colliding declarative content is not drawn")
 equal(fakeVoxel3D.glassState, true, "host shader selector is restored after draw fault")
 equal(pushCount, 1, "graphics state is pushed once for the phase")
 equal(popCount, 1, "graphics state is popped once for the phase")
@@ -530,6 +643,7 @@ local fixturePhaseIds = {
 }
 local fixtureTexture
 local fixtureValidated = 0
+local fixtureMeshPrimitives = {}
 for _, phase in ipairs({
   "background", "opaque_after_terrain", "translucent_after_actors",
 }) do
@@ -548,28 +662,58 @@ for _, phase in ipairs({
     equal(#content, 16, "KFP fixture content digest has sixteen lowercase hex digits")
     check(#command.cacheKey <= 64, "KFP fixture key stays within the host limit")
     if command.texture then fixtureTexture = command.texture end
+    if command.kind == "mesh" then
+      fixtureMeshPrimitives[command.geometry.primitive] = true
+    end
     fixtureValidated = fixtureValidated + 1
   end
 end
 equal(fixtureValidated, DrawFixture.commandCount,
   "shared fixture covers every declared baseline command")
+equal(DrawFixture.commandCount, 23,
+  "shared fixture locks the complete 23-command API baseline")
 equal(#DrawFixture.instancePrimitives, 15,
   "shared fixture covers every common instance primitive")
+for _, primitive in ipairs({
+  "box", "plane", "panorama", "cloud_layer", "rainbow", "world_apron",
+}) do
+  check(fixtureMeshPrimitives[primitive],
+    "shared fixture covers mesh primitive " .. primitive)
+end
 check(fixtureTexture, "shared fixture includes an opaque poster texture")
+fixtureTexture.releases = 0
+fixtureTexture.release = function(self) self.releases = self.releases + 1 end
 
 local fixtureRender = {}
+calls.fixturePrimitiveAccepted = {}
+calls.fixtureTextureCleared = true
 for _, phase in ipairs({
   "background", "opaque_after_terrain", "translucent_after_actors",
 }) do
   local phaseName = phase
   fixtureRender[phaseName] = function(context)
     for _, command in ipairs(DrawFixture.phases[phaseName]) do
+      local beforeDraws = #fakeVoxel3D.drawLog
       local accepted, drawError = context.draw[command.kind](command, context)
       if accepted ~= true then error(drawError or "fixture draw rejected", 0) end
       calls.fixtureAccepted = (calls.fixtureAccepted or 0) + 1
+      local primitive = command.geometry and command.geometry.primitive
+        or command.procedural and command.procedural.kind
+        or command.prototype and command.prototype.primitive
+        or "explicit_billboards"
+      calls.fixturePrimitiveAccepted[primitive] =
+        (calls.fixturePrimitiveAccepted[primitive] or 0) + 1
+      if command.procedural then
+        calls.fixtureStarsExpanded = (calls.fixtureStarsExpanded or 0)
+          + (#fakeVoxel3D.drawLog - beforeDraws)
+      end
       if command.texture then
-        calls.fixtureTextureCleared = fakeVoxel3D.drawLog[#fakeVoxel3D.drawLog]
-          .mesh.texture == nil
+        calls.fixtureTextureCleared = calls.fixtureTextureCleared
+          and fakeVoxel3D.drawLog[#fakeVoxel3D.drawLog].mesh.texture == nil
+        if primitive == "panorama" then
+          calls.panoramaTextureUsed = fakeVoxel3D.drawLog[#fakeVoxel3D.drawLog]
+            .texture == command.texture
+        end
       end
     end
   end
@@ -584,21 +728,43 @@ fixtureHandle, err = provider.register({
   render = fixtureRender,
 })
 check(fixtureHandle, err or "shared fixture extension registers")
-local fixtureBackground = companion:render("background", state)
-local fixtureOpaque = companion:render("opaque_after_terrain", state)
-local fixtureTranslucent = companion:render("translucent_after_actors", state)
-check(fixtureBackground and fixtureBackground.failed == 0,
-  "shared background mesh commands render")
-check(fixtureOpaque and fixtureOpaque.failed == 0,
-  "shared world apron and instance commands render")
-check(fixtureTranslucent and fixtureTranslucent.failed == 0,
-  "shared explicit billboard command renders")
-equal(calls.fixtureAccepted, DrawFixture.commandCount,
-  "host accepts every shared baseline fixture command")
+for pass = 1, 2 do
+  local fixtureBackground = companion:render("background", state)
+  local fixtureOpaque = companion:render("opaque_after_terrain", state)
+  local fixtureTranslucent = companion:render("translucent_after_actors", state)
+  check(fixtureBackground and fixtureBackground.failed == 0,
+    "shared background commands render on pass " .. pass)
+  check(fixtureOpaque and fixtureOpaque.failed == 0,
+    "shared world apron and instance commands render on pass " .. pass)
+  check(fixtureTranslucent and fixtureTranslucent.failed == 0,
+    "shared explicit billboard command renders on pass " .. pass)
+end
+equal(calls.fixtureAccepted, DrawFixture.commandCount * 2,
+  "host accepts and cache-validates every baseline command twice")
+for _, primitive in ipairs({ "panorama", "cloud_layer", "rainbow" }) do
+  equal(calls.fixturePrimitiveAccepted[primitive], 2,
+    primitive .. " is accepted with identical cached content twice")
+end
+equal(calls.fixturePrimitiveAccepted.stars, 2,
+  "procedural stars are accepted with identical cached content twice")
+equal(calls.fixtureStarsExpanded, 48,
+  "the fixture expands 24 deterministic stars on each pass")
+equal(calls.panoramaTextureUsed, true,
+  "panorama uses its callback-borrowed texture")
 equal(calls.fixtureTextureCleared, true,
-  "shared poster texture is unbound before the draw call returns")
+  "shared panorama and poster textures are unbound before return")
 check(companion.texture ~= fixtureTexture,
   "shared fixture texture is not retained as a host fallback")
+equal(fixtureTexture.releases, 0,
+  "shared panorama and poster texture is not released")
+check(#companion.meshes.panorama.vertices <= 128,
+  "panorama uses bounded host-owned geometry")
+check(#companion.meshes.cloud_layer.vertices <= 32,
+  "cloud layer uses bounded host-owned geometry")
+check(#companion.meshes.rainbow.vertices <= 96,
+  "rainbow uses bounded host-owned geometry")
+equal(companion.meshes.panorama.texture, nil,
+  "panorama mesh does not retain its borrowed texture")
 
 local lateUpdates = 0
 local late
@@ -622,6 +788,10 @@ companion:dispose("test-dispose")
 equal(calls.disposed, 1, "healthy extension is disposed exactly once")
 equal(borrowedTexture.releases, 0,
   "adapter never releases a borrowed texture during invalidation or disposal")
+equal(starTexture.releases, 0,
+  "adapter never releases a procedural-star texture during disposal")
+equal(fixtureTexture.releases, 0,
+  "adapter never releases shared panorama/poster texture during disposal")
 equal(companion.state, nil, "adapter drops retained world state on dispose")
 equal(companion.startContext, nil, "adapter drops retained activation context on dispose")
 equal(love.update, sentinelUpdate, "adapter does not replace global callbacks")

--- a/tests/voxel_companion_api_v1_test.lua
+++ b/tests/voxel_companion_api_v1_test.lua
@@ -1,0 +1,504 @@
+-- Focused standalone contract tests for the Voxel Companion API v1 host.
+
+local checks = 0
+
+local function check(value, message)
+  checks = checks + 1
+  if not value then error("FAIL: " .. message, 0) end
+end
+
+local function equal(actual, expected, message)
+  checks = checks + 1
+  if actual ~= expected then
+    error(("FAIL: %s (expected %s, got %s)")
+      :format(message, tostring(expected), tostring(actual)), 0)
+  end
+end
+
+local function contains(text, fragment, message)
+  check(type(text) == "string" and text:find(fragment, 1, true) ~= nil, message)
+end
+
+local API = assert(loadfile("lib/VoxelCompanionAPI.lua"))()
+equal(API.VERSION, 1, "vendored dispatcher reports API v1")
+
+local graphicsState = { color = "host", depth = "host", blend = "host" }
+local graphicsStack = {}
+local pushCount, popCount = 0, 0
+local sentinelUpdate = function() end
+
+love = {
+  update = sentinelUpdate,
+  system = { getOS = function() return "Windows" end },
+  image = {},
+  graphics = {},
+}
+
+function love.image.newImageData()
+  return { setPixel = function() end }
+end
+
+function love.graphics.newImage()
+  return {
+    setFilter = function() end,
+    release = function(self) self.released = true end,
+  }
+end
+
+function love.graphics.push(kind)
+  equal(kind, "all", "render isolation uses the full graphics state")
+  pushCount = pushCount + 1
+  graphicsStack[#graphicsStack + 1] = {
+    color = graphicsState.color,
+    depth = graphicsState.depth,
+    blend = graphicsState.blend,
+  }
+end
+
+function love.graphics.pop()
+  popCount = popCount + 1
+  local previous = table.remove(graphicsStack)
+  assert(previous, "unbalanced graphics pop")
+  graphicsState = previous
+end
+
+function love.graphics.setColor(r, g, b, a)
+  graphicsState.color = table.concat({ r, g, b, a }, ":")
+end
+
+function love.graphics.setDepthMode(mode, write)
+  graphicsState.depth = tostring(mode) .. ":" .. tostring(write)
+end
+
+function love.graphics.setBlendMode(mode, alpha)
+  graphicsState.blend = tostring(mode) .. ":" .. tostring(alpha)
+end
+
+local fakeVoxel3D = {
+  FACE_CORNERS = {},
+  FACE_SHADE = {},
+  eye = { 0, 16, 32 },
+  camera = {
+    eye = { 8, 12, 24 },
+    focus = { 8, 8, 8 },
+    up = { 0, 1, 0 },
+    fov = math.rad(65),
+  },
+  draws = 0,
+  glassState = true,
+  failNextDraw = false,
+}
+
+for direction = 1, 6 do
+  fakeVoxel3D.FACE_CORNERS[direction] = {
+    { 0, 0, 0 }, { 1, 0, 0 }, { 1, 1, 0 }, { 0, 1, 0 },
+  }
+  fakeVoxel3D.FACE_SHADE[direction] = 1
+end
+
+function fakeVoxel3D.pushQuad(indices, offset)
+  indices[#indices + 1] = offset
+end
+
+function fakeVoxel3D.newMesh(vertices, indices)
+  return {
+    vertices = vertices,
+    indices = indices,
+    release = function(self) self.released = true end,
+  }
+end
+
+function fakeVoxel3D.glass(enabled)
+  fakeVoxel3D.glassState = enabled
+end
+
+function fakeVoxel3D.draw()
+  fakeVoxel3D.draws = fakeVoxel3D.draws + 1
+  if fakeVoxel3D.failNextDraw then
+    fakeVoxel3D.failNextDraw = false
+    error("synthetic GPU draw failure", 0)
+  end
+end
+
+local fakeMat4 = {
+  mul = function(a, b) return { a, b } end,
+  translate = function(x, y, z) return { "translate", x, y, z } end,
+  scale = function(x, y, z) return { "scale", x, y, z } end,
+  rotateY = function(value) return { "rotateY", value } end,
+}
+
+local fakeVoxelState = {
+  isFirstPerson = function() return true end,
+  isThirdPerson = function() return false end,
+}
+
+local fakeDayNight
+fakeDayNight = {
+  period = "DAY",
+  isCanopy = function() return false end,
+  tod = function() return fakeDayNight.period end,
+  time = function() return 12.5 end,
+}
+
+local fakeShapes = {
+  [0] = { class = "grass", h = 0 },
+  [1] = { class = "wall", h = 8 },
+  [2] = { class = "tree", h = 12 },
+  [3] = { class = "water", h = 0 },
+}
+
+local fakeTileShape = {
+  forMap = function() return fakeShapes end,
+}
+
+local fakeMapModule = {
+  isOutdoor = function() return true end,
+}
+
+local fakeGame = { save = { version = "red" } }
+package.loaded["src.world.Map"] = fakeMapModule
+package.loaded["src.core.Game"] = fakeGame
+
+local function cleanMod()
+  local mod = { writes = 0, messages = {} }
+  function mod:read() return "-- clean upstream host\n" end
+  function mod:write()
+    self.writes = self.writes + 1
+    error("integrity scan must never write", 0)
+  end
+  mod.log = {
+    error = function(_, format, value)
+      mod.messages[#mod.messages + 1] = tostring(format):format(value)
+    end,
+  }
+  return mod
+end
+
+local function namespace(mod)
+  local modules = {
+    VoxelCompanionAPI = API,
+    Mat4 = fakeMat4,
+    TileShape = fakeTileShape,
+    VoxelState = fakeVoxelState,
+    Voxel3D = fakeVoxel3D,
+    DayNight = fakeDayNight,
+  }
+  return {
+    mod = mod,
+    require = function(name)
+      local value = modules[name]
+      assert(value, "unexpected module " .. tostring(name))
+      return value
+    end,
+  }
+end
+
+local function worldState()
+  local map = {
+    id = "PALLET_TOWN",
+    widthCells = 2,
+    heightCells = 2,
+    def = { width = 1, height = 1, tileset = "OVERWORLD" },
+    tileset = { id = "OVERWORLD", image = "overworld-atlas" },
+  }
+  function map:cellTile(x, z) return z * 2 + x end
+  function map:isWalkableCell(x, z) return not (x == 1 and z == 0) end
+  function map:isWaterCell(x, z) return x == 1 and z == 1 end
+  function map:isGrassCell(x, z) return x == 0 and z == 0 end
+  function map:warpAtCell(x, z)
+    return x == 0 and z == 1 and { target = "HOUSE" } or nil
+  end
+  function map:isWarpTileCell() return false end
+  local player = { id = "player", px = 0, py = 0, cellX = 0, cellY = 0,
+    facing = "down", gh = 0 }
+  return {
+    map = map,
+    player = player,
+    entities = {
+      player,
+      { id = "npc-1", kind = "npc", px = 16, py = 16,
+        cellX = 1, cellY = 1, facing = "up" },
+    },
+    neighbors = {},
+  }
+end
+
+local VoxelCompanion = assert(loadfile("lib/VoxelCompanion.lua"))(namespace(cleanMod()))
+local mod = cleanMod()
+local companion = VoxelCompanion.new({ mod = mod })
+local provider = companion.provider
+
+equal(provider.api, 1, "provider reports API v1")
+equal(provider.host.id, "BATTLE_ART_VOXEL_FORK", "provider reports stable host id")
+equal(provider.host.version, "1.9.7", "provider preserves upstream version")
+for _, capability in ipairs({
+  "world_snapshot", "camera_delta", "render_phases", "quality_tier",
+  "integrity_status",
+}) do
+  equal(provider.capabilities[capability], 1, "provider advertises " .. capability)
+end
+for _, capability in ipairs({
+  "terrain_patch", "shadow_pass", "battle_pass", "materials", "draw",
+}) do
+  equal(provider.capabilities[capability], nil,
+    "provider does not over-advertise " .. capability)
+end
+equal(mod.writes, 0, "clean integrity scan is read-only")
+
+local calls = {
+  world = 0,
+  update = 0,
+  healthyRender = 0,
+  faultyDispose = 0,
+  invalidated = 0,
+  disposed = 0,
+}
+
+local faulty, err = provider.register({
+  api = 1,
+  id = "test.draw-fault",
+  priority = 0,
+  requires = { "render_phases" },
+  render = {
+    background = function(context)
+      love.graphics.setColor(0.1, 0.2, 0.3, 0.4)
+      fakeVoxel3D.failNextDraw = true
+      context.draw:mesh({
+        geometry = { primitive = "box", width = 1, height = 1, depth = 1 },
+        material = "test:fault",
+      })
+    end,
+  },
+  dispose = function() calls.faultyDispose = calls.faultyDispose + 1 end,
+})
+check(faulty, err or "fault extension registers")
+
+local healthy
+healthy, err = provider.register({
+  api = 1,
+  id = "test.kfp-like",
+  priority = 10,
+  requires = {
+    "world_snapshot", "camera_delta", "render_phases", "quality_tier",
+  },
+  optional = {
+    "terrain_patch", "shadow_pass", "battle_pass", "integrity_status",
+  },
+  attach = function(services)
+    equal(services.quality:getTier(), "BALANCED", "quality facade returns canonical tier")
+    local status = services.integrity:status()
+    check(status.clean and not status.legacyMarkers, "integrity facade reports a clean host")
+  end,
+  worldChanged = function(snapshot)
+    calls.world = calls.world + 1
+    calls.worldId = snapshot.id
+    calls.worldRevision = snapshot.revision
+    calls.cellCount = #snapshot.cells
+  end,
+  update = function(frame)
+    calls.update = calls.update + 1
+    calls.quality = frame.qualityTier
+    calls.dt = frame.dt
+  end,
+  modifyCamera = function(camera)
+    equal(camera.mode, "first_person", "camera callback gets the canonical camera")
+    return {
+      positionDelta = { x = 1, y = 2, z = 3 },
+      rotationDelta = { yaw = 0.1, pitch = -0.02, roll = 0 },
+      fovDelta = 0.04,
+    }
+  end,
+  render = {
+    background = function(context)
+      calls.healthyRender = calls.healthyRender + 1
+      context.draw:mesh({
+        geometry = { primitive = "box", x = 8, y = 4, z = 8,
+          width = 2, height = 3, depth = 2 },
+        material = "test:healthy",
+      })
+      context.draw:mesh({
+        geometry = { primitive = "world_apron", width = 32, depth = 32,
+          skirtDepth = 16 },
+        material = "world:apron",
+      })
+    end,
+  },
+  invalidate = function(reason)
+    calls.invalidated = calls.invalidated + 1
+    calls.invalidateReason = reason
+  end,
+  dispose = function() calls.disposed = calls.disposed + 1 end,
+})
+check(healthy, err or "KFP-like extension registers")
+
+local shadow
+shadow, err = provider.register({
+  api = 1,
+  id = "test.flat-shadow",
+  render = { shadow_casters = function() end },
+})
+equal(shadow, nil, "flat shadow callback is refused")
+contains(err, "shadow_pass", "flat shadow refusal explains the missing capability")
+
+local battle
+battle, err = provider.register({
+  api = 1,
+  id = "test.flat-battle",
+  render = { battle_opaque = function() end },
+})
+equal(battle, nil, "flat battle callback is refused")
+contains(err, "battle_pass", "flat battle refusal explains the missing capability")
+
+local nested
+nested, err = provider.register({
+  api = 1,
+  id = "test.nested-shadow",
+  phases = { shadow_casters = function() end },
+})
+equal(nested, nil, "legacy nested shadow callback is refused")
+contains(err, "shadow_pass", "nested shadow refusal explains the missing capability")
+
+check(companion:start(), "host dispatcher starts")
+local state = worldState()
+local updateReport = companion:update(0.016, state)
+check(updateReport and updateReport.succeeded >= 1, "canonical update dispatch succeeds")
+equal(calls.world, 1, "initial world identity dispatches one snapshot")
+equal(calls.worldId, "PALLET_TOWN", "worldChanged receives the direct snapshot")
+equal(calls.cellCount, 4, "world snapshot contains the real map cells")
+equal(calls.quality, "BALANCED", "update receives the direct canonical frame")
+equal(calls.dt, 0.016, "update frame retains bounded delta time")
+
+local firstSnapshot = assert(companion.world.snapshot())
+equal(firstSnapshot.game, "red", "snapshot reports the real Gen 1 game")
+check(firstSnapshot.tags.outdoor, "snapshot derives outdoor map tags")
+check(firstSnapshot.cells[1].tags.grass, "snapshot derives grass cell tags")
+check(firstSnapshot.cells[3].tags.door, "snapshot derives warp cell tags")
+check(firstSnapshot.cells[4].tags.water, "snapshot derives water cell tags")
+firstSnapshot.cells[1].kind = "corrupted-copy"
+equal(companion.world.snapshot().cells[1].kind, "grass",
+  "snapshot facade returns defensive copies")
+
+state.player.px, state.player.py = 16, 16
+state.player.cellX, state.player.cellY = 1, 1
+companion:update(0.016, state)
+equal(calls.world, 1, "player movement does not rebuild the whole world snapshot")
+
+local beforeRevision = companion.revision
+companion:worldChanged("first-edit")
+companion:worldChanged("second-edit")
+equal(companion.revision, beforeRevision + 1,
+  "multiple block edits coalesce into one world revision")
+companion:update(0.016, state)
+equal(calls.world, 2, "coalesced edits dispatch one replacement snapshot")
+
+local delta = companion:cameraDelta(state)
+equal(delta.positionDelta.y, 2, "canonical camera delta is returned")
+equal(delta.rotationDelta.yaw, 0.1, "camera rotation remains in radians")
+equal(delta.fovDelta, 0.04, "camera FOV delta remains in radians")
+
+local renderReport = companion:render("background", state)
+check(renderReport, "background render dispatch returns a report")
+equal(renderReport.called, 2, "both active render extensions are called")
+equal(renderReport.failed, 1, "one extension draw fault is contained")
+equal(renderReport.succeeded, 1, "later extension renders after an earlier fault")
+equal(calls.faultyDispose, 1, "faulted extension is disposed exactly once")
+equal(calls.healthyRender, 1, "healthy extension rendered")
+equal(fakeVoxel3D.glassState, true, "host shader selector is restored after draw fault")
+equal(pushCount, 1, "graphics state is pushed once for the phase")
+equal(popCount, 1, "graphics state is popped once for the phase")
+equal(graphicsState.color, "host", "graphics color state is restored")
+equal(graphicsState.depth, "host", "graphics depth state is restored")
+equal(graphicsState.blend, "host", "graphics blend state is restored")
+
+local lateUpdates = 0
+local late
+late, err = provider.register({
+  api = 1,
+  id = "test.late-registration",
+  update = function(frame)
+    check(frame.dt >= 0, "late extension receives the canonical frame")
+    lateUpdates = lateUpdates + 1
+  end,
+})
+check(late, err or "late registration joins a running dispatcher")
+check(late:is_active(), "late registration is active without a private context argument")
+companion:update(0.02, state)
+equal(lateUpdates, 1, "late extension runs on the next update")
+
+companion:invalidate("test-invalidate")
+equal(calls.invalidated, 1, "host invalidation reaches the healthy extension")
+equal(calls.invalidateReason, "test-invalidate", "invalidation reason is canonical")
+companion:dispose("test-dispose")
+equal(calls.disposed, 1, "healthy extension is disposed exactly once")
+equal(companion.state, nil, "adapter drops retained world state on dispose")
+equal(companion.startContext, nil, "adapter drops retained activation context on dispose")
+equal(love.update, sentinelUpdate, "adapter does not replace global callbacks")
+
+local legacyMod = cleanMod()
+local contaminated = false
+function legacyMod:read(path)
+  if contaminated and path == "lib/VoxelScene.lua" then
+    return "local function __dsMod(name, statusKey) end\n"
+  end
+  return "-- clean\n"
+end
+local LegacyCompanion = assert(loadfile("lib/VoxelCompanion.lua"))(namespace(legacyMod))
+local legacy = LegacyCompanion.new({ mod = legacyMod })
+contaminated = true
+local refused
+refused, err = legacy.provider.register({
+  api = 1,
+  id = "test.must-refuse",
+  update = function() end,
+})
+equal(refused, nil, "legacy-spliced host refuses companion registration")
+contains(err, "legacy KFP splice markers detected in lib/VoxelScene.lua",
+  "legacy refusal names the exact contaminated target")
+contains(err, "reinstall a clean voxel host", "legacy refusal gives the recovery action")
+equal(legacyMod.writes, 0, "legacy refusal scan never edits host files")
+
+local cameraMat4 = { captured = {} }
+function cameraMat4.identity() return { "identity" } end
+function cameraMat4.perspective(fov, aspect, nearPlane, farPlane)
+  cameraMat4.captured.fov = fov
+  cameraMat4.captured.aspect = aspect
+  return { "projection", nearPlane, farPlane }
+end
+function cameraMat4.lookAt(eye, focus, up)
+  cameraMat4.captured.eye = eye
+  cameraMat4.captured.focus = focus
+  cameraMat4.captured.up = up
+  return { "view" }
+end
+function cameraMat4.scale(x, y, z) return { "scale", x, y, z } end
+function cameraMat4.mul(a, b) return { a, b } end
+
+local cameraNamespace = {
+  require = function(name)
+    if name == "Mat4" then return cameraMat4 end
+    if name == "VoxelState" then return { angle = 0, FOCAL = 1 } end
+    return {}
+  end,
+}
+local RealVoxel3D = assert(loadfile("lib/Voxel3D.lua"))(cameraNamespace)
+RealVoxel3D.camera = {
+  eye = { 0, 0, 0 },
+  focus = { 0, 0, 10 },
+  up = { 0, 1, 0 },
+  fov = 1,
+}
+RealVoxel3D.setCompanionCameraDelta({
+  positionDelta = { x = 100, y = 2, z = 0 },
+  rotationDelta = { yaw = 0.1, pitch = 0, roll = 0 },
+  fovDelta = 10,
+})
+RealVoxel3D.viewProjection(0, 0, 160, 144)
+equal(cameraMat4.captured.eye[1], 32, "camera position delta is bounded")
+equal(cameraMat4.captured.eye[2], 2, "camera position delta is additive")
+check(cameraMat4.captured.focus[1] > cameraMat4.captured.eye[1],
+  "radian yaw rotates the host focus direction")
+local expectedFov = 1 + math.rad(30)
+check(math.abs(cameraMat4.captured.fov - expectedFov) < 1e-9,
+  "large FOV deltas are radian values bounded at the host boundary")
+
+print(("%d checks passed (Voxel Companion API v1 BATTLE_ART host)"):format(checks))

--- a/tests/voxel_companion_api_v1_test.lua
+++ b/tests/voxel_companion_api_v1_test.lua
@@ -1105,24 +1105,39 @@ check(companion.texture ~= fixtureTexture,
   "shared fixture texture is not retained as a host fallback")
 equal(fixtureTexture.releases, 0,
   "shared panorama, cloud, and poster texture is not released")
-check(#companion.meshes.panorama.vertices <= 128,
-  "panorama uses bounded host-owned geometry")
+check(#companion.meshes.panorama_deep.vertices <= 256,
+  "deep panorama uses bounded host-owned band and skirt geometry")
 check(#companion.meshes.cloud_layer.vertices <= 32,
   "cloud layer uses bounded host-owned geometry")
 check(#companion.meshes.rainbow.vertices <= 96,
   "rainbow uses bounded host-owned geometry")
-equal(companion.meshes.panorama.texture, nil,
-  "panorama mesh does not retain its borrowed texture")
+equal(companion.meshes.panorama_deep.texture, nil,
+  "deep panorama mesh does not retain its borrowed texture")
 local panoramaTranslation = findTagged(calls.fixtureModels.panorama, "translate")[1]
 local panoramaScale = findTagged(calls.fixtureModels.panorama, "scale")[1]
-equal(panoramaTranslation[3], -550,
-  "deep panorama retains the released vertical midpoint")
+equal(panoramaTranslation[3], 0,
+  "deep panorama keeps authored vertical positions in its mesh")
 equal(panoramaScale[2], 1800,
   "panorama diameter is fixed physical geometry, not texture resolution")
-equal(panoramaScale[3], 1700,
-  "deep panorama retains the released top and skirt bounds")
+equal(panoramaScale[3], 1,
+  "panorama model does not stretch the authored vertical band")
 equal(panoramaScale[4], 1800,
   "panorama depth uses the fixed physical diameter")
+local deepVertices = companion.meshes.panorama_deep.vertices
+equal(#deepVertices, 32 * 8,
+  "deep panorama has one band quad and one skirt quad per segment")
+for index, vertex in ipairs(deepVertices) do
+  local y, v = vertex[2], vertex[5]
+  if index <= 32 * 4 then
+    check((y == -120 and v == 1) or (y == 300 and v == 0),
+      "authored panorama band retains its full vertical UV range")
+  else
+    check(y == -1400 or y == -120,
+      "deep panorama skirt retains the released vertical bounds")
+    equal(v, 1,
+      "deep panorama skirt samples only the texture bottom row")
+  end
+end
 local cloudTranslation = findTagged(calls.fixtureModels.cloud_layer, "translate")[1]
 local cloudScale = findTagged(calls.fixtureModels.cloud_layer, "scale")[1]
 check(cloudTranslation[3] >= 200,
@@ -1148,7 +1163,7 @@ for index, width in ipairs({ 4096, 1024 }) do
     texture = fixtureTexture,
     geometry = {
       primitive = "panorama", sourceWidth = width, targetWidth = width,
-      deepSkirt = true, distanceHaze = true,
+      deepSkirt = index == 1, distanceHaze = true,
     },
   })
   local before = #fakeVoxel3D.drawLog
@@ -1161,6 +1176,10 @@ for index, width in ipairs({ 4096, 1024 }) do
 end
 equal(treeSignature(panoramaModels[1]), treeSignature(panoramaModels[2]),
   "panorama world geometry is independent of texture quality width")
+check(#companion.meshes.panorama.vertices <= 128,
+  "normal panorama uses one bounded authored-band cylinder")
+equal(companion.meshes.panorama.texture, nil,
+  "normal panorama mesh does not retain its borrowed texture")
 
 -- KFP marks both its ceiling and synthesized room walls with one cutaway
 -- intent. The host applies that intent only in first person and only near the

--- a/tests/voxel_companion_api_v1_test.lua
+++ b/tests/voxel_companion_api_v1_test.lua
@@ -186,9 +186,10 @@ local fakeMat4 = {
   rotateY = function(value) return { "rotateY", value } end,
 }
 
+local fakeCameraMode = "first_person"
 local fakeVoxelState = {
-  isFirstPerson = function() return true end,
-  isThirdPerson = function() return false end,
+  isFirstPerson = function() return fakeCameraMode == "first_person" end,
+  isThirdPerson = function() return fakeCameraMode == "third_person" end,
 }
 
 local fakeDayNight
@@ -1028,6 +1029,103 @@ check(#companion.meshes.rainbow.vertices <= 96,
   "rainbow uses bounded host-owned geometry")
 equal(companion.meshes.panorama.texture, nil,
   "panorama mesh does not retain its borrowed texture")
+
+-- KFP marks both its ceiling and synthesized room walls with one cutaway
+-- intent. The host applies that intent only in first person and only near the
+-- player. The public callback camera mode is the authoritative mode source.
+local cutawayResults = {}
+local cutawayHandle
+cutawayHandle, err = provider.register({
+  api = 1,
+  id = "test.kfp-cutaway",
+  priority = 40,
+  requires = { "render_phases" },
+  render = {
+    opaque_after_terrain = function(context)
+      local mode = context.camera.mode
+      local result = { contextMode = mode }
+      cutawayResults[mode] = result
+
+      local function draw(label, sequence, prototype, items)
+        local before = #fakeVoxel3D.drawLog
+        local accepted, drawError = context.draw.instances(wireCommand(
+          "instances", "opaque_after_terrain", sequence, {
+            cacheKey = "test.kfp-cutaway:" .. label,
+            prototype = prototype,
+            items = items,
+          }), context)
+        if not accepted then error(drawError, 0) end
+        result[label] = #fakeVoxel3D.drawLog - before
+      end
+
+      local cells = {
+        { x = 16, y = 24, z = 16, cellX = 1, cellZ = 1 },
+        { x = 80, y = 24, z = 80, cellX = 5, cellZ = 5 },
+        { x = 96, y = 24, z = 16, cellX = 6, cellZ = 1 },
+      }
+      draw("ceiling", 101, {
+        primitive = "box", width = 16, height = 1, depth = 16,
+        cutaway = true, role = "ceiling",
+      }, cells)
+      draw("wall", 102, {
+        primitive = "box", width = 1, height = 24, depth = 16,
+        cutaway = true, role = "wall",
+      }, cells)
+      draw("ceiling-disabled", 103, {
+        primitive = "box", width = 16, height = 1, depth = 16,
+        cutaway = false, role = "ceiling",
+      }, { cells[1] })
+      draw("wall-disabled", 104, {
+        primitive = "box", width = 1, height = 24, depth = 16,
+        cutaway = false, role = "wall",
+      }, { cells[1] })
+      draw("other-role", 105, {
+        primitive = "box", width = 1, height = 24, depth = 16,
+        cutaway = true, role = "door",
+      }, { cells[1] })
+      draw("missing-cell", 106, {
+        primitive = "box", width = 1, height = 24, depth = 16,
+        cutaway = true, role = "wall",
+      }, { { x = 16, y = 24, z = 16 } })
+    end,
+  },
+})
+check(cutawayHandle, err or "KFP cutaway probe registers")
+
+for _, mode in ipairs({ "first_person", "third_person", "diorama" }) do
+  fakeCameraMode = mode
+  local report = companion:render("opaque_after_terrain", state)
+  local cutawayStatus = cutawayHandle:status()
+  check(report and report.failed == 0,
+    "KFP cutaway probe renders in " .. mode .. ": "
+      .. tostring(cutawayStatus.fault and cutawayStatus.fault.message))
+  equal(cutawayResults[mode].contextMode, mode,
+    "cutaway reads the public callback camera mode in " .. mode)
+end
+
+equal(cutawayResults.first_person.ceiling, 1,
+  "first-person cutaway removes nearby and radius-boundary ceilings")
+equal(cutawayResults.first_person.wall, 1,
+  "first-person cutaway removes nearby and radius-boundary walls")
+equal(cutawayResults.first_person["ceiling-disabled"], 1,
+  "cutaway=false preserves a nearby first-person ceiling")
+equal(cutawayResults.first_person["wall-disabled"], 1,
+  "cutaway=false preserves a nearby first-person wall")
+equal(cutawayResults.first_person["other-role"], 1,
+  "cutaway does not suppress a different semantic role")
+equal(cutawayResults.first_person["missing-cell"], 1,
+  "cutaway fails open when an item has no cell position")
+for _, mode in ipairs({ "third_person", "diorama" }) do
+  equal(cutawayResults[mode].ceiling, 3,
+    mode .. " preserves all ceiling cells")
+  equal(cutawayResults[mode].wall, 3,
+    mode .. " preserves all wall cells")
+  equal(cutawayResults[mode]["ceiling-disabled"], 1,
+    mode .. " preserves cutaway=false ceilings")
+  equal(cutawayResults[mode]["wall-disabled"], 1,
+    mode .. " preserves cutaway=false walls")
+end
+fakeCameraMode = "first_person"
 
 local lateUpdates = 0
 local late


### PR DESCRIPTION
## Summary

Adds Voxel Companion API v1 support for Kanto First Person 2.0 without patching or reading another mod's files.

## Runtime changes

- Exports the versioned `voxel_companion` provider.
- Keeps Battle Art as the only world renderer.
- Adds bounded background, post-terrain, and post-actor extension phases.
- Normalizes world snapshots and additive camera deltas.
- Isolates extension faults and restores graphics state.
- Uses bounded host-owned caches with exact-once release.
- Refuses known legacy KFP splice markers without modifying files.
- Supports the frozen ROM-free draw fixture and conservative sky baseline.

## Scope

The adapter advertises only capabilities it implements: `world_snapshot`, `camera_delta`, `render_phases`, `quality_tier`, and `integrity_status`. Terrain patches, shadow passes, and battle passes are not claimed.

## Verification

- 660 focused host checks pass.
- All changed Lua chunks compile under LuaJIT.
- The vendored dispatcher matches the KFP reference implementation.
- `git diff --check` passes.
- Manifest ID and version remain unchanged.

## Remaining owner gates

Please review the integration, choose the host release version, and run an in-game GPU smoke test before release. This PR does not publish KFP or bundle ROM-derived data.