### PR TITLE
feat(companion): add visual-object overrides for signs

### DIFF
--- a/docs/VOXEL_COMPANION_API_V1_HOST.md
+++ b/docs/VOXEL_COMPANION_API_V1_HOST.md
@@ -17,6 +17,10 @@
 - Frozen Voxel Companion API reference dispatcher: byte-exact SHA-256
   `6FDED9C804298AB064DB61B908382BE7C9A74AD29D611444C33E1BCC53A33D26`.
 
+`lib/VoxelCompanionAPI.lua` remains the exact frozen Git artifact. Battle Art's
+optional visual-object capability is implemented by `lib/VoxelVisualObjects.lua`
+and the adapter wrapper in `lib/VoxelCompanion.lua`.
+
 The integration does not change the upstream mod identifier, manifest version,
 load priority, permissions, conflicts, or package layout. The existing package
 scripts include all files under `lib`, so they include the adapter and vendored
@@ -61,9 +65,10 @@ The adapter uses only existing host-owned seams:
 6. `translucent_after_actors` runs after host actors, water, grass, and flowers
    and before the scene resolves.
 
-The adapter does not enter `ShadowMap` or `BattleScene`. It does not replace or
-mutate base terrain. The optional visual-object contract can suppress only the
-annotated visual quads of a claimed signpost.
+The adapter does not add a companion shadow or battle callback. It does not
+mutate map, game, collision, or interaction data. The terrain cache routes only
+annotated sign quads into small host-owned sidecars. The existing terrain and
+shadow passes draw those sidecars.
 
 ## World snapshot
 
@@ -80,7 +85,9 @@ Hard limits are:
 - 8 neighbors
 - 4,096 visual objects or claims
 
-The public facade returns defensive plain-data copies. Snapshot construction is
+The public facade returns defensive plain-data copies. Each companion callback
+gets its own copied visual descriptors, so nested writes by one companion cannot
+change a later callback or the host catalog. Snapshot construction is
 protected by one outer fault boundary. It does not use a protected call for
 each cell query. This keeps map-change work bounded without adding several
 protected calls per cell. Player movement does not rebuild the full map.
@@ -136,21 +143,28 @@ connection offset. First-person and third-person use the same descriptor and
 the same opaque render seam.
 
 IDs contain safe ASCII only and are stable for host, kind, map, and cell. The
-host accepts claims only for IDs in the current copied catalog. Duplicate,
-unknown, malformed, or render-ineligible claims clear that extension's claims.
-If two live extensions request one ID, the object has no owner until the
-conflict is removed. Thus a conflict keeps the original visible instead of
-selecting a registration-order winner. Other non-conflicting objects keep their
+host accepts claims only for IDs in the current copied catalog. Every claim call
+is transactional. A duplicate, unknown, malformed, render-ineligible, or
+conflicting call changes no accepted claim and no current or future owner. A
+rejected contender is never pending. Other non-conflicting objects keep their
 unique owners.
 
-Only a uniquely owned signpost's annotated visual quads are omitted. Ground,
-collision, interaction, map and game data, actors, and unrelated snapshot data
-do not change. Active overrides bypass persistent terrain records. Ownership
-changes refresh only the named map's full and body terrain slots; auxiliary
-grass, flowers, figures, structure analysis, and canonical disk records stay
-intact. Invalidate, fault cleanup, handle disposal, host disposal, or unload
-removes only the affected extension's claims. Existing lifecycle cleanup still
-owns extension resources, and repeated cleanup is safe.
+Only a uniquely owned signpost's color sidecar is omitted. Ground, collision,
+interaction, map and game data, actors, and unrelated snapshot data do not
+change. Full and body terrain variants cache the base terrain and their matching
+per-object sidecars together. An ownership change selects the ready sidecar in
+the same update; it does not rebuild terrain, blank unrelated geometry, or wait
+for a later pump. Annotated maps bypass older persistent terrain records because
+those records contain the sign quads. Auxiliary grass, flowers, figures, and
+structure analysis stay intact. Invalidate, fault cleanup, handle disposal,
+host disposal, or unload removes only the affected extension's claims. Existing
+lifecycle cleanup still owns extension resources, and repeated cleanup is safe.
+
+The public provider does not advertise `shadow_pass`. Therefore, a replacement
+cannot submit its own caster. While a claim is active, the original sign sidecar
+continues in the existing host shadow pass but is omitted from the color pass.
+This preserves the advertised `castsShadow = true` behavior without a new public
+shadow API. The descriptor's shadow flag describes this retained host caster.
 
 ### Semantic density-tag contract
 
@@ -343,24 +357,26 @@ rejection, and bounded mountain seed, support, roof, door, and connection
 policies.
 
 The focused checks also cover stable signpost IDs and transforms, current and
-neighbor mapping, defensive descriptor copies, same-transform replacement,
-first-person and third-person integration, original-quad suppression,
-malformed and unknown claims, duplicate and conflicting ownership, and
-invalidate/dispose restoration.
+neighbor mapping, two-companion nested mutation isolation, same-transform
+replacement, first-person and third-person integration, transactional malformed,
+unknown, duplicate, and conflicting claims, and invalidate/dispose restoration.
+The ROM-free integration test uses a sign annotated by `Structures`, builds and
+reads real full/body `ChunkMesher` cache variants, checks immediate ownership
+transitions without a pump, and verifies the retained shadow caster.
 
-The canonical KFP dispatcher conformance command is:
+The upstream KFP dispatcher conformance command is:
 
 ```text
 luajit tools\run_tests.lua companion
 ```
 
-At integration time, the lifecycle test passed 11 checks, the focused host
-test passed 2,706 checks, the visual-object terrain filter passed 7 checks,
-the canonical
-companion selector passed 54 tests, and the complete KFP suite passed 227
-tests. The complete 23-command ROM-free draw fixture has canonical LF SHA-256
+In this repository, the lifecycle test passes 11 checks, the focused host test
+passes 2,712 checks, and the ROM-free cache-transition integration test passes
+1,156 checks. The `tools/run_tests.lua` selector is not present here, so no KFP
+selector or complete KFP-suite result is claimed for this change. The complete
+23-command ROM-free draw fixture keeps canonical LF SHA-256
 `DE1DCA98A04AD9446B0AF4C13523DAB7F365BC7A76E70BC44B24F323D98A9BFA`.
-All changed Lua files also compiled with LuaJIT. The large upstream
+The changed Lua files compile with LuaJIT. The large upstream
 `tests/battle_art_voxel_fork_test.lua` cannot compile as one LuaJIT chunk
 because its main function already exceeds LuaJIT's 200-local limit. This is an
 upstream test-harness limit, not a companion adapter failure.

--- a/docs/VOXEL_COMPANION_API_V1_HOST.md
+++ b/docs/VOXEL_COMPANION_API_V1_HOST.md
@@ -94,18 +94,26 @@ protected calls per cell. Player movement does not rebuild the full map.
 
 ### Visual-object override extension
 
-`visual_object_overrides` is one optional Battle Art extension to API v1. It
-adds `snapshot.visualObjects` and exactly one registration method on the
-existing extension handle:
+`visual_object_overrides` is one optional Battle Art extension to API v1. The
+provider advertises extension version `2`. It adds
+`snapshot.visualObjects`, one registration method on the existing extension
+handle, and one method on the callback-borrowed draw facade:
 
 ```lua
 local ok, err = handle:claim_visual_objects({ objectId, anotherObjectId })
+
+local drawn, drawErr = context.draw.visual_object(command, context)
 ```
 
-It does not add a scene API, a mesh handle, or another draw path. A claimant
-must already have an `opaque_after_terrain` render handler. That handler renders
-the replacement with the existing borrowed `context.draw` facade. A companion
-can call the claim method during its own `worldChanged` callback, or outside a
+Version `1` claims remain compatible. Version `2` adds the bounded declarative
+draw method. It does not add a scene API, mesh handle, renderer handle, texture,
+font, model resource, shader, or another render phase. A claimant must already
+have an `opaque_after_terrain` render handler. It can call the draw method only
+in that handler and only for an object that it uniquely owns. The method returns
+exactly `true`, or `false, error`. It does not retain the command.
+
+A companion can call the claim method during its own flat `worldChanged`
+callback, during the equivalent `phases.map_changed` callback, or outside a
 dispatcher callback. An empty array releases its claims.
 
 Each descriptor is defensive plain data with this shape:
@@ -135,12 +143,112 @@ Each descriptor is defensive plain data with this shape:
 }
 ```
 
-The position is the bottom-center pivot of the host signpost envelope. A box
-replacement therefore uses `worldPosition.x`, `worldPosition.z`, and
-`worldPosition.y + dimensions.height / 2`. Neighbor descriptors keep the same
+The position is the bottom-center pivot of the host signpost envelope. A legacy
+version 1 manual box draw uses `worldPosition.x`, `worldPosition.z`, and
+`worldPosition.y + dimensions.height / 2`. A version 2 command can use local
+position zero and `bottom_center`; the host applies the transform. Neighbor descriptors keep the same
 stable map-and-cell ID and local transform. Their world transform includes the
 connection offset. First-person and third-person use the same descriptor and
 the same opaque render seam.
+
+### Bounded replacement command
+
+The draw command is plain declarative data:
+
+```lua
+{
+  schemaVersion = 1,
+  kind = "visual_object_replacement",
+  objectId = descriptor.id,
+  geometry = {
+    {
+      shape = "box",
+      position = { x = 0, y = 0, z = 0 },
+      rotation = { yaw = 0, pitch = 0, roll = 0 },
+      scale = { x = 1, y = 1, z = 1 },
+      pivot = "bottom_center",
+      dimensions = { width = 16, height = 12, depth = 2 },
+      material = { color = { 0.55, 0.32, 0.16, 1 } },
+    },
+  },
+  text = {
+    {
+      value = "PALLET TOWN",
+      encoding = "ascii-5x7",
+      position = { x = 0, y = 4, z = 1.1 },
+      rotation = { yaw = 0, pitch = 0, roll = 0 },
+      scale = { x = 0.2, y = 0.2, z = 1 },
+      orientation = "object",
+      align = "center",
+      material = { color = { 1, 1, 1, 1 } },
+    },
+  },
+}
+```
+
+Both arrays are required. Either array can be empty, but the command must have
+at least one geometry or text item. One command accepts at most 64 geometry
+items, four text items, and 2,048 expanded host primitives.
+
+Geometry accepts only `box` and `plane`. A box has positive `width`, `height`,
+and `depth`. A plane has positive `width` and `height`, lies in its local X/Y
+plane, and uses only the `center` pivot. A box uses `center` or
+`bottom_center`. There are no vertices, indices, mesh data, textures, resource
+paths, or model references.
+
+All command positions are descriptor-local and each axis is from -256 through
+256. Rotation uses radians in yaw-Y, pitch-X, roll-Z order. Each rotation is
+from -2 pi through 2 pi. Scale is positive and no axis can exceed 64. Each raw
+dimension is positive and no greater than 256. Each scaled span is no greater
+than 256. The final conservative transformed bound cannot exceed 65,536 world
+units. The host applies:
+
+```text
+descriptor translation * yaw * pitch * roll * positive scale
+* item translation * yaw * pitch * roll * positive scale
+* item pivot * dimensions
+```
+
+The material has exactly one field: `color`. It has four finite RGBA channels
+from 0 through 1. Alpha must be 1 because replacements use the opaque phase.
+
+Text uses the host-owned fixed 5x7 glyph set. `encoding` must be
+`ascii-5x7`. A value is 1 through 64 bytes and accepts only uppercase `A-Z`,
+digits `0-9`, space, hyphen, period, colon, apostrophe, slash, and ampersand.
+Line breaks, control bytes, lowercase text, Unicode, all-space text, and
+external font or file references fail closed. Text uses a fixed one-unit pixel,
+one-unit gap, seven-unit height, and 0.125-unit local depth before its declared
+scale. `position` is the bottom text anchor. `align` is `left`, `center`, or
+`right`.
+
+`orientation = "object"` applies the full descriptor and text rotations.
+`orientation = "billboard_yaw"` keeps the fully transformed anchor and positive
+descriptor/text scale, faces the camera only around world Y, and permits a text
+yaw offset. Billboard pitch and roll must be zero. It does not retain the
+camera or context.
+
+Malformed tables, unknown fields, metatables, non-finite numbers, out-of-range
+transforms, non-positive scale, bad material data, unsupported glyphs, unknown
+IDs, unowned IDs, and calls outside the owner callback return `false, error`
+before they submit geometry. The public handle has no enumerable host,
+dispatcher, record, mesh, renderer, scene, texture, font, model, or shader
+state.
+
+### PokePath handoff
+
+PokePath must require `visual_object_overrides` and check that the provider
+value is at least `2` before it uses `draw.visual_object`. On every
+`worldChanged` or `phases.map_changed` callback, it must refresh its copied
+descriptor list and claim only the stable sign IDs that it will replace. It
+must use each descriptor ID as `objectId`; the host, not PokePath, applies the
+current or neighbor world transform.
+
+In `opaque_after_terrain`, PokePath can submit a small box-built Pallet sign and
+the bounded `PALLET TOWN` text shown above. It must inspect each Boolean draw
+result and treat a rejection as a failed replacement draw. It must submit an
+empty claim list when it no longer replaces the objects. It must not supply a
+PokePath asset, texture, font, mesh, model, shader, scene object, file path, or
+private engine value through this contract.
 
 IDs contain safe ASCII only and are stable for host, kind, map, and cell. The
 host accepts claims only for IDs in the current copied catalog. Every claim call
@@ -157,7 +265,7 @@ the same update; it does not rebuild terrain, blank unrelated geometry, or wait
 for a later pump. Annotated maps bypass older persistent terrain records because
 those records contain the sign quads. Auxiliary grass, flowers, figures, and
 structure analysis stay intact. Invalidate, fault cleanup, handle disposal,
-host disposal, or unload removes only the affected extension's claims. Existing
+host disposal, or hook uninstall removes only the affected extension's claims. Existing
 lifecycle cleanup still owns extension resources, and repeated cleanup is safe.
 
 The public provider does not advertise `shadow_pass`. Therefore, a replacement
@@ -203,7 +311,7 @@ consumes these normalized roles and does not inspect host or engine internals.
 
 ## Draw adapter and safety
 
-The draw facade implements the three v1 draw methods:
+The draw facade implements the three baseline v1 draw methods:
 
 - `mesh` for box, plane, centered world apron, panorama, cloud layer, and
   rainbow geometry
@@ -212,6 +320,10 @@ The draw facade implements the three v1 draw methods:
   mountain, and hood prototypes
 - `billboards` for bounded explicit camera-facing items and deterministic
   procedural stars
+
+When `visual_object_overrides` is version `2`, the same borrowed facade also
+has the optional `visual_object` method described above. It is not a new
+baseline v1 draw kind and does not change the frozen dispatcher.
 
 Extensions call each method with the canonical dot-call form
 `draw.<kind>(command, context)`. A draw returns exactly `true` when the host
@@ -335,6 +447,7 @@ Run the focused host test from the repository root:
 luajit tests\companion_lifecycle_test.lua
 luajit tests\voxel_companion_api_v1_test.lua
 luajit tests\voxel_visual_object_filter_test.lua
+luajit tests\battle_scene_visual_sidecar_test.lua
 ```
 
 They cover delayed overworld readiness through the public core hook, descriptor
@@ -358,8 +471,12 @@ policies.
 
 The focused checks also cover stable signpost IDs and transforms, current and
 neighbor mapping, two-companion nested mutation isolation, same-transform
-replacement, first-person and third-person integration, transactional malformed,
-unknown, duplicate, and conflicting claims, and invalidate/dispose restoration.
+replacement, full descriptor/local yaw-pitch-roll and positive-scale
+propagation, fixed-glyph readable text, object and camera-yaw orientation,
+first-person and third-person integration, no private-handle leakage,
+phase-table map changes, scene transitions, uninstall cleanup, transactional
+malformed, unknown, duplicate, and conflicting claims, and invalidate/dispose
+restoration.
 The ROM-free integration test uses a sign annotated by `Structures`, builds and
 reads real full/body `ChunkMesher` cache variants, checks immediate ownership
 transitions without a pump, and verifies the retained shadow caster.
@@ -370,9 +487,10 @@ The upstream KFP dispatcher conformance command is:
 luajit tools\run_tests.lua companion
 ```
 
-In this repository, the lifecycle test passes 11 checks, the focused host test
-passes 2,712 checks, and the ROM-free cache-transition integration test passes
-1,156 checks. The `tools/run_tests.lua` selector is not present here, so no KFP
+In this repository, the lifecycle test passes 22 checks, the focused host test
+passes 2,818 checks, the ROM-free cache-transition integration test passes
+3,386 checks, and the BattleScene sidecar test passes 25 checks. The
+`tools/run_tests.lua` selector is not present here, so no KFP
 selector or complete KFP-suite result is claimed for this change. The complete
 23-command ROM-free draw fixture keeps canonical LF SHA-256
 `DE1DCA98A04AD9446B0AF4C13523DAB7F365BC7A76E70BC44B24F323D98A9BFA`.

--- a/docs/VOXEL_COMPANION_API_V1_HOST.md
+++ b/docs/VOXEL_COMPANION_API_V1_HOST.md
@@ -32,6 +32,7 @@ capabilities:
 - `render_phases`
 - `quality_tier`
 - `integrity_status`
+- `visual_object_overrides`
 
 It does not advertise `terrain_patch`, `shadow_pass`, or `battle_pass`. It also
 does not advertise `materials` or `draw`; those names are borrowed facades, not
@@ -60,8 +61,9 @@ The adapter uses only existing host-owned seams:
 6. `translucent_after_actors` runs after host actors, water, grass, and flowers
    and before the scene resolves.
 
-The adapter does not enter `ShadowMap` or `BattleScene`. It does not suppress,
-replace, or mutate base terrain.
+The adapter does not enter `ShadowMap` or `BattleScene`. It does not replace or
+mutate base terrain. The optional visual-object contract can suppress only the
+annotated visual quads of a claimed signpost.
 
 ## World snapshot
 
@@ -76,11 +78,79 @@ Hard limits are:
 - 262,144 cells
 - 2,048 actors
 - 8 neighbors
+- 4,096 visual objects or claims
 
 The public facade returns defensive plain-data copies. Snapshot construction is
 protected by one outer fault boundary. It does not use a protected call for
 each cell query. This keeps map-change work bounded without adding several
 protected calls per cell. Player movement does not rebuild the full map.
+
+### Visual-object override extension
+
+`visual_object_overrides` is one optional Battle Art extension to API v1. It
+adds `snapshot.visualObjects` and exactly one registration method on the
+existing extension handle:
+
+```lua
+local ok, err = handle:claim_visual_objects({ objectId, anotherObjectId })
+```
+
+It does not add a scene API, a mesh handle, or another draw path. A claimant
+must already have an `opaque_after_terrain` render handler. That handler renders
+the replacement with the existing borrowed `context.draw` facade. A companion
+can call the claim method during its own `worldChanged` callback, or outside a
+dispatcher callback. An empty array releases its claims.
+
+Each descriptor is defensive plain data with this shape:
+
+```lua
+{
+  schemaVersion = 1,
+  id = "BATTLE_ART_VOXEL_FORK:signpost:PALLET_TOWN:7:9",
+  kind = "signpost",
+  tags = { "host_geometry", "signpost", "visual_object" },
+  map = { id = "PALLET_TOWN", role = "current", offsetX = 0, offsetZ = 0 },
+  cell = { x = 7, z = 9 },
+  transform = {
+    localPosition = { x = 120, y = 0, z = 156 },
+    worldPosition = { x = 120, y = 0, z = 156 },
+    rotation = { yaw = 0, pitch = 0, roll = 0 },
+    scale = { x = 1, y = 1, z = 1 },
+  },
+  pivot = { kind = "bottom_center", x = 0, y = 0, z = 0 },
+  dimensions = { width = 16, height = 16, depth = 2 },
+  material = {
+    id = "host:tileset:OVERWORLD:signpost",
+    phase = "opaque_after_terrain",
+    opaque = true, alphaCutout = true,
+    castsShadow = true, receivesShadow = true,
+  },
+}
+```
+
+The position is the bottom-center pivot of the host signpost envelope. A box
+replacement therefore uses `worldPosition.x`, `worldPosition.z`, and
+`worldPosition.y + dimensions.height / 2`. Neighbor descriptors keep the same
+stable map-and-cell ID and local transform. Their world transform includes the
+connection offset. First-person and third-person use the same descriptor and
+the same opaque render seam.
+
+IDs contain safe ASCII only and are stable for host, kind, map, and cell. The
+host accepts claims only for IDs in the current copied catalog. Duplicate,
+unknown, malformed, or render-ineligible claims clear that extension's claims.
+If two live extensions request one ID, the object has no owner until the
+conflict is removed. Thus a conflict keeps the original visible instead of
+selecting a registration-order winner. Other non-conflicting objects keep their
+unique owners.
+
+Only a uniquely owned signpost's annotated visual quads are omitted. Ground,
+collision, interaction, map and game data, actors, and unrelated snapshot data
+do not change. Active overrides bypass persistent terrain records. Ownership
+changes refresh only the named map's full and body terrain slots; auxiliary
+grass, flowers, figures, structure analysis, and canonical disk records stay
+intact. Invalidate, fault cleanup, handle disposal, host disposal, or unload
+removes only the affected extension's claims. Existing lifecycle cleanup still
+owns extension resources, and repeated cleanup is safe.
 
 ### Semantic density-tag contract
 
@@ -250,6 +320,7 @@ Run the focused host test from the repository root:
 ```text
 luajit tests\companion_lifecycle_test.lua
 luajit tests\voxel_companion_api_v1_test.lua
+luajit tests\voxel_visual_object_filter_test.lua
 ```
 
 They cover delayed overworld readiness through the public core hook, descriptor
@@ -271,6 +342,12 @@ no-write rule, exact tree and boulder roles, walkable and unknown cylinder
 rejection, and bounded mountain seed, support, roof, door, and connection
 policies.
 
+The focused checks also cover stable signpost IDs and transforms, current and
+neighbor mapping, defensive descriptor copies, same-transform replacement,
+first-person and third-person integration, original-quad suppression,
+malformed and unknown claims, duplicate and conflicting ownership, and
+invalidate/dispose restoration.
+
 The canonical KFP dispatcher conformance command is:
 
 ```text
@@ -278,7 +355,8 @@ luajit tools\run_tests.lua companion
 ```
 
 At integration time, the lifecycle test passed 11 checks, the focused host
-test passed 2,636 checks, the canonical
+test passed 2,706 checks, the visual-object terrain filter passed 7 checks,
+the canonical
 companion selector passed 54 tests, and the complete KFP suite passed 227
 tests. The complete 23-command ROM-free draw fixture has canonical LF SHA-256
 `DE1DCA98A04AD9446B0AF4C13523DAB7F365BC7A76E70BC44B24F323D98A9BFA`.

--- a/lib/BattleScene.lua
+++ b/lib/BattleScene.lua
@@ -141,15 +141,21 @@ end
 -- not standing in it. Both maps are kept live so neither the arena's mesh nor
 -- the one waiting to be walked back onto is evicted mid-battle.
 local function prefetchArena(state, host)
-  if host == state.map then return VoxelScene.prefetch(state) end
+  if host == state.map then
+    local terrain, neighbors, water, neighborWater, _, visuals,
+      neighborVisuals = VoxelScene.prefetch(state)
+    return terrain, neighbors, water, neighborWater, visuals, neighborVisuals
+  end
   local live = { [host.id] = true, [state.map.id] = true }
   for _, nb in ipairs(state.neighbors or {}) do live[nb.map.id] = true end
   ChunkMesher.setLive(live)
   TerrainAtlas.setLive(live)
   ChunkMesher.request(host, false, nil, true)
-  local terrain, water = ChunkMesher.pair(host, false)
-  if not terrain then terrain, water = ChunkMesher.pair(host, true) end
-  return terrain, {}, water, {}
+  local terrain, water, _, visuals = ChunkMesher.pair(host, false)
+  if not terrain then
+    terrain, water, _, visuals = ChunkMesher.pair(host, true)
+  end
+  return terrain, {}, water, {}, visuals, {}
 end
 
 -- ------- the sun
@@ -234,7 +240,8 @@ BattleScene.monCards = monCards
 -- -- goes in the signature; the terrain half of the answer would otherwise
 -- keep a stale pass alive and freeze the shadows in whatever pose they were
 -- first drawn in.
-local function shadowSignature(state, arena, terrain, nbMesh, token)
+local function shadowSignature(state, arena, terrain, nbMesh, visuals,
+                               nbVisuals, token, neighborCount)
   local host = arena.map or state.map
   local parts = { "battle", host.id, arena.x, arena.y, arena.shape,
                   tostring(terrain), tostring(token or 0),
@@ -246,21 +253,42 @@ local function shadowSignature(state, arena, terrain, nbMesh, token)
                   -- from somewhere new must be re-cast from there
                   math.floor(ShadowMap.KX * 128),
                   math.floor(ShadowMap.KZ * 128) }
-  for i = 1, #nbMesh do parts[#parts + 1] = tostring(nbMesh[i]) end
+  for _, visual in ipairs(visuals or {}) do
+    parts[#parts + 1] = tostring(visual.mesh)
+  end
+  for i = 1, neighborCount or #nbMesh do
+    parts[#parts + 1] = tostring(nbMesh[i])
+    for _, visual in ipairs((nbVisuals and nbVisuals[i]) or {}) do
+      parts[#parts + 1] = tostring(visual.mesh)
+    end
+  end
   return table.concat(parts, ",")
 end
 
 local function castShadows(state, arena, terrain, nbMesh, cx, cy, vw, vh,
                            atlasFor, cards, models, token, host, neighbors,
-                           water, nbWater)
+                           water, nbWater, visuals, nbVisuals)
   if not ShadowMap.available() then return end
-  local sig = shadowSignature(state, arena, terrain, nbMesh, token)
+  local sig = shadowSignature(state, arena, terrain, nbMesh, visuals,
+                              nbVisuals, token, #neighbors)
   if not ShadowMap.stale(sig) then return end
   if not ShadowMap.begin(cx, cy, vw, vh) then return end
 
   ShadowMap.draw(terrain, atlasFor(host), nil)
   for i, nb in ipairs(neighbors) do
     ShadowMap.draw(nbMesh[i], atlasFor(nb.map), Mat4.translate(nb.ox, 0, nb.oy))
+  end
+  -- Visual-object claims belong only to the overworld companion pass. A
+  -- companion has no staged-battle renderer, so every original sign sidecar
+  -- remains both a caster here and visible in the color pass below.
+  for _, visual in ipairs(visuals or {}) do
+    ShadowMap.draw(visual.mesh, atlasFor(host), nil)
+  end
+  for i, nb in ipairs(neighbors) do
+    for _, visual in ipairs((nbVisuals and nbVisuals[i]) or {}) do
+      ShadowMap.draw(visual.mesh, atlasFor(nb.map),
+                     Mat4.translate(nb.ox, 0, nb.oy))
+    end
   end
   -- the water surface is its own reflective pass now (see Water) and so is
   -- no longer inside the terrain mesh; the sun still has to see it, or the
@@ -424,9 +452,10 @@ function BattleScene.render(state, arena, textures, token, battle, drawActors,
   -- A flat plate does not wait for or touch voxel meshes. The world arena
   -- still shares free-roam's request/evict bookkeeping and warms nothing
   -- extra; illustrated plates can therefore enter immediately on a cold map.
-  local terrain, nbMesh, water, nbWater
+  local terrain, nbMesh, water, nbWater, visuals, nbVisuals
   if not flatFill then
-    terrain, nbMesh, water, nbWater = prefetchArena(state, host)
+    terrain, nbMesh, water, nbWater, visuals, nbVisuals =
+      prefetchArena(state, host)
     if not terrain then return nil end
   end
 
@@ -501,7 +530,8 @@ function BattleScene.render(state, arena, textures, token, battle, drawActors,
     ShadowMap.discard()
   else
     castShadows(state, arena, terrain, nbMesh, cx, cy, vw, vh, atlasFor,
-                cards, stadium, token, host, neighbors, water, nbWater)
+                cards, stadium, token, host, neighbors, water, nbWater,
+                visuals, nbVisuals)
   end
 
   -- An opaque void either way. Outdoors the camera is low enough that the
@@ -567,6 +597,15 @@ function BattleScene.render(state, arena, textures, token, battle, drawActors,
     for i, nb in ipairs(neighbors) do
       Voxel3D.draw(nbMesh[i], atlasFor(nb.map),
                    Mat4.translate(nb.ox, 0, nb.oy))
+    end
+    for _, visual in ipairs(visuals or {}) do
+      Voxel3D.draw(visual.mesh, atlasFor(host), nil)
+    end
+    for i, nb in ipairs(neighbors) do
+      for _, visual in ipairs((nbVisuals and nbVisuals[i]) or {}) do
+        Voxel3D.draw(visual.mesh, atlasFor(nb.map),
+                     Mat4.translate(nb.ox, 0, nb.oy))
+      end
     end
     -- and the water over it -- PLAIN, always: the flat animated tiles, never
     -- the reflective pass, whatever the WATER row says. The reflection is

--- a/lib/ChunkMesher.lua
+++ b/lib/ChunkMesher.lua
@@ -75,15 +75,6 @@ local function visualObjectVisible(id)
   return not (ok and suppressed == true)
 end
 
-local function visualOverridesActive(mapId)
-  local companion = V.companion
-  if not (companion and type(companion.hasVisualObjectOverrides) == "function") then
-    return false
-  end
-  local ok, active = pcall(companion.hasVisualObjectOverrides, companion, mapId)
-  return ok and active == true
-end
-
 -- Small host-test seam used by the ROM-free contract suite.
 ChunkMesher.visualObjectVisible = visualObjectVisible
 
@@ -406,7 +397,7 @@ end
 --
 -- Omitted, water stays in the terrain mesh exactly as it always did, which
 -- is what the headless geometry() below and the sun's own pass both want.
-local function runGeometry(map, bodyOnly, masks, sink, waterSink)
+local function runGeometry(map, bodyOnly, masks, sink, waterSink, visualSinks)
   local push = sink.push
   local waterPush = waterSink and waterSink.push or nil
   local tileset = map.tileset
@@ -890,10 +881,19 @@ local function runGeometry(map, bodyOnly, masks, sink, waterSink)
     -- the edge keep-rules entirely: its eave legitimately overhangs the
     -- boundary plane into the neighbour's airspace, and no variant of
     -- the neighbour will ever draw that geometry
-    if visualObjectVisible(q.visualObjectId)
-       and (q.own or outwardOnEdge(q, x0, z0, x1, z1)
-            or keepQuad(x0, z0, x1, z1)) then
-      push({ q[1], q[2], q[3], q[4] }, quadUV(q), groundShades(q, q.shade))
+    if q.own or outwardOnEdge(q, x0, z0, x1, z1)
+        or keepQuad(x0, z0, x1, z1) then
+      local target = push
+      if q.visualObjectId and visualSinks then
+        local visualSink = visualSinks[q.visualObjectId]
+        if not visualSink then
+          visualSink = newSink()
+          visualSinks[q.visualObjectId] = visualSink
+        end
+        target = visualSink.push
+      end
+      target({ q[1], q[2], q[3], q[4] }, quadUV(q),
+        groundShades(q, q.shade))
     end
   end
 
@@ -982,11 +982,20 @@ end
 -- terrain one -- the shape the reflective pass needs (see Water). Without
 -- it the water is inside the terrain mesh, which is the historical
 -- contract and what every other caller still wants.
-function ChunkMesher.build(map, bodyOnly, masks, split)
+function ChunkMesher.build(map, bodyOnly, masks, split, separateVisuals)
   local sink = newSink()
   local waterSink = split and newSink() or nil
-  runGeometry(map, bodyOnly, masks, sink, waterSink)
-  return sink.finish(), waterSink and waterSink.finish() or nil
+  local visualSinks = separateVisuals and {} or nil
+  runGeometry(map, bodyOnly, masks, sink, waterSink, visualSinks)
+  local visuals = nil
+  if visualSinks then
+    visuals = {}
+    for id, visualSink in pairs(visualSinks) do
+      local mesh = visualSink.finish()
+      if mesh then visuals[id] = mesh end
+    end
+  end
+  return sink.finish(), waterSink and waterSink.finish() or nil, visuals
 end
 
 local function quadsMesh(quads)
@@ -1148,6 +1157,29 @@ local function swapSlot(c, slot, mesh)
   c[slot] = mesh
 end
 
+local function releaseVisualMeshes(list)
+  for _, mesh in pairs(type(list) == "table" and list or {}) do
+    if mesh and mesh.release then pcall(mesh.release, mesh) end
+  end
+end
+
+local function visualSlot(slot)
+  return slot .. "Visuals"
+end
+
+local function swapVisualSlot(c, slot, visuals)
+  local name = visualSlot(slot)
+  if c[name] ~= visuals then releaseVisualMeshes(c[name]) end
+  c[name] = visuals
+end
+
+local function mapHasVisualObjects(map)
+  for _, quad in ipairs(Structures.forMap(map).objectQuads or {}) do
+    if quad.visualObjectId then return true end
+  end
+  return false
+end
+
 -- ------------------------------------------------------------- the cache
 
 local function entry(id)
@@ -1174,6 +1206,9 @@ local function releaseEntry(c)
     if mesh and mesh.release then pcall(mesh.release, mesh) end
     c[slot] = nil
   end
+  releaseVisualMeshes(c.fullVisuals)
+  releaseVisualMeshes(c.bodyVisuals)
+  c.fullVisuals, c.bodyVisuals = nil, nil
   releaseFigures(c.figures)
   c.figures = nil
   c.stale = nil
@@ -1261,27 +1296,38 @@ local function runJob(job)
     if c.stale then c.stale.aux = nil end
   end
 
-  local mesh, water
-  -- Suppressed visual objects are session ownership state. Do not load or
-  -- write a persistent terrain record whose geometry would outlive that lease.
-  local volatileVisuals = visualOverridesActive(map.id)
-  local cached = not volatileVisuals
+  local mesh, water, visualMeshes
+  -- Annotated originals are small session meshes beside the canonical terrain.
+  -- Older persistent terrain records contain those quads, so annotated maps do
+  -- not read or write that record. Other maps keep the existing disk cache.
+  local annotatedVisuals = mapHasVisualObjects(map)
+  local cached = not annotatedVisuals
     and MeshDisk.loadTerrain(map, job.slot, job.masks) or nil
   if cached then
     mesh = meshFromRaw(cached.terrain)
     water = meshFromRaw(cached.water)
   else
     local sink, waterSink = newSink(), newSink()
-    runGeometry(map, job.slot == "body", job.masks, sink, waterSink)
+    local visualSinks = annotatedVisuals and {} or nil
+    runGeometry(map, job.slot == "body", job.masks, sink, waterSink,
+      visualSinks)
     local terrainRaw = sink.raw and sink.raw() or nil
     local waterRaw = waterSink.raw and waterSink.raw() or nil
     mesh, water = sink.finish(), waterSink.finish()
+    if visualSinks then
+      visualMeshes = {}
+      for id, visualSink in pairs(visualSinks) do
+        local visualMesh = visualSink.finish()
+        if visualMesh then visualMeshes[id] = visualMesh end
+      end
+    end
     if not current() then
       if mesh and mesh.release then pcall(mesh.release, mesh) end
       if water and water.release then pcall(water.release, water) end
+      releaseVisualMeshes(visualMeshes)
       return
     end
-    if terrainRaw and waterRaw and not volatileVisuals then
+    if terrainRaw and waterRaw and not annotatedVisuals then
       local savedTerrain, terrainError =
         MeshDisk.saveTerrain(map, job.slot, job.masks, terrainRaw, waterRaw)
       if not savedTerrain then
@@ -1293,10 +1339,12 @@ local function runJob(job)
   if not current() then
     if mesh and mesh.release then pcall(mesh.release, mesh) end
     if water and water.release then pcall(water.release, water) end
+    releaseVisualMeshes(visualMeshes)
     return
   end
   swapSlot(c, job.slot, mesh or false)
   swapSlot(c, waterSlot(job.slot), water or false)
+  swapVisualSlot(c, job.slot, visualMeshes)
   if c.stale then
     c.stale[job.slot] = nil
     if not (c.stale.full or c.stale.body or c.stale.aux) then
@@ -1458,14 +1506,15 @@ function ChunkMesher.get(map, bodyOnly, masks)
     if c.stale then c.stale.aux = nil end
   end
   if c[slot] == nil or (c.stale and c.stale[slot]) then
-    local ok, mesh, water = pcall(ChunkMesher.build, map, bodyOnly, masks,
-                                  true)
+    local ok, mesh, water, visuals = pcall(ChunkMesher.build, map, bodyOnly,
+      masks, true, mapHasVisualObjects(map))
     if not ok then
       print("[warn] voxel mesh build failed for " .. tostring(map.id)
             .. ": " .. tostring(mesh))
     end
     swapSlot(c, slot, (ok and mesh) or false)
     swapSlot(c, waterSlot(slot), (ok and water) or false)
+    swapVisualSlot(c, slot, (ok and visuals) or nil)
     if c.stale then
       c.stale[slot] = nil
       if not (c.stale.full or c.stale.body or c.stale.aux) then
@@ -1498,7 +1547,20 @@ function ChunkMesher.pair(map, bodyOnly)
   local c = cache[map.id]
   if not c then return nil, nil end
   local slot = bodyOnly and "body" or "full"
-  return c[slot] or nil, c[waterSlot(slot)] or nil
+  local list = c[visualSlot(slot)]
+  local visible, shadow = nil, nil
+  if type(list) == "table" then
+    local ids = {}
+    for id in pairs(list) do ids[#ids + 1] = id end
+    table.sort(ids)
+    visible, shadow = {}, {}
+    for _, id in ipairs(ids) do
+      local record = { id = id, mesh = list[id] }
+      shadow[#shadow + 1] = record
+      if visualObjectVisible(id) then visible[#visible + 1] = record end
+    end
+  end
+  return c[slot] or nil, c[waterSlot(slot)] or nil, visible, shadow
 end
 
 function ChunkMesher.grass(map)
@@ -1549,28 +1611,6 @@ function ChunkMesher.refresh(mapId)
   c.stale = { aux = true,
               full = (c.full ~= nil) or nil,
               body = (c.body ~= nil) or nil }
-end
-
--- Rebuild only terrain slots whose object-quads can change when a public
--- visual-object lease starts or ends. Grass, flowers, figures, water facts,
--- structure analysis, map data, and the persistent canonical cache are intact.
-function ChunkMesher.refreshVisualObjects(mapId)
-  if type(mapId) ~= "string" or mapId == "" then return false end
-  gen[mapId] = (gen[mapId] or 0) + 1
-  for i = #jobs, 1, -1 do
-    local job = jobs[i]
-    if job.id == mapId then
-      jobIndex[jobKey(job.id, job.slot)] = nil
-      table.remove(jobs, i)
-    end
-  end
-  local c = cache[mapId]
-  if c then
-    c.stale = c.stale or {}
-    c.stale.full = (c.full ~= nil) or nil
-    c.stale.body = (c.body ~= nil) or nil
-  end
-  return true
 end
 
 -- Evict everything outside `live` (a set of map ids): far maps' meshes

--- a/lib/ChunkMesher.lua
+++ b/lib/ChunkMesher.lua
@@ -78,6 +78,20 @@ end
 -- Small host-test seam used by the ROM-free contract suite.
 ChunkMesher.visualObjectVisible = visualObjectVisible
 
+-- True only when Structures produced geometry that this mesher can route to
+-- the named sidecar. Catalog callers use this instead of assuming that a
+-- sign-class map cell survived object extraction as one suppressible mesh.
+-- Analysis faults fail closed: the ordinary terrain path remains untouched.
+function ChunkMesher.visualObjectAnnotated(map, id)
+  if type(map) ~= "table" or type(id) ~= "string" then return false end
+  local ok, analysis = pcall(Structures.forMap, map)
+  if not ok or type(analysis) ~= "table" then return false end
+  for _, quad in ipairs(analysis.objectQuads or {}) do
+    if quad.visualObjectId == id then return true end
+  end
+  return false
+end
+
 -- Which drawn row a FLAT-topped volume's top face wears at depth `ty`.
 --
 -- A structure is usually deeper than the art that draws it, so the rows

--- a/lib/ChunkMesher.lua
+++ b/lib/ChunkMesher.lua
@@ -65,6 +65,28 @@ end
 
 local ChunkMesher = {}
 
+local function visualObjectVisible(id)
+  if id == nil then return true end
+  local companion = V.companion
+  if not (companion and type(companion.suppressesVisualObject) == "function") then
+    return true
+  end
+  local ok, suppressed = pcall(companion.suppressesVisualObject, companion, id)
+  return not (ok and suppressed == true)
+end
+
+local function visualOverridesActive(mapId)
+  local companion = V.companion
+  if not (companion and type(companion.hasVisualObjectOverrides) == "function") then
+    return false
+  end
+  local ok, active = pcall(companion.hasVisualObjectOverrides, companion, mapId)
+  return ok and active == true
+end
+
+-- Small host-test seam used by the ROM-free contract suite.
+ChunkMesher.visualObjectVisible = visualObjectVisible
+
 -- Which drawn row a FLAT-topped volume's top face wears at depth `ty`.
 --
 -- A structure is usually deeper than the art that draws it, so the rows
@@ -868,8 +890,9 @@ local function runGeometry(map, bodyOnly, masks, sink, waterSink)
     -- the edge keep-rules entirely: its eave legitimately overhangs the
     -- boundary plane into the neighbour's airspace, and no variant of
     -- the neighbour will ever draw that geometry
-    if q.own or outwardOnEdge(q, x0, z0, x1, z1)
-       or keepQuad(x0, z0, x1, z1) then
+    if visualObjectVisible(q.visualObjectId)
+       and (q.own or outwardOnEdge(q, x0, z0, x1, z1)
+            or keepQuad(x0, z0, x1, z1)) then
       push({ q[1], q[2], q[3], q[4] }, quadUV(q), groundShades(q, q.shade))
     end
   end
@@ -1239,7 +1262,11 @@ local function runJob(job)
   end
 
   local mesh, water
-  local cached = MeshDisk.loadTerrain(map, job.slot, job.masks)
+  -- Suppressed visual objects are session ownership state. Do not load or
+  -- write a persistent terrain record whose geometry would outlive that lease.
+  local volatileVisuals = visualOverridesActive(map.id)
+  local cached = not volatileVisuals
+    and MeshDisk.loadTerrain(map, job.slot, job.masks) or nil
   if cached then
     mesh = meshFromRaw(cached.terrain)
     water = meshFromRaw(cached.water)
@@ -1254,7 +1281,7 @@ local function runJob(job)
       if water and water.release then pcall(water.release, water) end
       return
     end
-    if terrainRaw and waterRaw then
+    if terrainRaw and waterRaw and not volatileVisuals then
       local savedTerrain, terrainError =
         MeshDisk.saveTerrain(map, job.slot, job.masks, terrainRaw, waterRaw)
       if not savedTerrain then
@@ -1522,6 +1549,28 @@ function ChunkMesher.refresh(mapId)
   c.stale = { aux = true,
               full = (c.full ~= nil) or nil,
               body = (c.body ~= nil) or nil }
+end
+
+-- Rebuild only terrain slots whose object-quads can change when a public
+-- visual-object lease starts or ends. Grass, flowers, figures, water facts,
+-- structure analysis, map data, and the persistent canonical cache are intact.
+function ChunkMesher.refreshVisualObjects(mapId)
+  if type(mapId) ~= "string" or mapId == "" then return false end
+  gen[mapId] = (gen[mapId] or 0) + 1
+  for i = #jobs, 1, -1 do
+    local job = jobs[i]
+    if job.id == mapId then
+      jobIndex[jobKey(job.id, job.slot)] = nil
+      table.remove(jobs, i)
+    end
+  end
+  local c = cache[mapId]
+  if c then
+    c.stale = c.stale or {}
+    c.stale.full = (c.full ~= nil) or nil
+    c.stale.body = (c.body ~= nil) or nil
+  end
+  return true
 end
 
 -- Evict everything outside `live` (a set of map ids): far maps' meshes

--- a/lib/CompanionLifecycle.lua
+++ b/lib/CompanionLifecycle.lua
@@ -13,11 +13,12 @@ function CompanionLifecycle.install(mod, companion)
       and type(mod.hooks.wrap) == "function",
     "CompanionLifecycle needs the public mod hook facade")
   assert(type(companion) == "table"
-      and type(companion.updateFromGame) == "function",
+      and type(companion.updateFromGame) == "function"
+      and type(companion.dispose) == "function",
     "CompanionLifecycle needs a companion adapter")
 
   local reportedFault = false
-  return mod.hooks:wrap("core.update", function(next, game, dt)
+  local remove = mod.hooks:wrap("core.update", function(next, game, dt)
     local results = pack(next(game, dt))
     local ok, err = pcall(companion.updateFromGame, companion, dt, game)
     if not ok and not reportedFault then
@@ -28,6 +29,26 @@ function CompanionLifecycle.install(mod, companion)
     end
     return unpack(results, 1, results.n)
   end)
+  local hookRemoved, uninstalled = false, false
+  local removed
+  return function(...)
+    if uninstalled then return true end
+    if not hookRemoved then
+      removed = pack(remove(...))
+      hookRemoved = true
+    end
+    local called, result, disposeError = pcall(
+      companion.dispose, companion, "host_uninstall")
+    if not called or not result then
+      local err = called and disposeError or result
+      if mod.log and type(mod.log.error) == "function" then
+        mod.log:error("Voxel Companion uninstall cleanup failed: %s", tostring(err))
+      end
+      error(err, 0)
+    end
+    uninstalled = true
+    return unpack(removed, 1, removed.n)
+  end
 end
 
 return CompanionLifecycle

--- a/lib/Mat4.lua
+++ b/lib/Mat4.lua
@@ -62,6 +62,14 @@ function Mat4.rotateX(a)
            0, 0, 0, 1 }
 end
 
+function Mat4.rotateZ(a)
+  local c, s = math.cos(a), math.sin(a)
+  return { c, -s, 0, 0,
+           s,  c, 0, 0,
+           0,  0, 1, 0,
+           0,  0, 0, 1 }
+end
+
 -- Right-handed perspective onto GL clip space (z in [-1, 1]).
 function Mat4.perspective(fovY, aspect, near, far)
   local f = 1 / math.tan(fovY / 2)

--- a/lib/Structures.lua
+++ b/lib/Structures.lua
@@ -49,7 +49,7 @@ local Map = require("src.world.Map")
 local Buildings = V.require("Buildings")
 local TileShape = V.require("TileShape")
 local Budget = V.require("BuildBudget")
-local CompanionAPI = V.require("VoxelCompanionAPI")
+local VisualObjects = V.require("VoxelVisualObjects")
 
 local Structures = {}
 
@@ -2730,7 +2730,7 @@ function Structures.buildObject(S, map, region, cluster,
     local cellX, cellZ = math.floor(cluster.minX / 2), math.floor(cluster.minY / 2)
     if math.floor(cluster.maxX / 2) == cellX
         and math.floor(cluster.maxY / 2) == cellZ then
-      visualObjectId = CompanionAPI.visual_object_id("BATTLE_ART_VOXEL_FORK",
+      visualObjectId = VisualObjects.id("BATTLE_ART_VOXEL_FORK",
         "signpost", map.id, cellX, cellZ)
     end
   end

--- a/lib/Structures.lua
+++ b/lib/Structures.lua
@@ -49,6 +49,7 @@ local Map = require("src.world.Map")
 local Buildings = V.require("Buildings")
 local TileShape = V.require("TileShape")
 local Budget = V.require("BuildBudget")
+local CompanionAPI = V.require("VoxelCompanionAPI")
 
 local Structures = {}
 
@@ -2718,9 +2719,20 @@ function Structures.buildObject(S, map, region, cluster,
   -- geometry: each solid pixel is one voxel column deep enough to read as
   -- a body, standing at the cluster's south row, base on the ground plane
   local depth = OBJECT_DEPTH
+  local pinnedShape = force
+    and S.shapeAt[keyOf(cluster.tiles[1][1], cluster.tiles[1][2])] or nil
   if force then
-    local cs = S.shapeAt[keyOf(cluster.tiles[1][1], cluster.tiles[1][2])]
-    depth = (cs and PINNED_DEPTH[cs.class]) or PINNED_DEPTH.billboard
+    depth = (pinnedShape and PINNED_DEPTH[pinnedShape.class])
+      or PINNED_DEPTH.billboard
+  end
+  local visualObjectId = nil
+  if pinnedShape and pinnedShape.class == "signpost" then
+    local cellX, cellZ = math.floor(cluster.minX / 2), math.floor(cluster.minY / 2)
+    if math.floor(cluster.maxX / 2) == cellX
+        and math.floor(cluster.maxY / 2) == cellZ then
+      visualObjectId = CompanionAPI.visual_object_id("BATTLE_ART_VOXEL_FORK",
+        "signpost", map.id, cellX, cellZ)
+    end
   end
   local wx0 = cluster.minX * 8
 
@@ -2856,7 +2868,8 @@ function Structures.buildObject(S, map, region, cluster,
         local u = (srcU[i] + 0.5) / atlasW
         local v = (srcV[i] + 0.5) / atlasH
         local function quad(c1, c2, c3, c4, shade)
-          quads[#quads + 1] = { c1, c2, c3, c4, u = u, v = v, shade = shade }
+          quads[#quads + 1] = { c1, c2, c3, c4, u = u, v = v, shade = shade,
+            visualObjectId = visualObjectId }
         end
         quad({ x, y, z1 }, { x + 1, y, z1 }, { x + 1, y + 1, z1 },
              { x, y + 1, z1 }, OBJ_SHADE.front)

--- a/lib/VoxelCompanion.lua
+++ b/lib/VoxelCompanion.lua
@@ -8,6 +8,7 @@
 local V = ...
 
 local API = V.require("VoxelCompanionAPI")
+local VisualObjects = V.require("VoxelVisualObjects")
 local Mat4 = V.require("Mat4")
 local TileShape = V.require("TileShape")
 local ChunkMesher = V.require("ChunkMesher")
@@ -26,6 +27,14 @@ local CAPABILITIES = {
   "quality_tier",
   "integrity_status",
   "visual_object_overrides",
+}
+
+local DISPATCH_CAPABILITIES = {
+  "world_snapshot",
+  "camera_delta",
+  "render_phases",
+  "quality_tier",
+  "integrity_status",
 }
 
 local WORLD_PHASES = {
@@ -1163,7 +1172,7 @@ local function appendVisualObjects(map, role, offsetX, offsetZ, byId, counts, sc
       if class == "signpost" then
         scan.count = scan.count + 1
         if scan.count > MAX_VISUAL_OBJECTS then return end
-        local id = API.visual_object_id("BATTLE_ART_VOXEL_FORK",
+        local id = VisualObjects.id("BATTLE_ART_VOXEL_FORK",
           "signpost", map.id, x, z)
         if id then
           counts[id] = (counts[id] or 0) + 1
@@ -1553,6 +1562,8 @@ local function updateFrame(self, dt)
   }
 end
 
+local hasOpaqueHandler, wrapSpec, VisualHandle
+
 function VoxelCompanion.new(options)
   options = options or {}
   local mod = options.mod or V.mod
@@ -1585,7 +1596,26 @@ function VoxelCompanion.new(options)
     frameIndex = 0,
     nextSnapshotAttempt = 0,
     lastSnapshotError = nil,
+    callbackDepth = 0,
+    callbackRecord = nil,
+    callbackStage = nil,
+    visualSources = {},
   }, VoxelCompanion)
+
+  self.visuals = VisualObjects.new({
+    claimAllowed = function(record)
+      local status = record.raw and record.raw:status() or nil
+      if not status or status.state == "disposed" or status.faulted then
+        return nil, "extension cannot claim visual objects in its current state"
+      end
+      if self.callbackDepth > 0
+          and not (self.callbackRecord == record
+            and self.callbackStage == "map_changed") then
+        return nil, "visual object claims are allowed only outside dispatch or during the owner's worldChanged callback"
+      end
+      return true
+    end,
+  })
 
   self.draw = makeDrawFacade(self)
   self.materials = {
@@ -1618,7 +1648,7 @@ function VoxelCompanion.new(options)
   self.dispatcher = API.new({
     host_id = "BATTLE_ART_VOXEL_FORK",
     host_version = "1.9.7",
-    capabilities = CAPABILITIES,
+    capabilities = DISPATCH_CAPABILITIES,
     max_extensions = 32,
     max_errors = 64,
     logger = function(event)
@@ -1626,17 +1656,11 @@ function VoxelCompanion.new(options)
       rememberDiagnostic(self, message)
       loggerCall(mod, "error", "Voxel Companion: " .. tostring(message))
     end,
-    visual_objects_changed = function(mapIds)
-      for _, mapId in ipairs(mapIds or {}) do
-        if type(ChunkMesher.refreshVisualObjects) == "function" then
-          ChunkMesher.refreshVisualObjects(mapId)
-        end
-      end
-    end,
   })
 
   local raw = self.dispatcher:provider()
   self.provider = raw
+  raw.capabilities.visual_object_overrides = 1
   local register = raw.register
   raw.register = function(spec)
     self.integrity = scanIntegrity(mod)
@@ -1657,9 +1681,21 @@ function VoxelCompanion.new(options)
         or (type(render) == "table" and render.battle_opaque ~= nil) then
       return nil, "battle_opaque requires unavailable battle_pass capability"
     end
-    -- Use the reference provider closure. It joins an already-running host
-    -- with the dispatcher's retained activation context.
-    return register(spec)
+    local existing = type(spec) == "table" and self.visualSources[spec] or nil
+    if existing and existing.raw:status().state ~= "disposed" then return existing end
+    local id = type(spec) == "table" and spec.id or nil
+    local record = self.visuals:addRecord(id, hasOpaqueHandler(spec))
+    local wrapped = wrapSpec(self, spec, record)
+    -- Use the byte-frozen reference provider closure. The wrapper removes only
+    -- this host extension's capability token and adds the optional claim method
+    -- to the returned handle.
+    local rawHandle, err = register(wrapped)
+    if not rawHandle then self.visuals:remove(record); return nil, err end
+    record.raw = rawHandle
+    local handle = setmetatable({ host = self, raw = rawHandle, record = record },
+      VisualHandle)
+    self.visualSources[spec] = handle
+    return handle
   end
   return self
 end
@@ -1732,7 +1768,7 @@ function VoxelCompanion:update(dt, state)
       and self.clock >= self.nextSnapshotAttempt then
     local snapshot, snapshotError = self.world.snapshot()
     if snapshot then
-      local cataloged, catalogError = self.dispatcher:set_visual_objects(
+      local cataloged, catalogError = self.visuals:setCatalog(
         snapshot.visualObjects or {})
       if cataloged then
         local report, dispatchError = self.dispatcher:world_changed(snapshot)
@@ -1777,13 +1813,190 @@ function VoxelCompanion:cameraDelta(state)
   return delta
 end
 
-function VoxelCompanion:suppressesVisualObject(id)
-  return self.started and self.dispatcher:is_visual_object_suppressed(id) or false
+local function pack(...)
+  return { n = select("#", ...), ... }
 end
 
-function VoxelCompanion:hasVisualObjectOverrides(mapId)
-  return self.started
-    and self.dispatcher:visual_object_overrides_active(mapId) or false
+local unpackValues = table.unpack or unpack
+
+local function callExtension(self, record, stage, handler, ...)
+  local previousRecord, previousStage = self.callbackRecord, self.callbackStage
+  local previousDepth = self.callbackDepth or 0
+  self.callbackRecord, self.callbackStage = record, stage
+  self.callbackDepth = previousDepth + 1
+  local args = pack(...)
+  local ok, result = xpcall(function()
+    return pack(handler(unpackValues(args, 1, args.n)))
+  end, function(problem) return problem end)
+  self.callbackRecord, self.callbackStage = previousRecord, previousStage
+  self.callbackDepth = previousDepth
+  if not ok then error(result, 0) end
+  return unpackValues(result, 1, result.n)
+end
+
+local function copyTable(source)
+  local out = {}
+  for key, value in pairs(source or {}) do out[key] = value end
+  return out
+end
+
+local function defensiveSnapshot(source)
+  local plain = {}
+  for _, key in ipairs({
+    "id", "revision", "game", "width", "height", "cellSize",
+    "paletteRevision", "tilesetRevision", "atlasRevision", "mode", "tags",
+    "player", "actors", "neighbors", "visualObjects", "cells", "time",
+    "weather",
+  }) do
+    plain[key] = source[key]
+  end
+  return copySnapshot(plain)
+end
+
+local function filterVisualCapability(source)
+  if type(source) ~= "table" then return source end
+  local out, write = {}, 0
+  for index = 1, #source do
+    if source[index] ~= "visual_object_overrides" then
+      write = write + 1
+      out[write] = source[index]
+    end
+  end
+  for key, value in pairs(source) do
+    if type(key) ~= "number" or key < 1 or key > #source
+        or key ~= math.floor(key) then
+      out[key] = value
+    end
+  end
+  return out
+end
+
+hasOpaqueHandler = function(spec)
+  return type(spec) == "table"
+    and ((type(spec.render) == "table"
+          and type(spec.render.opaque_after_terrain) == "function")
+      or (type(spec.phases) == "table"
+          and type(spec.phases.opaque_after_terrain) == "function"))
+end
+
+local function wrapCallbackTable(self, record, source, prefix, snapshotPhase)
+  if type(source) ~= "table" then return source end
+  local out = copyTable(source)
+  for name, handler in pairs(source) do
+    if type(handler) == "function" then
+      local callbackName, callback = name, handler
+      out[callbackName] = function(...)
+        local args = pack(...)
+        if snapshotPhase and callbackName == "map_changed" then
+          local snapshot, err = defensiveSnapshot(args[1])
+          if not snapshot then error(err or "could not copy visual snapshot", 0) end
+          args[1] = snapshot
+        end
+        return callExtension(self, record, prefix .. "." .. callbackName, callback,
+          unpackValues(args, 1, args.n))
+      end
+    end
+  end
+  return out
+end
+
+wrapSpec = function(self, spec, record)
+  if type(spec) ~= "table" then return spec end
+  local out = copyTable(spec)
+  out.requires = filterVisualCapability(spec.requires)
+  out.optional = filterVisualCapability(spec.optional)
+  out.lifecycle = wrapCallbackTable(self, record, spec.lifecycle, "lifecycle")
+  out.phases = wrapCallbackTable(self, record, spec.phases, "phases", true)
+  out.render = wrapCallbackTable(self, record, spec.render, "render")
+
+  for _, name in ipairs({ "attach", "update", "modifyCamera", "terrainPatch",
+                           "invalidate", "dispose" }) do
+    local handler = spec[name]
+    if type(handler) == "function" then
+      local callbackName, callback = name, handler
+      out[callbackName] = function(...)
+        if callbackName == "invalidate" or callbackName == "dispose" then
+          self.visuals:clear(record)
+        end
+        return callExtension(self, record, callbackName, callback, ...)
+      end
+    end
+  end
+  if type(spec.worldChanged) == "function" then
+    local handler = spec.worldChanged
+    out.worldChanged = function(snapshot, ...)
+      local defensive, err = defensiveSnapshot(snapshot)
+      if not defensive then error(err or "could not copy visual snapshot", 0) end
+      return callExtension(self, record, "map_changed", handler, defensive, ...)
+    end
+  end
+  if type(spec.camera) == "function" then
+    local handler = spec.camera
+    out.camera = function(...)
+      return callExtension(self, record, "camera", handler, ...)
+    end
+  end
+  if type(spec.terrain) == "function" then
+    local handler = spec.terrain
+    out.terrain = function(...)
+      return callExtension(self, record, "terrain", handler, ...)
+    end
+  end
+
+  local hasDispose = type(spec.dispose) == "function"
+    or (type(spec.lifecycle) == "table"
+        and type(spec.lifecycle.dispose) == "function")
+  if not hasDispose then
+    out.lifecycle = out.lifecycle or {}
+    out.lifecycle.dispose = function()
+      self.visuals:clear(record)
+    end
+  elseif type(spec.lifecycle) == "table"
+      and type(spec.lifecycle.dispose) == "function" then
+    local handler = spec.lifecycle.dispose
+    out.lifecycle.dispose = function(...)
+      self.visuals:clear(record)
+      return callExtension(self, record, "lifecycle.dispose", handler, ...)
+    end
+  end
+  return out
+end
+
+VisualHandle = {}
+VisualHandle.__index = VisualHandle
+
+function VisualHandle:id()
+  return self.raw:id()
+end
+
+function VisualHandle:is_active()
+  return self.raw:is_active()
+end
+
+function VisualHandle:status()
+  local status = self.raw:status()
+  status.visualClaims = self.host.visuals:status(self.record).visualClaims
+  return status
+end
+
+function VisualHandle:claim_visual_objects(ids)
+  return self.host.visuals:claim(self.record, ids)
+end
+
+function VisualHandle:invalidate(context, reason)
+  local ok, err = self.raw:invalidate(context, reason)
+  if ok then self.host.visuals:clear(self.record) end
+  return ok, err
+end
+
+function VisualHandle:dispose(context, reason)
+  local ok, err = self.raw:dispose(context, reason)
+  if ok then self.host.visuals:remove(self.record) end
+  return ok, err
+end
+
+function VoxelCompanion:suppressesVisualObject(id)
+  return self.started and self.visuals:isSuppressed(id) or false
 end
 
 function VoxelCompanion:render(phase, state)
@@ -1810,6 +2023,7 @@ end
 
 function VoxelCompanion:invalidate(reason)
   self:worldChanged(reason or "host_invalidated")
+  self.visuals:clearAll()
   for key, mesh in pairs(self.meshes) do
     if mesh and mesh.release then pcall(mesh.release, mesh) end
     self.meshes[key] = nil
@@ -1832,6 +2046,8 @@ function VoxelCompanion:dispose(reason)
   if self.started then
     result, err = self.dispatcher:dispose(self:_context(), reason or "host_dispose")
   end
+  self.visuals:dispose()
+  self.visualSources = {}
   self.started = false
   self.attached = false
   self.startContext = nil
@@ -1848,6 +2064,12 @@ end
 
 function VoxelCompanion:status()
   local status = self.dispatcher:status()
+  local visualStatus = self.visuals:status()
+  status.capabilities[#status.capabilities + 1] = "visual_object_overrides"
+  table.sort(status.capabilities)
+  status.visualObjects = visualStatus.visualObjects
+  status.visualOverrides = visualStatus.visualOverrides
+  status.visualConflicts = visualStatus.visualConflicts
   status.integrity = copyIntegrity(self.integrity)
   status.revision = self.revision
   status.diagnostics = {}

--- a/lib/VoxelCompanion.lua
+++ b/lib/VoxelCompanion.lua
@@ -331,6 +331,18 @@ local function buildPlane()
   return Voxel3D.newMesh(vertices, indices)
 end
 
+local function buildVisualPlane()
+  local vertices = {
+    { -0.5, -0.5, 0, 0.5, 0.5, 1 },
+    {  0.5, -0.5, 0, 0.5, 0.5, 1 },
+    {  0.5,  0.5, 0, 0.5, 0.5, 1 },
+    { -0.5,  0.5, 0, 0.5, 0.5, 1 },
+  }
+  local indices = {}
+  Voxel3D.pushQuad(indices, 0)
+  return Voxel3D.newMesh(vertices, indices)
+end
+
 local function buildBillboard()
   local vertices = {
     { -0.5, 0, 0, 0.5, 0.5, 1 },
@@ -466,6 +478,46 @@ end
 local function transform(x, y, z, width, height, depth)
   return Mat4.mul(Mat4.translate(x, y, z),
                   Mat4.scale(width, height, depth))
+end
+
+local function rotationTransform(rotation)
+  return Mat4.mul(Mat4.rotateY(rotation.yaw),
+    Mat4.mul(Mat4.rotateX(rotation.pitch), Mat4.rotateZ(rotation.roll)))
+end
+
+local function descriptorTransform(descriptor)
+  local transform = descriptor.transform
+  local position, scale = transform.worldPosition, transform.scale
+  return Mat4.mul(Mat4.translate(position.x, position.y, position.z),
+    Mat4.mul(rotationTransform(transform.rotation),
+      Mat4.scale(scale.x, scale.y, scale.z)))
+end
+
+local function localTransform(item)
+  local position, scale = item.position, item.scale
+  return Mat4.mul(Mat4.translate(position.x, position.y, position.z),
+    Mat4.mul(rotationTransform(item.rotation),
+      Mat4.scale(scale.x, scale.y, scale.z)))
+end
+
+-- Apply T * Ry * Rx * Rz * S to one descriptor-local point. This matches the
+-- model composition above and gives yaw billboards their transformed anchor.
+local function descriptorPoint(descriptor, point)
+  local transform = descriptor.transform
+  local x = point.x * transform.scale.x
+  local y = point.y * transform.scale.y
+  local z = point.z * transform.scale.z
+  local roll = transform.rotation.roll
+  local cr, sr = math.cos(roll), math.sin(roll)
+  x, y = x * cr - y * sr, x * sr + y * cr
+  local pitch = transform.rotation.pitch
+  local cp, sp = math.cos(pitch), math.sin(pitch)
+  y, z = y * cp - z * sp, y * sp + z * cp
+  local yaw = transform.rotation.yaw
+  local cy, sy = math.cos(yaw), math.sin(yaw)
+  x, z = x * cy + z * sy, -x * sy + z * cy
+  local world = transform.worldPosition
+  return { x = world.x + x, y = world.y + y, z = world.z + z }
 end
 
 local function billboardTransform(item, width, height)
@@ -685,6 +737,7 @@ local function ensureMesh(self, kind)
   if self.meshes[kind] ~= nil then return self.meshes[kind] or nil end
   local mesh
   if kind == "plane" then mesh = buildPlane()
+  elseif kind == "visual_plane" then mesh = buildVisualPlane()
   elseif kind == "billboard" then mesh = buildBillboard()
   elseif kind == "panorama" then mesh = buildPanorama(false)
   elseif kind == "panorama_deep" then mesh = buildPanorama(true)
@@ -1048,6 +1101,103 @@ local function runDraw(callback)
   return true
 end
 
+local function replacementGeometryModel(descriptor, item)
+  local size = item.dimensions
+  local depth = item.shape == "plane" and 1 or size.depth
+  local pivotY = item.pivot == "bottom_center" and size.height * 0.5 or 0
+  local primitive = Mat4.mul(Mat4.translate(0, pivotY, 0),
+    Mat4.scale(size.width, size.height, depth))
+  return Mat4.mul(descriptorTransform(descriptor),
+    Mat4.mul(localTransform(item), primitive))
+end
+
+local function replacementTextTransform(descriptor, item)
+  if item.orientation == "object" then
+    return Mat4.mul(descriptorTransform(descriptor), localTransform(item))
+  end
+  local anchor = descriptorPoint(descriptor, item.position)
+  local eyeX, _, eyeZ = eyePosition()
+  local yaw = math.atan2(eyeX - anchor.x, eyeZ - anchor.z)
+    + item.rotation.yaw
+  local descriptorScale, scale = descriptor.transform.scale, item.scale
+  return Mat4.mul(Mat4.translate(anchor.x, anchor.y, anchor.z),
+    Mat4.mul(Mat4.rotateY(yaw), Mat4.scale(
+      descriptorScale.x * scale.x,
+      descriptorScale.y * scale.y,
+      descriptorScale.z * scale.z)))
+end
+
+local function drawReplacementText(self, descriptor, item, mesh, texture)
+  local base = replacementTextTransform(descriptor, item)
+  local textWidth = #item.value * 6 - 1
+  local startX = item.align == "center" and -textWidth * 0.5
+    or (item.align == "right" and -textWidth or 0)
+  setMaterial(item.material.color)
+  for characterIndex = 1, #item.value do
+    local rows = VisualObjects.glyph(item.value:sub(characterIndex, characterIndex))
+    for row = 1, 7 do
+      local bits = rows[row]
+      for column = 0, 4 do
+        if math.floor(bits / 2 ^ (4 - column)) % 2 == 1 then
+          local pixel = Mat4.mul(Mat4.translate(
+            startX + (characterIndex - 1) * 6 + column + 0.5,
+            7 - row + 0.5, 0), Mat4.scale(1, 1, 0.125))
+          drawVoxel(self, mesh, texture, Mat4.mul(base, pixel), false)
+        end
+      end
+    end
+  end
+end
+
+local function drawVisualObject(self, packet, context)
+  if type(context) ~= "table" then
+    return false, "visual object replacement needs the current borrowed render context"
+  end
+  if self.callbackDepth < 1 or not self.callbackRecord
+      or (self.callbackStage ~= "render.opaque_after_terrain"
+        and self.callbackStage ~= "phases.opaque_after_terrain") then
+    return false, "visual object replacement is allowed only in the owner's opaque_after_terrain callback"
+  end
+  if type(packet) ~= "table" or getmetatable(packet) ~= nil then
+    return false, "visual object replacement must be a plain table"
+  end
+  local descriptor, ownershipError = self.visuals:ownedDescriptor(
+    self.callbackRecord, rawget(packet, "objectId"))
+  if not descriptor then return false, ownershipError end
+  local command, primitiveCount = VisualObjects.validateReplacementCommand(
+    packet, descriptor)
+  if not command then return false, primitiveCount end
+  local budgeted, budgetError = useDrawBudget(self, primitiveCount)
+  if not budgeted then return false, budgetError end
+  local texture = ensureTexture(self)
+  local box = ensureMesh(self, "box")
+  local needsPlane = false
+  for _, item in ipairs(command.geometry) do
+    if item.shape == "plane" then needsPlane = true break end
+  end
+  local plane = needsPlane and ensureMesh(self, "visual_plane") or nil
+  if not texture or not box or (needsPlane and not plane) then
+    return false, "visual object replacement host geometry is unavailable"
+  end
+
+  return runDraw(function()
+    local ok, err = xpcall(function()
+      Voxel3D.glass(false)
+      for _, item in ipairs(command.geometry) do
+        setMaterial(item.material.color)
+        drawVoxel(self, item.shape == "plane" and plane or box, texture,
+          replacementGeometryModel(descriptor, item), false)
+      end
+      for _, item in ipairs(command.text) do
+        drawReplacementText(self, descriptor, item, box, texture)
+      end
+    end, function(message) return tostring(message) end)
+    pcall(Voxel3D.glass, true)
+    if not ok then error(err, 0) end
+    return true
+  end)
+end
+
 local function makeDrawFacade(self)
   return {
     mesh = function(packet, context)
@@ -1146,6 +1296,9 @@ local function makeDrawFacade(self)
         end
         return true
       end)
+    end,
+    visual_object = function(packet, context)
+      return drawVisualObject(self, packet, context)
     end,
   }
 end
@@ -1570,6 +1723,7 @@ local function updateFrame(self, dt)
 end
 
 local hasOpaqueHandler, wrapSpec, VisualHandle
+local VisualHandleState = setmetatable({}, { __mode = "k" })
 
 function VoxelCompanion.new(options)
   options = options or {}
@@ -1667,7 +1821,7 @@ function VoxelCompanion.new(options)
 
   local raw = self.dispatcher:provider()
   self.provider = raw
-  raw.capabilities.visual_object_overrides = 1
+  raw.capabilities.visual_object_overrides = 2
   local register = raw.register
   raw.register = function(spec)
     self.integrity = scanIntegrity(mod)
@@ -1689,7 +1843,10 @@ function VoxelCompanion.new(options)
       return nil, "battle_opaque requires unavailable battle_pass capability"
     end
     local existing = type(spec) == "table" and self.visualSources[spec] or nil
-    if existing and existing.raw:status().state ~= "disposed" then return existing end
+    local existingState = existing and VisualHandleState[existing] or nil
+    if existingState and existingState.raw:status().state ~= "disposed" then
+      return existing
+    end
     local id = type(spec) == "table" and spec.id or nil
     local record = self.visuals:addRecord(id, hasOpaqueHandler(spec))
     local wrapped = wrapSpec(self, spec, record)
@@ -1699,8 +1856,8 @@ function VoxelCompanion.new(options)
     local rawHandle, err = register(wrapped)
     if not rawHandle then self.visuals:remove(record); return nil, err end
     record.raw = rawHandle
-    local handle = setmetatable({ host = self, raw = rawHandle, record = record },
-      VisualHandle)
+    local handle = setmetatable({}, VisualHandle)
+    VisualHandleState[handle] = { host = self, raw = rawHandle, record = record }
     self.visualSources[spec] = handle
     return handle
   end
@@ -1894,12 +2051,16 @@ local function wrapCallbackTable(self, record, source, prefix, snapshotPhase)
       local callbackName, callback = name, handler
       out[callbackName] = function(...)
         local args = pack(...)
+        local stage = prefix .. "." .. callbackName
         if snapshotPhase and callbackName == "map_changed" then
           local snapshot, err = defensiveSnapshot(args[1])
           if not snapshot then error(err or "could not copy visual snapshot", 0) end
           args[1] = snapshot
+          -- The phase-table and flat callbacks are the same public lifecycle
+          -- event. Keep claim authorization identical for both spellings.
+          stage = "map_changed"
         end
-        return callExtension(self, record, prefix .. "." .. callbackName, callback,
+        return callExtension(self, record, stage, callback,
           unpackValues(args, 1, args.n))
       end
     end
@@ -1971,34 +2132,45 @@ end
 
 VisualHandle = {}
 VisualHandle.__index = VisualHandle
+VisualHandle.__metatable = "voxel-companion visual handle"
+
+local function visualHandleState(handle)
+  local state = VisualHandleState[handle]
+  if not state then error("invalid visual extension handle", 2) end
+  return state
+end
 
 function VisualHandle:id()
-  return self.raw:id()
+  return visualHandleState(self).raw:id()
 end
 
 function VisualHandle:is_active()
-  return self.raw:is_active()
+  return visualHandleState(self).raw:is_active()
 end
 
 function VisualHandle:status()
-  local status = self.raw:status()
-  status.visualClaims = self.host.visuals:status(self.record).visualClaims
+  local state = visualHandleState(self)
+  local status = state.raw:status()
+  status.visualClaims = state.host.visuals:status(state.record).visualClaims
   return status
 end
 
 function VisualHandle:claim_visual_objects(ids)
-  return self.host.visuals:claim(self.record, ids)
+  local state = visualHandleState(self)
+  return state.host.visuals:claim(state.record, ids)
 end
 
 function VisualHandle:invalidate(context, reason)
-  local ok, err = self.raw:invalidate(context, reason)
-  if ok then self.host.visuals:clear(self.record) end
+  local state = visualHandleState(self)
+  local ok, err = state.raw:invalidate(context, reason)
+  if ok then state.host.visuals:clear(state.record) end
   return ok, err
 end
 
 function VisualHandle:dispose(context, reason)
-  local ok, err = self.raw:dispose(context, reason)
-  if ok then self.host.visuals:remove(self.record) end
+  local state = visualHandleState(self)
+  local ok, err = state.raw:dispose(context, reason)
+  if ok then state.host.visuals:remove(state.record) end
   return ok, err
 end
 

--- a/lib/VoxelCompanion.lua
+++ b/lib/VoxelCompanion.lua
@@ -10,6 +10,7 @@ local V = ...
 local API = V.require("VoxelCompanionAPI")
 local Mat4 = V.require("Mat4")
 local TileShape = V.require("TileShape")
+local ChunkMesher = V.require("ChunkMesher")
 local Voxel = V.require("VoxelState")
 local Voxel3D = V.require("Voxel3D")
 local DayNight = V.require("DayNight")
@@ -24,6 +25,7 @@ local CAPABILITIES = {
   "render_phases",
   "quality_tier",
   "integrity_status",
+  "visual_object_overrides",
 }
 
 local WORLD_PHASES = {
@@ -35,6 +37,7 @@ local WORLD_PHASES = {
 local MAX_CELLS = 262144
 local MAX_ACTORS = 2048
 local MAX_NEIGHBORS = 8
+local MAX_VISUAL_OBJECTS = 4096
 local MAX_PACKET_ITEMS = 2048
 local MAX_DRAWS_PER_FRAME = 4096
 local MAX_WORLD_COORDINATE = 65536
@@ -201,6 +204,7 @@ local function copySnapshot(source)
   out.tags = copyTags(source.tags)
   out.player = shallowCopy(source.player)
   out.cells, out.actors, out.neighbors = {}, {}, {}
+  out.visualObjects = {}
   for index, cell in ipairs(source.cells or {}) do
     local copy = shallowCopy(cell)
     copy.tags = copyTags(cell.tags)
@@ -217,6 +221,15 @@ local function copySnapshot(source)
     local copy = shallowCopy(neighbor)
     copy.tags = copyTags(neighbor.tags)
     out.neighbors[index] = copy
+  end
+  local function copyPlain(value)
+    if type(value) ~= "table" then return value end
+    local copy = {}
+    for key, item in pairs(value) do copy[key] = copyPlain(item) end
+    return copy
+  end
+  for index, visual in ipairs(source.visualObjects or {}) do
+    out.visualObjects[index] = copyPlain(visual)
   end
   return out
 end
@@ -1134,6 +1147,73 @@ local function cellClass(map, shapes, x, z)
   return tile, shape and shape.class or "ground", shape and shape.h or 0
 end
 
+local function appendVisualObjects(map, role, offsetX, offsetZ, byId, counts, scan)
+  if type(map) ~= "table" or type(map.id) ~= "string" or not map.tileset then return end
+  local width = integer(map.widthCells, nil)
+    or integer(map.def and map.def.width, 0) * 2
+  local height = integer(map.heightCells, nil)
+    or integer(map.def and map.def.height, 0) * 2
+  if width < 1 or height < 1 or width * height > MAX_CELLS then return end
+  local shapes = TileShape.forMap(map)
+  local tilesetId = boundedText(map.tileset.id, "unknown", 64)
+  if not tilesetId:match("^[A-Za-z0-9._%-]+$") then tilesetId = "unknown" end
+  for z = 0, height - 1 do
+    for x = 0, width - 1 do
+      local _, class = cellClass(map, shapes, x, z)
+      if class == "signpost" then
+        scan.count = scan.count + 1
+        if scan.count > MAX_VISUAL_OBJECTS then return end
+        local id = API.visual_object_id("BATTLE_ART_VOXEL_FORK",
+          "signpost", map.id, x, z)
+        if id then
+          counts[id] = (counts[id] or 0) + 1
+          if counts[id] > 1 then
+            -- The public ID names map data, not one rendered placement. If the
+            -- same map/cell appears twice, no single replacement transform is
+            -- authoritative. Omit the descriptor so ownership fails closed.
+            byId[id] = nil
+          else
+            local localX, localY, localZ = x * 16 + 8, 0, z * 16 + 12
+            byId[id] = {
+              schemaVersion = 1,
+              id = id,
+              kind = "signpost",
+              tags = { "host_geometry", "signpost", "visual_object" },
+              map = {
+                id = map.id,
+                role = role,
+                offsetX = offsetX,
+                offsetZ = offsetZ,
+              },
+              cell = { x = x, z = z },
+              transform = {
+                localPosition = { x = localX, y = localY, z = localZ },
+                worldPosition = {
+                  x = localX + offsetX,
+                  y = localY,
+                  z = localZ + offsetZ,
+                },
+                rotation = { yaw = 0, pitch = 0, roll = 0 },
+                scale = { x = 1, y = 1, z = 1 },
+              },
+              pivot = { kind = "bottom_center", x = 0, y = 0, z = 0 },
+              dimensions = { width = 16, height = 16, depth = 2 },
+              material = {
+                id = "host:tileset:" .. tilesetId .. ":signpost",
+                phase = "opaque_after_terrain",
+                opaque = true,
+                alphaCutout = true,
+                castsShadow = true,
+                receivesShadow = true,
+              },
+            }
+          end
+        end
+      end
+    end
+  end
+end
+
 local function addWorldTags(tags, map)
   local def = map and map.def or {}
   local mapId = tostring(map and map.id or ""):upper()
@@ -1396,6 +1476,24 @@ local function snapshotFor(self)
     end
   end
 
+
+  local visualObjects, visualById, visualCounts = {}, {}, {}
+  local visualScan = { count = 0 }
+  appendVisualObjects(map, "current", 0, 0,
+    visualById, visualCounts, visualScan)
+  for index = 1, math.min(#(state.neighbors or {}), MAX_NEIGHBORS) do
+    local neighbor = state.neighbors[index]
+    if neighbor and neighbor.map then
+      appendVisualObjects(neighbor.map, "neighbor",
+        finite(neighbor.ox, 0), finite(neighbor.oy, 0),
+        visualById, visualCounts, visualScan)
+    end
+  end
+  for _, object in pairs(visualById) do
+    visualObjects[#visualObjects + 1] = object
+  end
+  table.sort(visualObjects, function(a, b) return a.id < b.id end)
+
   local mode = "diorama"
   if Voxel.isFirstPerson() then mode = "first_person"
   elseif Voxel.isThirdPerson() then mode = "third_person" end
@@ -1414,6 +1512,7 @@ local function snapshotFor(self)
     player = poseOf(state.player),
     actors = actors,
     neighbors = neighbors,
+    visualObjects = visualObjects,
     cells = cells,
     time = finite(DayNight.time(), 0),
     weather = "clear",
@@ -1527,6 +1626,13 @@ function VoxelCompanion.new(options)
       rememberDiagnostic(self, message)
       loggerCall(mod, "error", "Voxel Companion: " .. tostring(message))
     end,
+    visual_objects_changed = function(mapIds)
+      for _, mapId in ipairs(mapIds or {}) do
+        if type(ChunkMesher.refreshVisualObjects) == "function" then
+          ChunkMesher.refreshVisualObjects(mapId)
+        end
+      end
+    end,
   })
 
   local raw = self.dispatcher:provider()
@@ -1626,13 +1732,19 @@ function VoxelCompanion:update(dt, state)
       and self.clock >= self.nextSnapshotAttempt then
     local snapshot, snapshotError = self.world.snapshot()
     if snapshot then
-      local report, dispatchError = self.dispatcher:world_changed(snapshot)
-      if report then
-        self.worldPending = false
-        self.worldChangeReason = nil
-        self.lastSnapshotError = nil
+      local cataloged, catalogError = self.dispatcher:set_visual_objects(
+        snapshot.visualObjects or {})
+      if cataloged then
+        local report, dispatchError = self.dispatcher:world_changed(snapshot)
+        if report then
+          self.worldPending = false
+          self.worldChangeReason = nil
+          self.lastSnapshotError = nil
+        else
+          snapshotError = dispatchError
+        end
       else
-        snapshotError = dispatchError
+        snapshotError = catalogError
       end
     end
     if not snapshot or self.worldPending then
@@ -1663,6 +1775,15 @@ function VoxelCompanion:cameraDelta(state)
   if not self.started then return nil end
   local delta = self.dispatcher:modifyCamera(cameraContext(self))
   return delta
+end
+
+function VoxelCompanion:suppressesVisualObject(id)
+  return self.started and self.dispatcher:is_visual_object_suppressed(id) or false
+end
+
+function VoxelCompanion:hasVisualObjectOverrides(mapId)
+  return self.started
+    and self.dispatcher:visual_object_overrides_active(mapId) or false
 end
 
 function VoxelCompanion:render(phase, state)
@@ -1740,6 +1861,7 @@ VoxelCompanion.LIMITS = {
   cells = MAX_CELLS,
   actors = MAX_ACTORS,
   neighbors = MAX_NEIGHBORS,
+  visualObjects = MAX_VISUAL_OBJECTS,
   packetItems = MAX_PACKET_ITEMS,
   frameDraws = MAX_DRAWS_PER_FRAME,
   commandSignatures = MAX_COMMAND_SIGNATURES,

--- a/lib/VoxelCompanion.lua
+++ b/lib/VoxelCompanion.lua
@@ -1156,6 +1156,13 @@ local function cellClass(map, shapes, x, z)
   return tile, shape and shape.class or "ground", shape and shape.h or 0
 end
 
+local function annotatedVisualObject(map, id)
+  local inspect = ChunkMesher.visualObjectAnnotated
+  if type(inspect) ~= "function" then return false end
+  local ok, annotated = pcall(inspect, map, id)
+  return ok and annotated == true
+end
+
 local function appendVisualObjects(map, role, offsetX, offsetZ, byId, counts, scan)
   if type(map) ~= "table" or type(map.id) ~= "string" or not map.tileset then return end
   local width = integer(map.widthCells, nil)
@@ -1174,7 +1181,7 @@ local function appendVisualObjects(map, role, offsetX, offsetZ, byId, counts, sc
         if scan.count > MAX_VISUAL_OBJECTS then return end
         local id = VisualObjects.id("BATTLE_ART_VOXEL_FORK",
           "signpost", map.id, x, z)
-        if id then
+        if id and annotatedVisualObject(map, id) then
           counts[id] = (counts[id] or 0) + 1
           if counts[id] > 1 then
             -- The public ID names map data, not one rendered placement. If the

--- a/lib/VoxelCompanionAPI.lua
+++ b/lib/VoxelCompanionAPI.lua
@@ -17,6 +17,7 @@ API.CAPABILITIES = {
   SHADOW_PASS = "shadow_pass",
   BATTLE_PASS = "battle_pass",
   INTEGRITY_STATUS = "integrity_status",
+  VISUAL_OBJECT_OVERRIDES = "visual_object_overrides",
 }
 -- Short aliases name capability-backed attach facades. Materials and draw are
 -- normalized render services, not negotiated wire capabilities.
@@ -40,6 +41,7 @@ local STANDARD_CAPABILITY_SET = {
   shadow_pass = true,
   battle_pass = true,
   integrity_status = true,
+  visual_object_overrides = true,
 }
 
 API.PHASES = {
@@ -129,6 +131,8 @@ local MAX_ERROR_MESSAGE_LENGTH = 4096
 local MAX_DRAW_ITEMS = 8192
 local MAX_DRAW_TEXT_LENGTH = 512
 local MAX_DRAW_CACHE_KEY_LENGTH = 64
+local MAX_VISUAL_OBJECTS = 4096
+local MAX_VISUAL_CLAIMS = 4096
 
 API.DRAW_LIMITS = {
   cacheKeyBytes = MAX_DRAW_CACHE_KEY_LENGTH,
@@ -518,6 +522,170 @@ local function semantic_token(value, path, maximum)
     return nil, path .. " must be a semantic identifier, not an asset or path string"
   end
   return text
+end
+
+local function safe_visual_id(value, path)
+  local id, err = bounded_text(value, path, MAX_ID_LENGTH)
+  if not id then return nil, err end
+  if not id:match("^[A-Za-z0-9][A-Za-z0-9%._:%-]*$") then
+    return nil, path .. " must use safe ASCII identifier characters"
+  end
+  return id
+end
+
+-- Hosts and companions can derive the same stable identifier without exposing
+-- a mesh, atlas object, or another private renderer handle.
+function API.visual_object_id(host_id, kind, map_id, cell_x, cell_z)
+  for _, item in ipairs({ host_id, kind, map_id }) do
+    if type(item) ~= "string" or item == ""
+        or not item:match("^[A-Za-z0-9][A-Za-z0-9%._%-]*$") then
+      return nil, "visual object identity contains an unsafe segment"
+    end
+  end
+  if not is_integer(cell_x) or not is_integer(cell_z) then
+    return nil, "visual object cell coordinates must be integers"
+  end
+  local id = table.concat({ host_id, kind, map_id, cell_x, cell_z }, ":")
+  if #id > MAX_ID_LENGTH then return nil, "visual object id is too long" end
+  return id
+end
+
+local VISUAL_DESCRIPTOR_KEYS = {
+  schemaVersion = true, id = true, kind = true, tags = true, map = true,
+  cell = true, transform = true, pivot = true, dimensions = true,
+  material = true,
+}
+local VISUAL_MAP_KEYS = {
+  id = true, role = true, offsetX = true, offsetZ = true,
+}
+local VISUAL_CELL_KEYS = { x = true, z = true }
+local VISUAL_TRANSFORM_KEYS = {
+  localPosition = true, worldPosition = true, rotation = true, scale = true,
+}
+local VISUAL_PIVOT_KEYS = { kind = true, x = true, y = true, z = true }
+local VISUAL_DIMENSION_KEYS = { width = true, height = true, depth = true }
+local VISUAL_MATERIAL_KEYS = {
+  id = true, phase = true, opaque = true, alphaCutout = true,
+  castsShadow = true, receivesShadow = true,
+}
+
+local function validate_finite_fields(value, keys, path, positive)
+  if type(value) ~= "table" or getmetatable(value) ~= nil then
+    return nil, path .. " must be a plain table"
+  end
+  local ok, err = validate_known_keys(value, keys, path)
+  if not ok then return nil, err end
+  for key in pairs(keys) do
+    local number = value[key]
+    if not is_finite(number) or (positive and number <= 0) then
+      return nil, ("%s.%s must be a %snumber")
+        :format(path, key, positive and "positive " or "finite ")
+    end
+  end
+  return true
+end
+
+local function validate_visual_descriptor(value, path)
+  if type(value) ~= "table" or getmetatable(value) ~= nil then
+    return nil, path .. " must be a plain table"
+  end
+  local ok, err = validate_known_keys(value, VISUAL_DESCRIPTOR_KEYS, path)
+  if not ok then return nil, err end
+  if value.schemaVersion ~= 1 then return nil, path .. ".schemaVersion must be 1" end
+  local id
+  id, err = safe_visual_id(value.id, path .. ".id")
+  if not id then return nil, err end
+  local kind
+  kind, err = semantic_token(value.kind, path .. ".kind", 64)
+  if not kind then return nil, err end
+
+  local tag_count
+  tag_count, err = validate_dense_array(value.tags, path .. ".tags", 32)
+  if not tag_count then return nil, err end
+  local tags = {}
+  for index = 1, tag_count do
+    local tag
+    tag, err = semantic_token(value.tags[index],
+      ("%s.tags[%d]"):format(path, index), 64)
+    if not tag then return nil, err end
+    if tags[tag] then return nil, path .. ".tags contains a duplicate" end
+    tags[tag] = true
+  end
+
+  if type(value.map) ~= "table" or getmetatable(value.map) ~= nil then
+    return nil, path .. ".map must be a plain table"
+  end
+  ok, err = validate_known_keys(value.map, VISUAL_MAP_KEYS, path .. ".map")
+  if not ok then return nil, err end
+  local map_id
+  map_id, err = safe_visual_id(value.map.id, path .. ".map.id")
+  if not map_id then return nil, err end
+  if value.map.role ~= "current" and value.map.role ~= "neighbor" then
+    return nil, path .. ".map.role must be current or neighbor"
+  end
+  if not is_finite(value.map.offsetX) or not is_finite(value.map.offsetZ) then
+    return nil, path .. ".map offsets must be finite"
+  end
+
+  if type(value.cell) ~= "table" or getmetatable(value.cell) ~= nil then
+    return nil, path .. ".cell must be a plain table"
+  end
+  ok, err = validate_known_keys(value.cell, VISUAL_CELL_KEYS, path .. ".cell")
+  if not ok then return nil, err end
+  if not is_integer(value.cell.x) or not is_integer(value.cell.z) then
+    return nil, path .. ".cell coordinates must be integers"
+  end
+
+  if type(value.transform) ~= "table" or getmetatable(value.transform) ~= nil then
+    return nil, path .. ".transform must be a plain table"
+  end
+  ok, err = validate_known_keys(value.transform, VISUAL_TRANSFORM_KEYS,
+    path .. ".transform")
+  if not ok then return nil, err end
+  for _, field in ipairs({ "localPosition", "worldPosition", "rotation", "scale" }) do
+    ok, err = validate_finite_fields(value.transform[field],
+      field == "rotation" and ROTATION_KEYS or POSITION_KEYS,
+      path .. ".transform." .. field, field == "scale")
+    if not ok then return nil, err end
+  end
+
+  if type(value.pivot) ~= "table" or getmetatable(value.pivot) ~= nil then
+    return nil, path .. ".pivot must be a plain table"
+  end
+  ok, err = validate_known_keys(value.pivot, VISUAL_PIVOT_KEYS, path .. ".pivot")
+  if not ok then return nil, err end
+  if value.pivot.kind ~= "bottom_center" then
+    return nil, path .. ".pivot.kind must be bottom_center"
+  end
+  for _, key in ipairs({ "x", "y", "z" }) do
+    if not is_finite(value.pivot[key]) then
+      return nil, path .. ".pivot coordinates must be finite"
+    end
+  end
+
+  ok, err = validate_finite_fields(value.dimensions, VISUAL_DIMENSION_KEYS,
+    path .. ".dimensions", true)
+  if not ok then return nil, err end
+
+  if type(value.material) ~= "table" or getmetatable(value.material) ~= nil then
+    return nil, path .. ".material must be a plain table"
+  end
+  ok, err = validate_known_keys(value.material, VISUAL_MATERIAL_KEYS,
+    path .. ".material")
+  if not ok then return nil, err end
+  local material_id
+  material_id, err = semantic_token(value.material.id, path .. ".material.id", 128)
+  if not material_id then return nil, err end
+  if value.material.phase ~= "opaque_after_terrain" then
+    return nil, path .. ".material.phase must be opaque_after_terrain"
+  end
+  for _, key in ipairs({ "opaque", "alphaCutout", "castsShadow", "receivesShadow" }) do
+    if type(value.material[key]) ~= "boolean" then
+      return nil, path .. ".material." .. key .. " must be Boolean"
+    end
+  end
+
+  return clone_data(value, path)
 end
 
 local function validate_draw_cache_key(value)
@@ -1483,6 +1651,7 @@ function API.new(options)
     clock = true,
     max_errors = true,
     max_extensions = true,
+    visual_objects_changed = true,
   }
   local ok, err = validate_known_keys(options, allowed, "options")
   if not ok then error(err, 2) end
@@ -1500,6 +1669,10 @@ function API.new(options)
   end
   if options.clock ~= nil and type(options.clock) ~= "function" then
     error("options.clock must be a function", 2)
+  end
+  if options.visual_objects_changed ~= nil
+      and type(options.visual_objects_changed) ~= "function" then
+    error("options.visual_objects_changed must be a function", 2)
   end
   local max_errors = options.max_errors or 64
   if not is_integer(max_errors) or max_errors < 1 or max_errors > 4096 then
@@ -1539,6 +1712,7 @@ function API.new(options)
     _clock = options.clock or os.clock,
     _max_errors = max_errors,
     _max_extensions = max_extensions,
+    _visual_objects_changed = options.visual_objects_changed,
     _errors = {},
     _error_sequence = 0,
     _records = {},
@@ -1548,6 +1722,12 @@ function API.new(options)
     _attached = false,
     _state = "open",
     _dispatch_depth = 0,
+    _invoking_record = nil,
+    _invoking_stage = nil,
+    _visual_objects = {},
+    _visual_object_order = {},
+    _visual_owners = {},
+    _visual_conflicts = {},
   }, Dispatcher)
 end
 
@@ -1603,13 +1783,129 @@ function Dispatcher:_rebuild_order()
   self._order = order
 end
 
+function Dispatcher:_notify_visual_owner_changes(previous, current, previous_objects)
+  local changed_maps = {}
+  local ids = {}
+  for id in pairs(previous or {}) do ids[id] = true end
+  for id in pairs(current or {}) do ids[id] = true end
+  for id in pairs(ids) do
+    if (previous[id] ~= nil) ~= (current[id] ~= nil) then
+      local descriptor = self._visual_objects[id]
+        or (previous_objects and previous_objects[id])
+      local map_id = descriptor and descriptor.map and descriptor.map.id
+      if map_id then changed_maps[map_id] = true end
+    end
+  end
+  if not next(changed_maps) or not self._visual_objects_changed then return end
+  local maps = sorted_keys(changed_maps)
+  local ok, problem = pcall(self._visual_objects_changed, maps)
+  if not ok then self:_append_error(nil, "visual_objects_changed", problem) end
+end
+
+function Dispatcher:_rebuild_visual_owners(previous_objects)
+  local previous = self._visual_owners or {}
+  local contenders = {}
+  for _, record in ipairs(self._order) do
+    if record.active and not record.faulted and record.visual_claims then
+      for id in pairs(record.visual_claims) do
+        if self._visual_objects[id] then
+          local list = contenders[id]
+          if not list then list = {}; contenders[id] = list end
+          list[#list + 1] = record.id
+        end
+      end
+    end
+  end
+
+  local owners, conflicts = {}, {}
+  for id, list in pairs(contenders) do
+    table.sort(list)
+    if #list == 1 then owners[id] = list[1]
+    else conflicts[id] = list end
+  end
+  self._visual_owners = owners
+  self._visual_conflicts = conflicts
+  self:_notify_visual_owner_changes(previous, owners, previous_objects)
+end
+
+function Dispatcher:_clear_visual_claims(record)
+  if not record or record.visual_claims == nil then return false end
+  record.visual_claims = nil
+  self:_rebuild_visual_owners()
+  return true
+end
+
+-- Host-only catalog seam. Descriptors are validated and copied before they
+-- become claimable. A bad replacement catalog leaves the prior catalog live.
+function Dispatcher:set_visual_objects(descriptors)
+  if not self._capabilities.visual_object_overrides then
+    return nil, "visual object overrides are unavailable"
+  end
+  local count, err = validate_dense_array(descriptors, "visual objects",
+    MAX_VISUAL_OBJECTS)
+  if not count then return nil, err end
+  local by_id, order = {}, {}
+  for index = 1, count do
+    local descriptor
+    descriptor, err = validate_visual_descriptor(descriptors[index],
+      ("visual objects[%d]"):format(index))
+    if not descriptor then return nil, err end
+    if by_id[descriptor.id] then
+      return nil, "visual object catalog contains duplicate id " .. descriptor.id
+    end
+    by_id[descriptor.id] = descriptor
+    order[#order + 1] = descriptor
+  end
+  table.sort(order, function(a, b) return a.id < b.id end)
+
+  local previous_objects = self._visual_objects
+  self._visual_objects = by_id
+  self._visual_object_order = order
+  for _, record in ipairs(self._order) do
+    if record.visual_claims then
+      for id in pairs(record.visual_claims) do
+        if not by_id[id] then record.visual_claims[id] = nil end
+      end
+      if not next(record.visual_claims) then record.visual_claims = nil end
+    end
+  end
+  self:_rebuild_visual_owners(previous_objects)
+  return true
+end
+
+function Dispatcher:visual_objects()
+  local copy, err = clone_data(self._visual_object_order, "visual objects")
+  if not copy then return nil, err end
+  return copy
+end
+
+function Dispatcher:is_visual_object_suppressed(id)
+  return type(id) == "string" and self._visual_owners[id] ~= nil or false
+end
+
+function Dispatcher:visual_object_owner(id)
+  return type(id) == "string" and self._visual_owners[id] or nil
+end
+
+function Dispatcher:visual_object_overrides_active(map_id)
+  if type(map_id) ~= "string" then return false end
+  for id in pairs(self._visual_owners) do
+    local descriptor = self._visual_objects[id]
+    if descriptor and descriptor.map and descriptor.map.id == map_id then return true end
+  end
+  return false
+end
+
 function Dispatcher:_invoke(record, stage, handler, source, ...)
   local context, close = borrowed_view(source, stage .. " context")
   local extra = pack(...)
+  local previous_record, previous_stage = self._invoking_record, self._invoking_stage
+  self._invoking_record, self._invoking_stage = record, stage
   local function run()
     return pack(handler(context, unpack(extra, 1, extra.n)))
   end
   local ok, result = xpcall(run, traceback_error)
+  self._invoking_record, self._invoking_stage = previous_record, previous_stage
   local clean, mutation = close()
   if not ok then return nil, result end
   if not clean then return nil, mutation end
@@ -1619,6 +1915,7 @@ end
 function Dispatcher:_invoke_dispose(record, source, reason, keep_fault_state)
   if record.dispose_called then return true end
   record.dispose_called = true
+  self:_clear_visual_claims(record)
   record.active = false
   local handler = record.lifecycle.dispose
   if handler then
@@ -1646,6 +1943,7 @@ function Dispatcher:_fault(record, stage, message, source)
   local owns_guard = self._dispatch_depth == 0
   if owns_guard then self._dispatch_depth = 1 end
   record.active = false
+  self:_clear_visual_claims(record)
   record.faulted = true
   record.state = "faulted"
   record.fault = self:_append_error(record, stage, message)
@@ -1860,6 +2158,7 @@ function Dispatcher:register(spec, running_context)
       record.started = true
       record.active = true
       record.state = "active"
+      self:_rebuild_visual_owners()
     end
   end
   return handle
@@ -1912,6 +2211,7 @@ function Dispatcher:start(context)
   end
   self._dispatch_depth = self._dispatch_depth - 1
   self._state = "running"
+  self:_rebuild_visual_owners()
   return report
 end
 
@@ -2151,6 +2451,7 @@ function Dispatcher:invalidate(context, reason)
   return self:_run_dispatch("invalidate", function()
     local report = new_report("lifecycle", "invalidate")
     for _, record in ipairs(copy_array(self._order)) do
+      self:_clear_visual_claims(record)
       local handler = record.lifecycle.invalidate
       if handler then
         if not record.active then
@@ -2216,6 +2517,10 @@ function Dispatcher:dispose(context, reason)
   self._dispatch_depth = self._dispatch_depth - 1
   self._services = nil
   self._running_context = nil
+  self._visual_objects = {}
+  self._visual_object_order = {}
+  self._visual_owners = {}
+  self._visual_conflicts = {}
   self._records = {}
   self._order = {}
   self._state = "disposed"
@@ -2258,6 +2563,9 @@ function Dispatcher:status()
     attached = self._attached,
     capabilities = self:capabilities(),
     extensions = extensions,
+    visualObjects = #self._visual_object_order,
+    visualOverrides = #sorted_keys(self._visual_owners),
+    visualConflicts = #sorted_keys(self._visual_conflicts),
     errorCount = #self._errors,
   }
 end
@@ -2277,12 +2585,78 @@ function Handle:status()
     state = record.state,
     active = record.active,
     faulted = record.faulted,
+    visualClaims = record.visual_claims and #sorted_keys(record.visual_claims) or 0,
     fault = record.fault and {
       sequence = record.fault.sequence,
       stage = record.fault.stage,
       message = record.fault.message,
     } or nil,
   }
+end
+
+-- Optional visual-object override registration. The extension uses the normal
+-- opaque render callback and its borrowed draw facade for replacement work.
+-- This method registers only ownership of copied, currently known IDs.
+function Handle:claim_visual_objects(ids)
+  local dispatcher, record = self._dispatcher, self._record
+  if not dispatcher._capabilities.visual_object_overrides then
+    return nil, "visual object overrides are unavailable"
+  end
+  if record.state == "disposed" or record.faulted then
+    return nil, "extension cannot claim visual objects in its current state"
+  end
+  local in_own_world_callback = dispatcher._invoking_record == record
+    and type(dispatcher._invoking_stage) == "string"
+    and dispatcher._invoking_stage:match("%.map_changed$") ~= nil
+  if dispatcher._dispatch_depth > 0 and not in_own_world_callback then
+    dispatcher:_clear_visual_claims(record)
+    return nil, "visual object claims are allowed only outside dispatch or during the owner's worldChanged callback"
+  end
+  if type(record.phases.opaque_after_terrain) ~= "function" then
+    dispatcher:_clear_visual_claims(record)
+    return nil, "visual object claims require an opaque_after_terrain render handler"
+  end
+
+  local count, err = validate_dense_array(ids, "visual object claims",
+    MAX_VISUAL_CLAIMS)
+  if not count then
+    dispatcher:_clear_visual_claims(record)
+    return nil, err
+  end
+  local claims = {}
+  for index = 1, count do
+    local id
+    id, err = safe_visual_id(ids[index],
+      ("visual object claims[%d]"):format(index))
+    if not id then
+      dispatcher:_clear_visual_claims(record)
+      return nil, err
+    end
+    if claims[id] then
+      dispatcher:_clear_visual_claims(record)
+      return nil, "visual object claims contains duplicate id " .. id
+    end
+    if not dispatcher._visual_objects[id] then
+      dispatcher:_clear_visual_claims(record)
+      return nil, "unknown visual object id " .. id
+    end
+    claims[id] = true
+  end
+
+  record.visual_claims = next(claims) and claims or nil
+  dispatcher:_rebuild_visual_owners()
+  local conflicts = {}
+  for id in pairs(claims) do
+    local owners = dispatcher._visual_conflicts[id]
+    if owners then
+      conflicts[#conflicts + 1] = id .. " [" .. table.concat(owners, ",") .. "]"
+    end
+  end
+  table.sort(conflicts)
+  if #conflicts > 0 then
+    return nil, "visual object ownership conflict: " .. table.concat(conflicts, "; ")
+  end
+  return true
 end
 
 function Handle:invalidate(context, reason)
@@ -2295,6 +2669,7 @@ function Handle:invalidate(context, reason)
     context = {}
   end
   if type(context) ~= "table" then return nil, "invalidate context must be a table" end
+  dispatcher:_clear_visual_claims(record)
   local handler = record.lifecycle.invalidate
   if not handler then return true end
 

--- a/lib/VoxelCompanionAPI.lua
+++ b/lib/VoxelCompanionAPI.lua
@@ -17,7 +17,6 @@ API.CAPABILITIES = {
   SHADOW_PASS = "shadow_pass",
   BATTLE_PASS = "battle_pass",
   INTEGRITY_STATUS = "integrity_status",
-  VISUAL_OBJECT_OVERRIDES = "visual_object_overrides",
 }
 -- Short aliases name capability-backed attach facades. Materials and draw are
 -- normalized render services, not negotiated wire capabilities.
@@ -41,7 +40,6 @@ local STANDARD_CAPABILITY_SET = {
   shadow_pass = true,
   battle_pass = true,
   integrity_status = true,
-  visual_object_overrides = true,
 }
 
 API.PHASES = {
@@ -131,8 +129,6 @@ local MAX_ERROR_MESSAGE_LENGTH = 4096
 local MAX_DRAW_ITEMS = 8192
 local MAX_DRAW_TEXT_LENGTH = 512
 local MAX_DRAW_CACHE_KEY_LENGTH = 64
-local MAX_VISUAL_OBJECTS = 4096
-local MAX_VISUAL_CLAIMS = 4096
 
 API.DRAW_LIMITS = {
   cacheKeyBytes = MAX_DRAW_CACHE_KEY_LENGTH,
@@ -522,170 +518,6 @@ local function semantic_token(value, path, maximum)
     return nil, path .. " must be a semantic identifier, not an asset or path string"
   end
   return text
-end
-
-local function safe_visual_id(value, path)
-  local id, err = bounded_text(value, path, MAX_ID_LENGTH)
-  if not id then return nil, err end
-  if not id:match("^[A-Za-z0-9][A-Za-z0-9%._:%-]*$") then
-    return nil, path .. " must use safe ASCII identifier characters"
-  end
-  return id
-end
-
--- Hosts and companions can derive the same stable identifier without exposing
--- a mesh, atlas object, or another private renderer handle.
-function API.visual_object_id(host_id, kind, map_id, cell_x, cell_z)
-  for _, item in ipairs({ host_id, kind, map_id }) do
-    if type(item) ~= "string" or item == ""
-        or not item:match("^[A-Za-z0-9][A-Za-z0-9%._%-]*$") then
-      return nil, "visual object identity contains an unsafe segment"
-    end
-  end
-  if not is_integer(cell_x) or not is_integer(cell_z) then
-    return nil, "visual object cell coordinates must be integers"
-  end
-  local id = table.concat({ host_id, kind, map_id, cell_x, cell_z }, ":")
-  if #id > MAX_ID_LENGTH then return nil, "visual object id is too long" end
-  return id
-end
-
-local VISUAL_DESCRIPTOR_KEYS = {
-  schemaVersion = true, id = true, kind = true, tags = true, map = true,
-  cell = true, transform = true, pivot = true, dimensions = true,
-  material = true,
-}
-local VISUAL_MAP_KEYS = {
-  id = true, role = true, offsetX = true, offsetZ = true,
-}
-local VISUAL_CELL_KEYS = { x = true, z = true }
-local VISUAL_TRANSFORM_KEYS = {
-  localPosition = true, worldPosition = true, rotation = true, scale = true,
-}
-local VISUAL_PIVOT_KEYS = { kind = true, x = true, y = true, z = true }
-local VISUAL_DIMENSION_KEYS = { width = true, height = true, depth = true }
-local VISUAL_MATERIAL_KEYS = {
-  id = true, phase = true, opaque = true, alphaCutout = true,
-  castsShadow = true, receivesShadow = true,
-}
-
-local function validate_finite_fields(value, keys, path, positive)
-  if type(value) ~= "table" or getmetatable(value) ~= nil then
-    return nil, path .. " must be a plain table"
-  end
-  local ok, err = validate_known_keys(value, keys, path)
-  if not ok then return nil, err end
-  for key in pairs(keys) do
-    local number = value[key]
-    if not is_finite(number) or (positive and number <= 0) then
-      return nil, ("%s.%s must be a %snumber")
-        :format(path, key, positive and "positive " or "finite ")
-    end
-  end
-  return true
-end
-
-local function validate_visual_descriptor(value, path)
-  if type(value) ~= "table" or getmetatable(value) ~= nil then
-    return nil, path .. " must be a plain table"
-  end
-  local ok, err = validate_known_keys(value, VISUAL_DESCRIPTOR_KEYS, path)
-  if not ok then return nil, err end
-  if value.schemaVersion ~= 1 then return nil, path .. ".schemaVersion must be 1" end
-  local id
-  id, err = safe_visual_id(value.id, path .. ".id")
-  if not id then return nil, err end
-  local kind
-  kind, err = semantic_token(value.kind, path .. ".kind", 64)
-  if not kind then return nil, err end
-
-  local tag_count
-  tag_count, err = validate_dense_array(value.tags, path .. ".tags", 32)
-  if not tag_count then return nil, err end
-  local tags = {}
-  for index = 1, tag_count do
-    local tag
-    tag, err = semantic_token(value.tags[index],
-      ("%s.tags[%d]"):format(path, index), 64)
-    if not tag then return nil, err end
-    if tags[tag] then return nil, path .. ".tags contains a duplicate" end
-    tags[tag] = true
-  end
-
-  if type(value.map) ~= "table" or getmetatable(value.map) ~= nil then
-    return nil, path .. ".map must be a plain table"
-  end
-  ok, err = validate_known_keys(value.map, VISUAL_MAP_KEYS, path .. ".map")
-  if not ok then return nil, err end
-  local map_id
-  map_id, err = safe_visual_id(value.map.id, path .. ".map.id")
-  if not map_id then return nil, err end
-  if value.map.role ~= "current" and value.map.role ~= "neighbor" then
-    return nil, path .. ".map.role must be current or neighbor"
-  end
-  if not is_finite(value.map.offsetX) or not is_finite(value.map.offsetZ) then
-    return nil, path .. ".map offsets must be finite"
-  end
-
-  if type(value.cell) ~= "table" or getmetatable(value.cell) ~= nil then
-    return nil, path .. ".cell must be a plain table"
-  end
-  ok, err = validate_known_keys(value.cell, VISUAL_CELL_KEYS, path .. ".cell")
-  if not ok then return nil, err end
-  if not is_integer(value.cell.x) or not is_integer(value.cell.z) then
-    return nil, path .. ".cell coordinates must be integers"
-  end
-
-  if type(value.transform) ~= "table" or getmetatable(value.transform) ~= nil then
-    return nil, path .. ".transform must be a plain table"
-  end
-  ok, err = validate_known_keys(value.transform, VISUAL_TRANSFORM_KEYS,
-    path .. ".transform")
-  if not ok then return nil, err end
-  for _, field in ipairs({ "localPosition", "worldPosition", "rotation", "scale" }) do
-    ok, err = validate_finite_fields(value.transform[field],
-      field == "rotation" and ROTATION_KEYS or POSITION_KEYS,
-      path .. ".transform." .. field, field == "scale")
-    if not ok then return nil, err end
-  end
-
-  if type(value.pivot) ~= "table" or getmetatable(value.pivot) ~= nil then
-    return nil, path .. ".pivot must be a plain table"
-  end
-  ok, err = validate_known_keys(value.pivot, VISUAL_PIVOT_KEYS, path .. ".pivot")
-  if not ok then return nil, err end
-  if value.pivot.kind ~= "bottom_center" then
-    return nil, path .. ".pivot.kind must be bottom_center"
-  end
-  for _, key in ipairs({ "x", "y", "z" }) do
-    if not is_finite(value.pivot[key]) then
-      return nil, path .. ".pivot coordinates must be finite"
-    end
-  end
-
-  ok, err = validate_finite_fields(value.dimensions, VISUAL_DIMENSION_KEYS,
-    path .. ".dimensions", true)
-  if not ok then return nil, err end
-
-  if type(value.material) ~= "table" or getmetatable(value.material) ~= nil then
-    return nil, path .. ".material must be a plain table"
-  end
-  ok, err = validate_known_keys(value.material, VISUAL_MATERIAL_KEYS,
-    path .. ".material")
-  if not ok then return nil, err end
-  local material_id
-  material_id, err = semantic_token(value.material.id, path .. ".material.id", 128)
-  if not material_id then return nil, err end
-  if value.material.phase ~= "opaque_after_terrain" then
-    return nil, path .. ".material.phase must be opaque_after_terrain"
-  end
-  for _, key in ipairs({ "opaque", "alphaCutout", "castsShadow", "receivesShadow" }) do
-    if type(value.material[key]) ~= "boolean" then
-      return nil, path .. ".material." .. key .. " must be Boolean"
-    end
-  end
-
-  return clone_data(value, path)
 end
 
 local function validate_draw_cache_key(value)
@@ -1651,7 +1483,6 @@ function API.new(options)
     clock = true,
     max_errors = true,
     max_extensions = true,
-    visual_objects_changed = true,
   }
   local ok, err = validate_known_keys(options, allowed, "options")
   if not ok then error(err, 2) end
@@ -1669,10 +1500,6 @@ function API.new(options)
   end
   if options.clock ~= nil and type(options.clock) ~= "function" then
     error("options.clock must be a function", 2)
-  end
-  if options.visual_objects_changed ~= nil
-      and type(options.visual_objects_changed) ~= "function" then
-    error("options.visual_objects_changed must be a function", 2)
   end
   local max_errors = options.max_errors or 64
   if not is_integer(max_errors) or max_errors < 1 or max_errors > 4096 then
@@ -1712,7 +1539,6 @@ function API.new(options)
     _clock = options.clock or os.clock,
     _max_errors = max_errors,
     _max_extensions = max_extensions,
-    _visual_objects_changed = options.visual_objects_changed,
     _errors = {},
     _error_sequence = 0,
     _records = {},
@@ -1722,12 +1548,6 @@ function API.new(options)
     _attached = false,
     _state = "open",
     _dispatch_depth = 0,
-    _invoking_record = nil,
-    _invoking_stage = nil,
-    _visual_objects = {},
-    _visual_object_order = {},
-    _visual_owners = {},
-    _visual_conflicts = {},
   }, Dispatcher)
 end
 
@@ -1783,129 +1603,13 @@ function Dispatcher:_rebuild_order()
   self._order = order
 end
 
-function Dispatcher:_notify_visual_owner_changes(previous, current, previous_objects)
-  local changed_maps = {}
-  local ids = {}
-  for id in pairs(previous or {}) do ids[id] = true end
-  for id in pairs(current or {}) do ids[id] = true end
-  for id in pairs(ids) do
-    if (previous[id] ~= nil) ~= (current[id] ~= nil) then
-      local descriptor = self._visual_objects[id]
-        or (previous_objects and previous_objects[id])
-      local map_id = descriptor and descriptor.map and descriptor.map.id
-      if map_id then changed_maps[map_id] = true end
-    end
-  end
-  if not next(changed_maps) or not self._visual_objects_changed then return end
-  local maps = sorted_keys(changed_maps)
-  local ok, problem = pcall(self._visual_objects_changed, maps)
-  if not ok then self:_append_error(nil, "visual_objects_changed", problem) end
-end
-
-function Dispatcher:_rebuild_visual_owners(previous_objects)
-  local previous = self._visual_owners or {}
-  local contenders = {}
-  for _, record in ipairs(self._order) do
-    if record.active and not record.faulted and record.visual_claims then
-      for id in pairs(record.visual_claims) do
-        if self._visual_objects[id] then
-          local list = contenders[id]
-          if not list then list = {}; contenders[id] = list end
-          list[#list + 1] = record.id
-        end
-      end
-    end
-  end
-
-  local owners, conflicts = {}, {}
-  for id, list in pairs(contenders) do
-    table.sort(list)
-    if #list == 1 then owners[id] = list[1]
-    else conflicts[id] = list end
-  end
-  self._visual_owners = owners
-  self._visual_conflicts = conflicts
-  self:_notify_visual_owner_changes(previous, owners, previous_objects)
-end
-
-function Dispatcher:_clear_visual_claims(record)
-  if not record or record.visual_claims == nil then return false end
-  record.visual_claims = nil
-  self:_rebuild_visual_owners()
-  return true
-end
-
--- Host-only catalog seam. Descriptors are validated and copied before they
--- become claimable. A bad replacement catalog leaves the prior catalog live.
-function Dispatcher:set_visual_objects(descriptors)
-  if not self._capabilities.visual_object_overrides then
-    return nil, "visual object overrides are unavailable"
-  end
-  local count, err = validate_dense_array(descriptors, "visual objects",
-    MAX_VISUAL_OBJECTS)
-  if not count then return nil, err end
-  local by_id, order = {}, {}
-  for index = 1, count do
-    local descriptor
-    descriptor, err = validate_visual_descriptor(descriptors[index],
-      ("visual objects[%d]"):format(index))
-    if not descriptor then return nil, err end
-    if by_id[descriptor.id] then
-      return nil, "visual object catalog contains duplicate id " .. descriptor.id
-    end
-    by_id[descriptor.id] = descriptor
-    order[#order + 1] = descriptor
-  end
-  table.sort(order, function(a, b) return a.id < b.id end)
-
-  local previous_objects = self._visual_objects
-  self._visual_objects = by_id
-  self._visual_object_order = order
-  for _, record in ipairs(self._order) do
-    if record.visual_claims then
-      for id in pairs(record.visual_claims) do
-        if not by_id[id] then record.visual_claims[id] = nil end
-      end
-      if not next(record.visual_claims) then record.visual_claims = nil end
-    end
-  end
-  self:_rebuild_visual_owners(previous_objects)
-  return true
-end
-
-function Dispatcher:visual_objects()
-  local copy, err = clone_data(self._visual_object_order, "visual objects")
-  if not copy then return nil, err end
-  return copy
-end
-
-function Dispatcher:is_visual_object_suppressed(id)
-  return type(id) == "string" and self._visual_owners[id] ~= nil or false
-end
-
-function Dispatcher:visual_object_owner(id)
-  return type(id) == "string" and self._visual_owners[id] or nil
-end
-
-function Dispatcher:visual_object_overrides_active(map_id)
-  if type(map_id) ~= "string" then return false end
-  for id in pairs(self._visual_owners) do
-    local descriptor = self._visual_objects[id]
-    if descriptor and descriptor.map and descriptor.map.id == map_id then return true end
-  end
-  return false
-end
-
 function Dispatcher:_invoke(record, stage, handler, source, ...)
   local context, close = borrowed_view(source, stage .. " context")
   local extra = pack(...)
-  local previous_record, previous_stage = self._invoking_record, self._invoking_stage
-  self._invoking_record, self._invoking_stage = record, stage
   local function run()
     return pack(handler(context, unpack(extra, 1, extra.n)))
   end
   local ok, result = xpcall(run, traceback_error)
-  self._invoking_record, self._invoking_stage = previous_record, previous_stage
   local clean, mutation = close()
   if not ok then return nil, result end
   if not clean then return nil, mutation end
@@ -1915,7 +1619,6 @@ end
 function Dispatcher:_invoke_dispose(record, source, reason, keep_fault_state)
   if record.dispose_called then return true end
   record.dispose_called = true
-  self:_clear_visual_claims(record)
   record.active = false
   local handler = record.lifecycle.dispose
   if handler then
@@ -1943,7 +1646,6 @@ function Dispatcher:_fault(record, stage, message, source)
   local owns_guard = self._dispatch_depth == 0
   if owns_guard then self._dispatch_depth = 1 end
   record.active = false
-  self:_clear_visual_claims(record)
   record.faulted = true
   record.state = "faulted"
   record.fault = self:_append_error(record, stage, message)
@@ -2158,7 +1860,6 @@ function Dispatcher:register(spec, running_context)
       record.started = true
       record.active = true
       record.state = "active"
-      self:_rebuild_visual_owners()
     end
   end
   return handle
@@ -2211,7 +1912,6 @@ function Dispatcher:start(context)
   end
   self._dispatch_depth = self._dispatch_depth - 1
   self._state = "running"
-  self:_rebuild_visual_owners()
   return report
 end
 
@@ -2451,7 +2151,6 @@ function Dispatcher:invalidate(context, reason)
   return self:_run_dispatch("invalidate", function()
     local report = new_report("lifecycle", "invalidate")
     for _, record in ipairs(copy_array(self._order)) do
-      self:_clear_visual_claims(record)
       local handler = record.lifecycle.invalidate
       if handler then
         if not record.active then
@@ -2517,10 +2216,6 @@ function Dispatcher:dispose(context, reason)
   self._dispatch_depth = self._dispatch_depth - 1
   self._services = nil
   self._running_context = nil
-  self._visual_objects = {}
-  self._visual_object_order = {}
-  self._visual_owners = {}
-  self._visual_conflicts = {}
   self._records = {}
   self._order = {}
   self._state = "disposed"
@@ -2563,9 +2258,6 @@ function Dispatcher:status()
     attached = self._attached,
     capabilities = self:capabilities(),
     extensions = extensions,
-    visualObjects = #self._visual_object_order,
-    visualOverrides = #sorted_keys(self._visual_owners),
-    visualConflicts = #sorted_keys(self._visual_conflicts),
     errorCount = #self._errors,
   }
 end
@@ -2585,78 +2277,12 @@ function Handle:status()
     state = record.state,
     active = record.active,
     faulted = record.faulted,
-    visualClaims = record.visual_claims and #sorted_keys(record.visual_claims) or 0,
     fault = record.fault and {
       sequence = record.fault.sequence,
       stage = record.fault.stage,
       message = record.fault.message,
     } or nil,
   }
-end
-
--- Optional visual-object override registration. The extension uses the normal
--- opaque render callback and its borrowed draw facade for replacement work.
--- This method registers only ownership of copied, currently known IDs.
-function Handle:claim_visual_objects(ids)
-  local dispatcher, record = self._dispatcher, self._record
-  if not dispatcher._capabilities.visual_object_overrides then
-    return nil, "visual object overrides are unavailable"
-  end
-  if record.state == "disposed" or record.faulted then
-    return nil, "extension cannot claim visual objects in its current state"
-  end
-  local in_own_world_callback = dispatcher._invoking_record == record
-    and type(dispatcher._invoking_stage) == "string"
-    and dispatcher._invoking_stage:match("%.map_changed$") ~= nil
-  if dispatcher._dispatch_depth > 0 and not in_own_world_callback then
-    dispatcher:_clear_visual_claims(record)
-    return nil, "visual object claims are allowed only outside dispatch or during the owner's worldChanged callback"
-  end
-  if type(record.phases.opaque_after_terrain) ~= "function" then
-    dispatcher:_clear_visual_claims(record)
-    return nil, "visual object claims require an opaque_after_terrain render handler"
-  end
-
-  local count, err = validate_dense_array(ids, "visual object claims",
-    MAX_VISUAL_CLAIMS)
-  if not count then
-    dispatcher:_clear_visual_claims(record)
-    return nil, err
-  end
-  local claims = {}
-  for index = 1, count do
-    local id
-    id, err = safe_visual_id(ids[index],
-      ("visual object claims[%d]"):format(index))
-    if not id then
-      dispatcher:_clear_visual_claims(record)
-      return nil, err
-    end
-    if claims[id] then
-      dispatcher:_clear_visual_claims(record)
-      return nil, "visual object claims contains duplicate id " .. id
-    end
-    if not dispatcher._visual_objects[id] then
-      dispatcher:_clear_visual_claims(record)
-      return nil, "unknown visual object id " .. id
-    end
-    claims[id] = true
-  end
-
-  record.visual_claims = next(claims) and claims or nil
-  dispatcher:_rebuild_visual_owners()
-  local conflicts = {}
-  for id in pairs(claims) do
-    local owners = dispatcher._visual_conflicts[id]
-    if owners then
-      conflicts[#conflicts + 1] = id .. " [" .. table.concat(owners, ",") .. "]"
-    end
-  end
-  table.sort(conflicts)
-  if #conflicts > 0 then
-    return nil, "visual object ownership conflict: " .. table.concat(conflicts, "; ")
-  end
-  return true
 end
 
 function Handle:invalidate(context, reason)
@@ -2669,7 +2295,6 @@ function Handle:invalidate(context, reason)
     context = {}
   end
   if type(context) ~= "table" then return nil, "invalidate context must be a table" end
-  dispatcher:_clear_visual_claims(record)
   local handler = record.lifecycle.invalidate
   if not handler then return true end
 

--- a/lib/VoxelScene.lua
+++ b/lib/VoxelScene.lua
@@ -407,7 +407,7 @@ end
 -- update + render). Keep stable masks/live metadata and reuse the output arrays.
 local neighborhood = { map = nil, count = 0, rows = {} }
 local cachedMasks = {}
-local nbMeshBuf, nbWaterBuf = {}, {}
+local nbMeshBuf, nbWaterBuf, nbVisualShadowBuf = {}, {}, {}
 local lastCompleteCanvas, lastCompleteW, lastCompleteH = nil, 0, 0
 local lastCompleteMapId = nil
 
@@ -486,9 +486,9 @@ function VoxelScene.prefetch(state)
   -- cut out of that build's own geometry (ChunkMesher.pair), so the two
   -- always come from the same slot and a lake is never drawn twice or left
   -- as a hole.
-  local terrain, water = ChunkMesher.pair(state.map, false)
+  local terrain, water, _, visualShadows = ChunkMesher.pair(state.map, false)
   if not terrain then
-    terrain, water = ChunkMesher.pair(state.map, true)
+    terrain, water, _, visualShadows = ChunkMesher.pair(state.map, true)
   end
   -- A cold WARP destination has never been a connected neighbour, so it has
   -- no body slot waiting for it. Queue that smaller useful-first mesh before
@@ -503,20 +503,25 @@ function VoxelScene.prefetch(state)
   for i, nb in ipairs(nbs) do
     if RenderDistance.neighbor(nb, state.player) then
       ChunkMesher.request(nb.map, true)
-      nbMeshBuf[i], nbWaterBuf[i] = ChunkMesher.pair(nb.map, true)
+      nbMeshBuf[i], nbWaterBuf[i], _, nbVisualShadowBuf[i] =
+        ChunkMesher.pair(nb.map, true)
       if not nbMeshBuf[i] then
-        nbMeshBuf[i], nbWaterBuf[i] = ChunkMesher.pair(nb.map, false)
+        nbMeshBuf[i], nbWaterBuf[i], _, nbVisualShadowBuf[i] =
+          ChunkMesher.pair(nb.map, false)
       end
     else
       nbMeshBuf[i], nbWaterBuf[i] = nil, nil
+      nbVisualShadowBuf[i] = nil
     end
     -- if not nbMeshBuf[i] then ready = false end
   end
   for i = #nbs + 1, #nbMeshBuf do
     nbMeshBuf[i], nbWaterBuf[i] = nil, nil
+    nbVisualShadowBuf[i] = nil
   end
   Voxel.ready = ready
-  return terrain, nbMeshBuf, water, nbWaterBuf, ready
+  return terrain, nbMeshBuf, water, nbWaterBuf, ready,
+    visualShadows, nbVisualShadowBuf
 end
 
 local function heldFrame(w, h, mapId)
@@ -878,8 +883,8 @@ end
 
 -- The sun pass: render the scene once from the light, so the main pass can
 -- ask any fragment whether the sun reached it. Every caster the main pass
--- draws goes in -- the terrain mesh, which is where buildings, trees,
--- ledges, signs and every prop live, plus one UPRIGHT card per character
+-- draws goes in -- the terrain mesh, its sign sidecars, and one UPRIGHT card
+-- per character
 -- (Voxel3D.casterMatrix; the leaning slab is a trick for the camera, not
 -- for the sun) -- so shadows land on walls, roofs, ledges and passing NPCs
 -- as readily as on the floor.
@@ -888,17 +893,25 @@ end
 -- left out on purpose: thousands of tufts would cast a speckle no bigger
 -- than the pixels it lands on, at the cost of the mesh being drawn twice.
 local function castShadows(state, terrain, nbMesh, posed, cx, cy, vw, vh,
-                           atlasFor, water, nbWater)
+                           atlasFor, water, nbWater, visualShadows,
+                           nbVisualShadows)
   if not ShadowMap.available() then return end
   local sig = shadowSignature(state, terrain, nbMesh, posed, cx, cy, vw, vh)
   if not ShadowMap.stale(sig) then return end
   if not ShadowMap.begin(cx, cy, vw, vh) then return end
 
   ShadowMap.draw(terrain, atlasFor(state.map), nil)
+  for _, visual in ipairs(visualShadows or {}) do
+    ShadowMap.draw(visual.mesh, atlasFor(state.map), nil)
+  end
   for i, nb in ipairs(state.neighbors or {}) do
     if RenderDistance.neighbor(nb, state.player) then
       ShadowMap.draw(nbMesh[i], atlasFor(nb.map),
                      Mat4.translate(nb.ox, 0, nb.oy))
+      for _, visual in ipairs((nbVisualShadows and nbVisualShadows[i]) or {}) do
+        ShadowMap.draw(visual.mesh, atlasFor(nb.map),
+                       Mat4.translate(nb.ox, 0, nb.oy))
+      end
     end
   end
   -- The water surface, which the terrain mesh no longer carries (it is its
@@ -988,7 +1001,8 @@ function VoxelScene.render(state, w, h, vw, vh, paletteFor)
   -- still falls back to the engine's 2D path; an in-flight healthy build stays
   -- black so flat tiles are never exposed immediately before the voxels land.
   -- Voxel.ready also holds the camera tween at flat until terrain exists.
-  local terrain, nbMesh, water, nbWater, neighborhoodReady =
+  local terrain, nbMesh, water, nbWater, neighborhoodReady,
+    visualShadows, nbVisualShadows =
     VoxelScene.prefetch(state)
   if not neighborhoodReady then
     -- The FULL mesh already suppresses its ring beneath every connected map.
@@ -1093,7 +1107,7 @@ function VoxelScene.render(state, w, h, vw, vh, paletteFor)
 
   local shCx, shCy = FirstPerson.shadowCenter(cx, cy, vh)
   castShadows(state, terrain, nbMesh, posed, shCx, shCy, vw, vh, atlasFor,
-              water, nbWater)
+              water, nbWater, visualShadows, nbVisualShadows)
 
   if not Voxel3D.beginScene(w, h, cx, cy, vw, vh, skyFor(state.map)) then
     Voxel3D.setCompanionCameraDelta(nil)
@@ -1112,10 +1126,26 @@ function VoxelScene.render(state, w, h, vw, vh, paletteFor)
   -- Drawn before terrain, depth alone decides where it remains visible.
   WorldUnderlay.draw(state, cx, cy, underlayColor)
   Voxel3D.draw(terrain, atlasFor(state.map), nil)
+  local drawnVisuals, drawnNeighborVisuals = {}, {}
+  for _, visual in ipairs(visualShadows or {}) do
+    if ChunkMesher.visualObjectVisible(visual.id) then
+      Voxel3D.draw(visual.mesh, atlasFor(state.map), nil)
+      drawnVisuals[visual.id] = true
+    end
+  end
   for i, nb in ipairs(state.neighbors or {}) do
     if RenderDistance.neighbor(nb, state.player) then
       Voxel3D.draw(nbMesh[i], atlasFor(nb.map),
                    Mat4.translate(nb.ox, 0, nb.oy))
+      local drawn = {}
+      drawnNeighborVisuals[i] = drawn
+      for _, visual in ipairs((nbVisualShadows and nbVisualShadows[i]) or {}) do
+        if ChunkMesher.visualObjectVisible(visual.id) then
+          Voxel3D.draw(visual.mesh, atlasFor(nb.map),
+                       Mat4.translate(nb.ox, 0, nb.oy))
+          drawn[visual.id] = true
+        end
+      end
     end
   end
 
@@ -1128,6 +1158,28 @@ function VoxelScene.render(state, w, h, vw, vh, paletteFor)
   -- complete, while actors, water, and translucent work have not drawn.
   if companion and type(companion.render) == "function" then
     pcall(companion.render, companion, "opaque_after_terrain", state)
+  end
+
+  -- A render fault can dispose an owner inside the companion call above. The
+  -- ordinary terrain draw point has passed, so restore any newly released
+  -- original now instead of leaving a one-frame hole or waiting for a pump.
+  for _, visual in ipairs(visualShadows or {}) do
+    if not drawnVisuals[visual.id]
+        and ChunkMesher.visualObjectVisible(visual.id) then
+      Voxel3D.draw(visual.mesh, atlasFor(state.map), nil)
+    end
+  end
+  for i, nb in ipairs(state.neighbors or {}) do
+    if RenderDistance.neighbor(nb, state.player) then
+      local drawn = drawnNeighborVisuals[i] or {}
+      for _, visual in ipairs((nbVisualShadows and nbVisualShadows[i]) or {}) do
+        if not drawn[visual.id]
+            and ChunkMesher.visualObjectVisible(visual.id) then
+          Voxel3D.draw(visual.mesh, atlasFor(nb.map),
+                       Mat4.translate(nb.ox, 0, nb.oy))
+        end
+      end
+    end
   end
 
   -- Without a shadow map (headless, or a driver that could not make the

--- a/lib/VoxelVisualObjects.lua
+++ b/lib/VoxelVisualObjects.lua
@@ -11,6 +11,83 @@ local MAX_OBJECTS = 4096
 local MAX_CLAIMS = 4096
 local MAX_COPY_NODES = 262144
 local MAX_COPY_DEPTH = 16
+local MAX_WORLD_COORDINATE = 65536
+local MAX_LOCAL_COORDINATE = 256
+local MAX_ROTATION = math.pi * 2
+local MAX_SCALE = 64
+local MAX_DIMENSION = 4096
+local MAX_COMMAND_DIMENSION = 256
+local MAX_GEOMETRY_COMMANDS = 64
+local MAX_TEXT_COMMANDS = 4
+local MAX_TEXT_BYTES = 64
+local MAX_COMMAND_PRIMITIVES = 2048
+
+local REPLACEMENT_KEYS = {
+  schemaVersion = true, kind = true, objectId = true,
+  geometry = true, text = true,
+}
+local GEOMETRY_KEYS = {
+  shape = true, position = true, rotation = true, scale = true,
+  pivot = true, dimensions = true, material = true,
+}
+local TEXT_KEYS = {
+  value = true, encoding = true, position = true, rotation = true,
+  scale = true, orientation = true, align = true, material = true,
+}
+local VECTOR_KEYS = { x = true, y = true, z = true }
+local ROTATION_KEYS = { yaw = true, pitch = true, roll = true }
+local DIMENSION_KEYS = { width = true, height = true, depth = true }
+local PLANE_DIMENSION_KEYS = { width = true, height = true }
+local MATERIAL_KEYS = { color = true }
+
+-- Fixed host-owned 5x7 glyph rows. Each number is one five-bit scanline.
+-- The public command accepts only keys in this table, so text never resolves a
+-- font, texture, file, model, or other external resource.
+local GLYPHS = {
+  [" "] = { 0, 0, 0, 0, 0, 0, 0 },
+  A = { 14, 17, 17, 31, 17, 17, 17 },
+  B = { 30, 17, 17, 30, 17, 17, 30 },
+  C = { 14, 17, 16, 16, 16, 17, 14 },
+  D = { 30, 17, 17, 17, 17, 17, 30 },
+  E = { 31, 16, 16, 30, 16, 16, 31 },
+  F = { 31, 16, 16, 30, 16, 16, 16 },
+  G = { 14, 17, 16, 23, 17, 17, 15 },
+  H = { 17, 17, 17, 31, 17, 17, 17 },
+  I = { 31, 4, 4, 4, 4, 4, 31 },
+  J = { 7, 2, 2, 2, 18, 18, 12 },
+  K = { 17, 18, 20, 24, 20, 18, 17 },
+  L = { 16, 16, 16, 16, 16, 16, 31 },
+  M = { 17, 27, 21, 21, 17, 17, 17 },
+  N = { 17, 25, 21, 19, 17, 17, 17 },
+  O = { 14, 17, 17, 17, 17, 17, 14 },
+  P = { 30, 17, 17, 30, 16, 16, 16 },
+  Q = { 14, 17, 17, 17, 21, 18, 13 },
+  R = { 30, 17, 17, 30, 20, 18, 17 },
+  S = { 15, 16, 16, 14, 1, 1, 30 },
+  T = { 31, 4, 4, 4, 4, 4, 4 },
+  U = { 17, 17, 17, 17, 17, 17, 14 },
+  V = { 17, 17, 17, 17, 17, 10, 4 },
+  W = { 17, 17, 17, 21, 21, 21, 10 },
+  X = { 17, 17, 10, 4, 10, 17, 17 },
+  Y = { 17, 17, 10, 4, 4, 4, 4 },
+  Z = { 31, 1, 2, 4, 8, 16, 31 },
+  ["0"] = { 14, 17, 19, 21, 25, 17, 14 },
+  ["1"] = { 4, 12, 4, 4, 4, 4, 14 },
+  ["2"] = { 14, 17, 1, 2, 4, 8, 31 },
+  ["3"] = { 30, 1, 1, 14, 1, 1, 30 },
+  ["4"] = { 2, 6, 10, 18, 31, 2, 2 },
+  ["5"] = { 31, 16, 16, 30, 1, 1, 30 },
+  ["6"] = { 14, 16, 16, 30, 17, 17, 14 },
+  ["7"] = { 31, 1, 2, 4, 8, 8, 8 },
+  ["8"] = { 14, 17, 17, 14, 17, 17, 14 },
+  ["9"] = { 14, 17, 17, 15, 1, 1, 14 },
+  ["-"] = { 0, 0, 0, 31, 0, 0, 0 },
+  ["."] = { 0, 0, 0, 0, 0, 12, 12 },
+  [":"] = { 0, 12, 12, 0, 12, 12, 0 },
+  ["'"] = { 12, 12, 8, 0, 0, 0, 0 },
+  ["/"] = { 1, 2, 2, 4, 8, 8, 16 },
+  ["&"] = { 12, 18, 20, 8, 21, 18, 13 },
+}
 
 local function finite(value)
   return type(value) == "number" and value == value
@@ -99,14 +176,224 @@ local function denseCount(value, path, maximum)
   return count
 end
 
+local function knownKeys(value, allowed, path)
+  if type(value) ~= "table" or getmetatable(value) ~= nil then
+    return nil, path .. " must be a plain table"
+  end
+  for key in pairs(value) do
+    if type(key) ~= "string" or not allowed[key] then
+      return nil, path .. " contains an unsupported field"
+    end
+  end
+  return true
+end
+
+local function boundedNumber(value, minimum, maximum, path)
+  if not finite(value) or value < minimum or value > maximum then
+    return nil, path .. " is outside its finite range"
+  end
+  return value
+end
+
+local function vector3(value, keys, minimum, maximum, path)
+  local ok, err = knownKeys(value, keys, path)
+  if not ok then return nil, err end
+  local names = keys == ROTATION_KEYS and { "yaw", "pitch", "roll" }
+    or { "x", "y", "z" }
+  local out = {}
+  for _, name in ipairs(names) do
+    local number
+    number, err = boundedNumber(value[name], minimum, maximum,
+      path .. "." .. name)
+    if number == nil then return nil, err end
+    out[name] = number
+  end
+  return out
+end
+
+local function positiveVector(value, maximum, path)
+  local out, err = vector3(value, VECTOR_KEYS, 0, maximum, path)
+  if not out then return nil, err end
+  for _, name in ipairs({ "x", "y", "z" }) do
+    if out[name] <= 0 then return nil, path .. "." .. name .. " must be positive" end
+  end
+  return out
+end
+
+local function dimensions(value, path, shape)
+  local keys = shape == "plane" and PLANE_DIMENSION_KEYS or DIMENSION_KEYS
+  local ok, err = knownKeys(value, keys, path)
+  if not ok then return nil, err end
+  local out = {}
+  local names = shape == "plane" and { "width", "height" }
+    or { "width", "height", "depth" }
+  for _, name in ipairs(names) do
+    local number
+    number, err = boundedNumber(value[name], 0, MAX_COMMAND_DIMENSION,
+      path .. "." .. name)
+    if number == nil then return nil, err end
+    if number <= 0 then return nil, path .. "." .. name .. " must be positive" end
+    out[name] = number
+  end
+  if shape == "plane" then out.depth = 0 end
+  return out
+end
+
+local function material(value, path)
+  local ok, err = knownKeys(value, MATERIAL_KEYS, path)
+  if not ok then return nil, err end
+  local count
+  count, err = denseCount(value.color, path .. ".color", 4)
+  if not count then return nil, err end
+  if count ~= 4 then return nil, path .. ".color must have four RGBA channels" end
+  local color = {}
+  for index = 1, 4 do
+    local channel
+    channel, err = boundedNumber(value.color[index], 0, 1,
+      ("%s.color[%d]"):format(path, index))
+    if channel == nil then return nil, err end
+    color[index] = channel
+  end
+  if color[4] ~= 1 then return nil, path .. ".color alpha must be 1" end
+  return { color = color }
+end
+
+local function commandTransform(value, path)
+  local position, err = vector3(value.position, VECTOR_KEYS,
+    -MAX_LOCAL_COORDINATE, MAX_LOCAL_COORDINATE, path .. ".position")
+  if not position then return nil, err end
+  local rotation
+  rotation, err = vector3(value.rotation, ROTATION_KEYS,
+    -MAX_ROTATION, MAX_ROTATION, path .. ".rotation")
+  if not rotation then return nil, err end
+  local scale
+  scale, err = positiveVector(value.scale, MAX_SCALE, path .. ".scale")
+  if not scale then return nil, err end
+  return position, rotation, scale
+end
+
+local function glyphPrimitiveCount(text, path)
+  if type(text) ~= "string" or #text < 1 or #text > MAX_TEXT_BYTES then
+    return nil, path .. " must be 1..64 ASCII bytes"
+  end
+  local count = 0
+  for index = 1, #text do
+    local character = text:sub(index, index)
+    local rows = GLYPHS[character]
+    if not rows then
+      return nil, path .. " accepts only A-Z, 0-9, space, - . : ' / and &"
+    end
+    for row = 1, 7 do
+      local bits = rows[row]
+      for column = 0, 4 do
+        if math.floor(bits / 2 ^ column) % 2 == 1 then count = count + 1 end
+      end
+    end
+  end
+  if count == 0 then return nil, path .. " must contain a visible glyph" end
+  return count
+end
+
+local function transformedReach(descriptor, position, xSpan, ySpan, zSpan)
+  local localReach = math.abs(position.x) + math.abs(position.y)
+    + math.abs(position.z) + xSpan + ySpan + zSpan
+  local scale = descriptor.transform.scale
+  local scaleMax = math.max(scale.x, scale.y, scale.z)
+  local world = descriptor.transform.worldPosition
+  return math.max(math.abs(world.x), math.abs(world.y), math.abs(world.z))
+    + localReach * scaleMax
+end
+
+local function validateGeometryItem(value, path, descriptor)
+  local ok, err = knownKeys(value, GEOMETRY_KEYS, path)
+  if not ok then return nil, err end
+  if value.shape ~= "box" and value.shape ~= "plane" then
+    return nil, path .. ".shape must be box or plane"
+  end
+  if value.pivot ~= "center" and value.pivot ~= "bottom_center" then
+    return nil, path .. ".pivot must be center or bottom_center"
+  end
+  if value.shape == "plane" and value.pivot ~= "center" then
+    return nil, path .. ".pivot must be center for plane geometry"
+  end
+  local position, rotation, scale = commandTransform(value, path)
+  if not position then return nil, rotation end
+  local size
+  size, err = dimensions(value.dimensions, path .. ".dimensions", value.shape)
+  if not size then return nil, err end
+  local surface
+  surface, err = material(value.material, path .. ".material")
+  if not surface then return nil, err end
+  local xSpan = size.width * scale.x
+  local ySpan = size.height * scale.y
+  local zSpan = size.depth * scale.z
+  if xSpan > MAX_COMMAND_DIMENSION or ySpan > MAX_COMMAND_DIMENSION
+      or zSpan > MAX_COMMAND_DIMENSION then
+    return nil, path .. " scaled dimensions exceed the command bound"
+  end
+  if transformedReach(descriptor, position, xSpan, ySpan, zSpan)
+      > MAX_WORLD_COORDINATE then
+    return nil, path .. " exceeds the transformed world bound"
+  end
+  return {
+    shape = value.shape, position = position, rotation = rotation,
+    scale = scale, pivot = value.pivot, dimensions = size, material = surface,
+  }
+end
+
+local function validateTextItem(value, path, descriptor)
+  local ok, err = knownKeys(value, TEXT_KEYS, path)
+  if not ok then return nil, err end
+  if value.encoding ~= "ascii-5x7" then
+    return nil, path .. ".encoding must be ascii-5x7"
+  end
+  if value.orientation ~= "object" and value.orientation ~= "billboard_yaw" then
+    return nil, path .. ".orientation must be object or billboard_yaw"
+  end
+  if value.align ~= "left" and value.align ~= "center"
+      and value.align ~= "right" then
+    return nil, path .. ".align must be left, center, or right"
+  end
+  local position, rotation, scale = commandTransform(value, path)
+  if not position then return nil, rotation end
+  if value.orientation == "billboard_yaw"
+      and (rotation.pitch ~= 0 or rotation.roll ~= 0) then
+    return nil, path .. " billboard_yaw requires zero pitch and roll"
+  end
+  local surface
+  surface, err = material(value.material, path .. ".material")
+  if not surface then return nil, err end
+  local primitiveCount
+  primitiveCount, err = glyphPrimitiveCount(value.value, path .. ".value")
+  if not primitiveCount then return nil, err end
+  local width = (#value.value * 6 - 1) * scale.x
+  local height, depth = 7 * scale.y, 0.125 * scale.z
+  if width > MAX_COMMAND_DIMENSION or height > MAX_COMMAND_DIMENSION
+      or depth > MAX_COMMAND_DIMENSION then
+    return nil, path .. " scaled text exceeds the command bound"
+  end
+  if transformedReach(descriptor, position, width, height, depth)
+      > MAX_WORLD_COORDINATE then
+    return nil, path .. " exceeds the transformed world bound"
+  end
+  return {
+    value = value.value, encoding = value.encoding, position = position,
+    rotation = rotation, scale = scale, orientation = value.orientation,
+    align = value.align, material = surface,
+  }, primitiveCount
+end
+
 local function requireFiniteFields(value, fields, path, positive)
   if type(value) ~= "table" or getmetatable(value) ~= nil then
     return nil, path .. " must be a plain table"
   end
   for _, field in ipairs(fields) do
     local number = value[field]
-    if not finite(number) or (positive and number <= 0) then
+    if not finite(number) then
       return nil, path .. "." .. field .. " must be finite"
+    end
+    if positive and number <= 0 then
+      return nil, path .. "." .. field .. " must be positive"
     end
   end
   return true
@@ -144,6 +431,10 @@ local function validateDescriptor(value, path)
   if not finite(map.offsetX) or not finite(map.offsetZ) then
     return nil, path .. ".map offsets must be finite"
   end
+  if math.abs(map.offsetX) > MAX_WORLD_COORDINATE
+      or math.abs(map.offsetZ) > MAX_WORLD_COORDINATE then
+    return nil, path .. ".map offsets exceed the world bound"
+  end
   if type(value.cell) ~= "table" or not integer(value.cell.x)
       or not integer(value.cell.z) then
     return nil, path .. ".cell coordinates must be integers"
@@ -159,6 +450,23 @@ local function validateDescriptor(value, path)
       path .. ".transform." .. field, field == "scale")
     if not ok then return nil, err end
   end
+  for _, field in ipairs({ "localPosition", "worldPosition" }) do
+    for _, axis in ipairs({ "x", "y", "z" }) do
+      if math.abs(value.transform[field][axis]) > MAX_WORLD_COORDINATE then
+        return nil, path .. ".transform." .. field .. " exceeds the world bound"
+      end
+    end
+  end
+  for _, axis in ipairs({ "yaw", "pitch", "roll" }) do
+    if math.abs(value.transform.rotation[axis]) > MAX_ROTATION then
+      return nil, path .. ".transform.rotation exceeds the rotation bound"
+    end
+  end
+  for _, axis in ipairs({ "x", "y", "z" }) do
+    if value.transform.scale[axis] > MAX_SCALE then
+      return nil, path .. ".transform.scale exceeds the scale bound"
+    end
+  end
   if type(value.pivot) ~= "table" or value.pivot.kind ~= "bottom_center" then
     return nil, path .. ".pivot must use bottom_center"
   end
@@ -166,9 +474,19 @@ local function validateDescriptor(value, path)
   ok, err = requireFiniteFields(value.pivot, { "x", "y", "z" },
     path .. ".pivot", false)
   if not ok then return nil, err end
+  for _, axis in ipairs({ "x", "y", "z" }) do
+    if math.abs(value.pivot[axis]) > MAX_LOCAL_COORDINATE then
+      return nil, path .. ".pivot exceeds the local bound"
+    end
+  end
   ok, err = requireFiniteFields(value.dimensions,
     { "width", "height", "depth" }, path .. ".dimensions", true)
   if not ok then return nil, err end
+  for _, field in ipairs({ "width", "height", "depth" }) do
+    if value.dimensions[field] > MAX_DIMENSION then
+      return nil, path .. ".dimensions exceeds the dimension bound"
+    end
+  end
   local material = value.material
   if type(material) ~= "table" or type(material.id) ~= "string"
       or material.id == "" then
@@ -184,6 +502,69 @@ local function validateDescriptor(value, path)
     end
   end
   return Visual.copy(value, path)
+end
+
+-- Validate and normalize one callback-borrowed visual replacement command.
+-- The result contains only copied scalar tables. It is used only for the
+-- current draw call and is never retained by the registry.
+function Visual.validateReplacementCommand(value, descriptor)
+  local ok, err = knownKeys(value, REPLACEMENT_KEYS,
+    "visual object replacement")
+  if not ok then return nil, err end
+  if value.schemaVersion ~= 1 then
+    return nil, "visual object replacement.schemaVersion must be 1"
+  end
+  if value.kind ~= "visual_object_replacement" then
+    return nil, "visual object replacement.kind must be visual_object_replacement"
+  end
+  local id
+  id, err = safeId(value.objectId, "visual object replacement.objectId")
+  if not id then return nil, err end
+  if type(descriptor) ~= "table" or descriptor.id ~= id then
+    return nil, "visual object replacement needs its current claimed descriptor"
+  end
+
+  local geometryCount
+  geometryCount, err = denseCount(value.geometry,
+    "visual object replacement.geometry", MAX_GEOMETRY_COMMANDS)
+  if not geometryCount then return nil, err end
+  local textCount
+  textCount, err = denseCount(value.text,
+    "visual object replacement.text", MAX_TEXT_COMMANDS)
+  if not textCount then return nil, err end
+  if geometryCount + textCount < 1 then
+    return nil, "visual object replacement must contain geometry or text"
+  end
+
+  local out = {
+    schemaVersion = 1, kind = value.kind, objectId = id,
+    geometry = {}, text = {},
+  }
+  local primitiveCount = 0
+  for index = 1, geometryCount do
+    local item
+    item, err = validateGeometryItem(value.geometry[index],
+      ("visual object replacement.geometry[%d]"):format(index), descriptor)
+    if not item then return nil, err end
+    out.geometry[index] = item
+    primitiveCount = primitiveCount + 1
+  end
+  for index = 1, textCount do
+    local item, glyphs
+    item, glyphs = validateTextItem(value.text[index],
+      ("visual object replacement.text[%d]"):format(index), descriptor)
+    if not item then return nil, glyphs end
+    out.text[index] = item
+    primitiveCount = primitiveCount + glyphs
+  end
+  if primitiveCount > MAX_COMMAND_PRIMITIVES then
+    return nil, "visual object replacement exceeds its primitive limit"
+  end
+  return out, primitiveCount
+end
+
+function Visual.glyph(character)
+  return GLYPHS[character]
 end
 
 local Registry = {}
@@ -315,6 +696,17 @@ function Registry:owner(id)
   return record and record.id or nil
 end
 
+function Registry:ownedDescriptor(record, id)
+  if not self.records[record] or self.owners[id] ~= record then
+    return nil, "visual object replacement requires the current unique owner"
+  end
+  local descriptor = self.catalog[id]
+  if not descriptor then
+    return nil, "visual object replacement descriptor is no longer current"
+  end
+  return descriptor
+end
+
 function Registry:status(record)
   local claims = 0
   for _ in pairs(record and record.claims or {}) do claims = claims + 1 end
@@ -326,5 +718,6 @@ end
 
 Visual.MAX_OBJECTS = MAX_OBJECTS
 Visual.MAX_CLAIMS = MAX_CLAIMS
+Visual.MAX_COMMAND_PRIMITIVES = MAX_COMMAND_PRIMITIVES
 
 return Visual

--- a/lib/VoxelVisualObjects.lua
+++ b/lib/VoxelVisualObjects.lua
@@ -1,0 +1,330 @@
+-- Battle Art's optional visual-object extension to the byte-frozen
+-- Voxel Companion API v1 dispatcher.
+--
+-- This module owns only copied declarative descriptors and unique owner IDs.
+-- It never exposes or retains a terrain mesh, texture, map, or draw context.
+
+local Visual = {}
+
+local MAX_ID = 128
+local MAX_OBJECTS = 4096
+local MAX_CLAIMS = 4096
+local MAX_COPY_NODES = 262144
+local MAX_COPY_DEPTH = 16
+
+local function finite(value)
+  return type(value) == "number" and value == value
+    and value ~= math.huge and value ~= -math.huge
+end
+
+local function integer(value)
+  return finite(value) and value == math.floor(value)
+end
+
+local function safeId(value, path)
+  if type(value) ~= "string" or value == "" or #value > MAX_ID
+      or not value:match("^[A-Za-z0-9][A-Za-z0-9%._:%-]*$") then
+    return nil, path .. " must use safe ASCII identifier characters"
+  end
+  return value
+end
+
+local function safeSegment(value)
+  return type(value) == "string" and value ~= "" and #value <= MAX_ID
+    and value:match("^[A-Za-z0-9][A-Za-z0-9%._%-]*$") ~= nil
+end
+
+function Visual.id(hostId, kind, mapId, cellX, cellZ)
+  if not safeSegment(hostId) or not safeSegment(kind) or not safeSegment(mapId) then
+    return nil, "visual object identity contains an unsafe segment"
+  end
+  if not integer(cellX) or not integer(cellZ) then
+    return nil, "visual object cell coordinates must be integers"
+  end
+  local id = table.concat({ hostId, kind, mapId, cellX, cellZ }, ":")
+  if #id > MAX_ID then return nil, "visual object id is too long" end
+  return id
+end
+
+local function copyDeclarative(value, path, state, depth)
+  local kind = type(value)
+  if kind == "nil" or kind == "boolean" or kind == "string" then return value end
+  if kind == "number" then
+    if finite(value) then return value end
+    return nil, path .. " contains a non-finite number"
+  end
+  if kind ~= "table" or getmetatable(value) ~= nil then
+    return nil, path .. " must contain only plain declarative data"
+  end
+  if depth > MAX_COPY_DEPTH then return nil, path .. " is too deeply nested" end
+  if state.seen[value] then return nil, path .. " contains a cycle or alias" end
+  state.seen[value] = true
+  local out = {}
+  for key, item in pairs(value) do
+    state.nodes = state.nodes + 1
+    if state.nodes > MAX_COPY_NODES then
+      state.seen[value] = nil
+      return nil, path .. " is too large"
+    end
+    local keyKind = type(key)
+    if keyKind ~= "string" and not (keyKind == "number" and integer(key)) then
+      state.seen[value] = nil
+      return nil, path .. " contains an unsupported key"
+    end
+    local copied, err = copyDeclarative(item,
+      path .. "." .. tostring(key), state, depth + 1)
+    if err then state.seen[value] = nil; return nil, err end
+    out[key] = copied
+  end
+  state.seen[value] = nil
+  return out
+end
+
+function Visual.copy(value, path)
+  return copyDeclarative(value, path or "visual data",
+    { seen = {}, nodes = 0 }, 0)
+end
+
+local function denseCount(value, path, maximum)
+  if type(value) ~= "table" or getmetatable(value) ~= nil then
+    return nil, path .. " must be an array"
+  end
+  local count = #value
+  if count > maximum then return nil, path .. " exceeds its item limit" end
+  for key in pairs(value) do
+    if not integer(key) or key < 1 or key > count then
+      return nil, path .. " must be a dense array"
+    end
+  end
+  return count
+end
+
+local function requireFiniteFields(value, fields, path, positive)
+  if type(value) ~= "table" or getmetatable(value) ~= nil then
+    return nil, path .. " must be a plain table"
+  end
+  for _, field in ipairs(fields) do
+    local number = value[field]
+    if not finite(number) or (positive and number <= 0) then
+      return nil, path .. "." .. field .. " must be finite"
+    end
+  end
+  return true
+end
+
+local function validateDescriptor(value, path)
+  if type(value) ~= "table" or getmetatable(value) ~= nil then
+    return nil, path .. " must be a plain table"
+  end
+  if value.schemaVersion ~= 1 then return nil, path .. ".schemaVersion must be 1" end
+  local id, err = safeId(value.id, path .. ".id")
+  if not id then return nil, err end
+  if type(value.kind) ~= "string" or value.kind == "" then
+    return nil, path .. ".kind must be text"
+  end
+  local tagCount
+  tagCount, err = denseCount(value.tags, path .. ".tags", 32)
+  if not tagCount then return nil, err end
+  local tags = {}
+  for index = 1, tagCount do
+    local tag = value.tags[index]
+    if type(tag) ~= "string" or tag == "" or #tag > 64 then
+      return nil, path .. ".tags contains invalid text"
+    end
+    if tags[tag] then return nil, path .. ".tags contains a duplicate" end
+    tags[tag] = true
+  end
+  local map = value.map
+  if type(map) ~= "table" or not safeSegment(map.id) then
+    return nil, path .. ".map.id is invalid"
+  end
+  if map.role ~= "current" and map.role ~= "neighbor" then
+    return nil, path .. ".map.role must be current or neighbor"
+  end
+  if not finite(map.offsetX) or not finite(map.offsetZ) then
+    return nil, path .. ".map offsets must be finite"
+  end
+  if type(value.cell) ~= "table" or not integer(value.cell.x)
+      or not integer(value.cell.z) then
+    return nil, path .. ".cell coordinates must be integers"
+  end
+  if type(value.transform) ~= "table" then
+    return nil, path .. ".transform must be a plain table"
+  end
+  for _, field in ipairs({ "localPosition", "worldPosition", "rotation", "scale" }) do
+    local keys = field == "rotation" and { "yaw", "pitch", "roll" }
+      or { "x", "y", "z" }
+    local ok
+    ok, err = requireFiniteFields(value.transform[field], keys,
+      path .. ".transform." .. field, field == "scale")
+    if not ok then return nil, err end
+  end
+  if type(value.pivot) ~= "table" or value.pivot.kind ~= "bottom_center" then
+    return nil, path .. ".pivot must use bottom_center"
+  end
+  local ok
+  ok, err = requireFiniteFields(value.pivot, { "x", "y", "z" },
+    path .. ".pivot", false)
+  if not ok then return nil, err end
+  ok, err = requireFiniteFields(value.dimensions,
+    { "width", "height", "depth" }, path .. ".dimensions", true)
+  if not ok then return nil, err end
+  local material = value.material
+  if type(material) ~= "table" or type(material.id) ~= "string"
+      or material.id == "" then
+    return nil, path .. ".material.id must be text"
+  end
+  if material.phase ~= "opaque_after_terrain" then
+    return nil, path .. ".material.phase must be opaque_after_terrain"
+  end
+  for _, field in ipairs({ "opaque", "alphaCutout", "castsShadow",
+                            "receivesShadow" }) do
+    if type(material[field]) ~= "boolean" then
+      return nil, path .. ".material." .. field .. " must be Boolean"
+    end
+  end
+  return Visual.copy(value, path)
+end
+
+local Registry = {}
+Registry.__index = Registry
+
+function Visual.new(options)
+  options = options or {}
+  return setmetatable({
+    catalog = {}, order = {}, owners = {}, records = {},
+    claimAllowed = options.claimAllowed,
+  }, Registry)
+end
+
+function Registry:addRecord(id, eligible)
+  local record = { id = id, eligible = eligible == true, claims = nil }
+  self.records[record] = true
+  return record
+end
+
+function Registry:setCatalog(descriptors)
+  local count, err = denseCount(descriptors, "visual objects", MAX_OBJECTS)
+  if not count then return nil, err end
+  local byId, order = {}, {}
+  for index = 1, count do
+    local descriptor
+    descriptor, err = validateDescriptor(descriptors[index],
+      ("visual objects[%d]"):format(index))
+    if not descriptor then return nil, err end
+    if byId[descriptor.id] then
+      return nil, "visual object catalog contains duplicate id " .. descriptor.id
+    end
+    byId[descriptor.id] = descriptor
+    order[#order + 1] = descriptor
+  end
+  table.sort(order, function(a, b) return a.id < b.id end)
+
+  local owners = {}
+  for record in pairs(self.records) do
+    if record.claims then
+      local retained = {}
+      for id in pairs(record.claims) do
+        if byId[id] then retained[id], owners[id] = true, record end
+      end
+      record.claims = next(retained) and retained or nil
+    end
+  end
+  self.catalog, self.order, self.owners = byId, order, owners
+  return true
+end
+
+function Registry:claim(record, ids)
+  if not self.records[record] then
+    return nil, "extension cannot claim visual objects in its current state"
+  end
+  if self.claimAllowed then
+    local allowed, err = self.claimAllowed(record)
+    if not allowed then return nil, err end
+  end
+  if not record.eligible then
+    return nil, "visual object claims require an opaque_after_terrain render handler"
+  end
+  local count, err = denseCount(ids, "visual object claims", MAX_CLAIMS)
+  if not count then return nil, err end
+  local proposed = {}
+  for index = 1, count do
+    local id
+    id, err = safeId(ids[index], ("visual object claims[%d]"):format(index))
+    if not id then return nil, err end
+    if proposed[id] then
+      return nil, "visual object claims contains duplicate id " .. id
+    end
+    if not self.catalog[id] then
+      return nil, "unknown visual object id " .. id
+    end
+    proposed[id] = true
+  end
+
+  local conflicts = {}
+  for id in pairs(proposed) do
+    local owner = self.owners[id]
+    if owner and owner ~= record then
+      local pair = { owner.id, record.id }
+      table.sort(pair)
+      conflicts[#conflicts + 1] = id .. " [" .. table.concat(pair, ",") .. "]"
+    end
+  end
+  table.sort(conflicts)
+  if #conflicts > 0 then
+    return nil, "visual object ownership conflict: " .. table.concat(conflicts, "; ")
+  end
+
+  for id in pairs(record.claims or {}) do
+    if self.owners[id] == record then self.owners[id] = nil end
+  end
+  record.claims = next(proposed) and proposed or nil
+  for id in pairs(proposed) do self.owners[id] = record end
+  return true
+end
+
+function Registry:clear(record)
+  if not self.records[record] then return false end
+  for id in pairs(record.claims or {}) do
+    if self.owners[id] == record then self.owners[id] = nil end
+  end
+  record.claims = nil
+  return true
+end
+
+function Registry:remove(record)
+  self:clear(record)
+  self.records[record] = nil
+end
+
+function Registry:clearAll()
+  for record in pairs(self.records) do self:clear(record) end
+end
+
+function Registry:dispose()
+  self:clearAll()
+  self.catalog, self.order, self.owners, self.records = {}, {}, {}, {}
+end
+
+function Registry:isSuppressed(id)
+  return type(id) == "string" and self.owners[id] ~= nil or false
+end
+
+function Registry:owner(id)
+  local record = type(id) == "string" and self.owners[id] or nil
+  return record and record.id or nil
+end
+
+function Registry:status(record)
+  local claims = 0
+  for _ in pairs(record and record.claims or {}) do claims = claims + 1 end
+  local owners = 0
+  for _ in pairs(self.owners) do owners = owners + 1 end
+  return { visualObjects = #self.order, visualOverrides = owners,
+           visualClaims = claims, visualConflicts = 0 }
+end
+
+Visual.MAX_OBJECTS = MAX_OBJECTS
+Visual.MAX_CLAIMS = MAX_CLAIMS
+
+return Visual

--- a/main.lua
+++ b/main.lua
@@ -126,7 +126,15 @@ V.companion = Companion
 -- engine's public per-frame hook to retry after the real overworld update and
 -- to observe later map/revision changes. This must not depend on a render
 -- pipeline being active: KFP can attach while Battle Art's voxel mode is off.
-CompanionLifecycle.install(mod, Companion)
+local uninstallCompanion = CompanionLifecycle.install(mod, Companion)
+
+-- `core.quit_to_launcher` is the engine's native mod-unload boundary. Retain
+-- the exact disposer returned above and run it before this loader is replaced,
+-- so claims, adapter GPU resources, and the update hook cannot survive unload.
+mod.hooks:wrap("core.quit_to_launcher", function(next)
+  uninstallCompanion()
+  return next()
+end)
 
 -- `mods.loaded` is the first point at which every content mod has finished
 -- patching the registries and the last point before a save can mutate live map

--- a/tests/battle_scene_visual_sidecar_test.lua
+++ b/tests/battle_scene_visual_sidecar_test.lua
@@ -1,0 +1,308 @@
+-- ROM-free staged-battle checks for original visual-object sidecars.
+local checks = 0
+local function check(value, message)
+  checks = checks + 1
+  if not value then error("FAIL: " .. message, 0) end
+end
+local function equal(actual, expected, message)
+  checks = checks + 1
+  if actual ~= expected then
+    error(("FAIL: %s (expected %s, got %s)")
+      :format(message, tostring(expected), tostring(actual)), 0)
+  end
+end
+
+local function mesh(name) return { name = name } end
+local currentTerrain = mesh("current-terrain")
+local neighborTerrain = mesh("neighbor-terrain")
+local alternateFullTerrain = mesh("alternate-full-terrain")
+local alternateBodyTerrain = mesh("alternate-body-terrain")
+local currentWater = mesh("current-water")
+local neighborWater = mesh("neighbor-water")
+local alternateFullWater = mesh("alternate-full-water")
+local alternateBodyWater = mesh("alternate-body-water")
+local currentSign = mesh("current-sign-original")
+local neighborSign = mesh("neighbor-sign-original")
+local alternateFullSign = mesh("alternate-full-sign-original")
+local alternateBodySign = mesh("alternate-body-sign-original")
+
+local current = {
+  id = "CURRENT", def = { width = 1, height = 1 },
+  tileset = { id = "OVERWORLD" },
+}
+local neighbor = {
+  id = "NEIGHBOR", def = { width = 1, height = 1 },
+  tileset = { id = "OVERWORLD" },
+}
+local alternate = {
+  id = "ALTERNATE", def = { width = 1, height = 1 },
+  tileset = { id = "CAVERN" },
+}
+
+local colorDraws, shadowDraws, pairCalls = {}, {}, {}
+local alternateFullReady = true
+local function countDraws(log, target)
+  local count = 0
+  for _, draw in ipairs(log) do
+    if draw.mesh == target then count = count + 1 end
+  end
+  return count
+end
+local function modelFor(log, target)
+  for _, draw in ipairs(log) do
+    if draw.mesh == target then return draw.model end
+  end
+end
+
+local Mat4 = {
+  translate = function(x, y, z) return { "translate", x, y, z } end,
+  rotateY = function(value) return { "rotateY", value } end,
+  scale = function(x, y, z) return { "scale", x, y, z } end,
+  mul = function(a, b) return { "mul", a, b } end,
+  lookAt = function() return { "lookAt" } end,
+}
+
+local Voxel3D = {
+  SHADOW_ALPHA = 0.3,
+  tint = { 1, 1, 1 },
+  eye = { 0, 20, 40 },
+  focus = { 0, 0, 0 },
+  fovY = math.rad(60),
+  vp = {
+    0.01, 0, 0, 0,
+    0, 0.01, 0, 0,
+    0, 0, 0, 0,
+    0, 0, 0, 1,
+  },
+}
+function Voxel3D.available() return true end
+function Voxel3D.viewProjection()
+  if Voxel3D.camera then
+    Voxel3D.eye = Voxel3D.camera.eye
+    Voxel3D.focus = Voxel3D.camera.focus
+  end
+  return Voxel3D.vp
+end
+function Voxel3D.beginScene() return true end
+function Voxel3D.draw(value, _, model)
+  colorDraws[#colorDraws + 1] = { mesh = value, model = model }
+end
+function Voxel3D.endScene() return { name = "battle-canvas" } end
+function Voxel3D.backdrop() end
+function Voxel3D.flatten() end
+function Voxel3D.seams() end
+function Voxel3D.glass() end
+function Voxel3D.dayTint() end
+function Voxel3D.lighting() end
+
+local ShadowMap = {
+  KX = 0.25, KZ = 0.5, clipVP = {}, uvVP = {}, bias = 0, res = 0,
+}
+function ShadowMap.available() return true end
+function ShadowMap.stale() return true end
+function ShadowMap.begin() return true end
+function ShadowMap.draw(value, _, model)
+  shadowDraws[#shadowDraws + 1] = { mesh = value, model = model }
+end
+function ShadowMap.finish() end
+function ShadowMap.sprites() end
+function ShadowMap.snug(model) return model end
+function ShadowMap.discard() end
+function ShadowMap.active() return false end
+function ShadowMap.texture() return nil end
+
+local ChunkMesher = {}
+function ChunkMesher.setLive() end
+function ChunkMesher.request(map, bodyOnly)
+  pairCalls[#pairCalls + 1] = { operation = "request", map = map, body = bodyOnly }
+end
+function ChunkMesher.pair(map, bodyOnly)
+  pairCalls[#pairCalls + 1] = { operation = "pair", map = map, body = bodyOnly }
+  if map ~= alternate then return nil, nil, nil, nil end
+  if not bodyOnly then
+    if not alternateFullReady then return nil, nil, nil, nil end
+    return alternateFullTerrain, alternateFullWater, {}, {
+      { id = "alternate-sign", mesh = alternateFullSign },
+    }
+  end
+  -- The third result models an active overworld claim. BattleScene must use
+  -- the fourth, original-shadow result for both of its own passes.
+  return alternateBodyTerrain, alternateBodyWater, {}, {
+    { id = "alternate-sign", mesh = alternateBodySign },
+  }
+end
+function ChunkMesher.grass() return nil end
+function ChunkMesher.flowers() return nil end
+function ChunkMesher.visualObjectVisible()
+  error("BattleScene must not apply overworld replacement claims", 0)
+end
+
+local VoxelScene = {}
+function VoxelScene.prefetch(state)
+  check(state.map == current, "current-map prefetch receives the overworld state")
+  return currentTerrain, { neighborTerrain }, currentWater, { neighborWater },
+    true, { { id = "current-sign", mesh = currentSign } },
+    { { { id = "neighbor-sign", mesh = neighborSign } } }
+end
+function VoxelScene._modeColors() return {} end
+function VoxelScene.groundAt() return 0 end
+function VoxelScene.skyColor() return { 0.1, 0.2, 0.3, 1 } end
+function VoxelScene.skyShade() return { 0.1, 0.1, 0.1, 1 } end
+function VoxelScene.pull() return 0 end
+
+local TerrainAtlas = {
+  setLive = function() end,
+  forMap = function(map) return { map = map.id } end,
+}
+local BattleCam = {
+  rig = function(arena)
+    return {
+      eye = { arena.mid[1], 24, arena.mid[2] + 40 },
+      focus = { arena.mid[1], 0, arena.mid[2] },
+      up = { 0, 1, 0 }, fov = math.rad(60), curve = 0,
+    }, math.rad(45)
+  end,
+  frameH = function() return 96 end,
+}
+local BattleBillboard = {
+  FULL_W = 16, FULL_PIC = 56, PULL = 0,
+  yawToward = function() return 0 end,
+  mesh = function() return mesh("unused-card") end,
+}
+local StadiumModels = {
+  placements = function() return {} end,
+  uses = function() return false end,
+  drawShadow = function() return false end,
+  draw = function() return true end,
+}
+local DayNight = {
+  applyRig = function() end,
+  tint = function() return { 1, 1, 1 } end,
+  isCanopy = function() return false end,
+  windowLight = function() return 0 end,
+  shadowScale = function() return 1 end,
+}
+local UiBackplates = {
+  arenaWhite = function() return false end,
+  arenaGen6 = function() return false end,
+  arenaPng = function() return false end,
+  arenaArt = function() return false end,
+  bossEnabled = function() return false end,
+  spritesUnlit = function() return false end,
+  backdropOffsetPixels = function() return 0 end,
+}
+local AntiAlias = {
+  expand = function(w, h) return w, h end,
+  resolve = function(canvas) return canvas end,
+}
+
+package.loaded["src.render.PaletteFX"] = { pal = function() return {} end }
+package.loaded["src.world.Map"] = { isOutdoor = function() return false end }
+package.loaded["src.core.Game"] = { data = {}, stack = { top = function() end } }
+package.loaded["src.render.TileRenderer"] = { tick = function() end }
+package.loaded["src.render.Renderer"] = { fitScale = function() return 2 end }
+
+love = {
+  graphics = {
+    getPixelDimensions = function() return 320, 288 end,
+    getDimensions = function() return 320, 288 end,
+    setShader = function() end,
+    setDepthMode = function() end,
+    setCanvas = function() end,
+  },
+}
+
+local namespace = {}
+function namespace.require(name)
+  return assert(({
+    Mat4 = Mat4,
+    Voxel3D = Voxel3D,
+    ShadowMap = ShadowMap,
+    ChunkMesher = ChunkMesher,
+    TerrainAtlas = TerrainAtlas,
+    VoxelScene = VoxelScene,
+    BattleCam = BattleCam,
+    BattleBillboard = BattleBillboard,
+    StadiumModels = StadiumModels,
+    DayNight = DayNight,
+    UiBackplates = UiBackplates,
+    Gen6Backdrop = { image = function() return nil end },
+    BackdropImage = { load = function() return nil end },
+    BossBackdrop = { image = function() return nil end },
+    AntiAlias = AntiAlias,
+    GlassMask = { texture = function() return nil end },
+  })[name], "unexpected BattleScene module " .. tostring(name))
+end
+
+local BattleScene = assert(loadfile("lib/BattleScene.lua"))(namespace)
+local player = { id = "player" }
+local state = {
+  map = current,
+  player = player,
+  entities = { player },
+  neighbors = { { map = neighbor, ox = 64, oy = -32 } },
+  paletteNameFor = function() return "default" end,
+}
+local function arena(host)
+  return {
+    map = host,
+    x = 0, y = 0, shape = "test",
+    mid = { 24, 24 },
+    player = { 16, 16 }, enemy = { 32, 32 },
+    playerCell = { 1, 1 },
+  }
+end
+
+local function resetLogs()
+  colorDraws, shadowDraws, pairCalls = {}, {}, {}
+end
+
+resetLogs()
+check(BattleScene.render(state, arena(nil), nil, 1),
+  "current-map staged battle renders")
+equal(countDraws(colorDraws, currentSign), 1,
+  "current-map original sign draws in the color pass")
+equal(countDraws(shadowDraws, currentSign), 1,
+  "current-map original sign draws in the shadow pass")
+equal(countDraws(colorDraws, neighborSign), 1,
+  "neighbor original sign draws in the color pass")
+equal(countDraws(shadowDraws, neighborSign), 1,
+  "neighbor original sign draws in the shadow pass")
+local neighborColorModel = modelFor(colorDraws, neighborSign)
+local neighborShadowModel = modelFor(shadowDraws, neighborSign)
+equal(neighborColorModel[1], "translate",
+  "neighbor color sidecar uses its map transform")
+equal(neighborColorModel[2], 64, "neighbor color sidecar keeps X offset")
+equal(neighborColorModel[4], -32, "neighbor color sidecar keeps Z offset")
+equal(neighborShadowModel[2], 64, "neighbor shadow sidecar keeps X offset")
+equal(neighborShadowModel[4], -32, "neighbor shadow sidecar keeps Z offset")
+
+resetLogs()
+check(BattleScene.render(state, arena(alternate), nil, 2),
+  "alternate full-arena staged battle renders")
+equal(#pairCalls, 2, "alternate full arena needs no body fallback")
+equal(pairCalls[2].body, false, "alternate arena selects the ready full cache")
+equal(countDraws(colorDraws, alternateFullSign), 1,
+  "alternate full original sign draws in the color pass")
+equal(countDraws(shadowDraws, alternateFullSign), 1,
+  "alternate full original sign draws in the shadow pass")
+equal(countDraws(colorDraws, alternateBodySign), 0,
+  "alternate full arena does not mix in the body sidecar")
+
+alternateFullReady = false
+resetLogs()
+check(BattleScene.render(state, arena(alternate), nil, 3),
+  "alternate-arena staged battle renders")
+equal(#pairCalls, 3, "alternate arena requests full and falls back to body")
+equal(pairCalls[2].body, false, "alternate arena checks the full cache first")
+equal(pairCalls[3].body, true, "alternate arena selects the body cache fallback")
+equal(countDraws(colorDraws, alternateBodySign), 1,
+  "alternate body original sign draws in the color pass")
+equal(countDraws(shadowDraws, alternateBodySign), 1,
+  "alternate body original sign draws in the shadow pass")
+equal(countDraws(colorDraws, currentSign), 0,
+  "alternate arena does not reuse current-map sidecars")
+equal(countDraws(shadowDraws, neighborSign), 0,
+  "alternate arena does not reuse neighbor sidecars")
+
+print(("%d checks passed (BattleScene visual sidecars)"):format(checks))

--- a/tests/companion_lifecycle_test.lua
+++ b/tests/companion_lifecycle_test.lua
@@ -23,7 +23,7 @@ local mod = {
   hooks = {
     wrap = function(_, name, callback)
       wrappedName, wrapped = name, callback
-      return function() end
+      return function() return true end
     end,
   },
   log = {
@@ -38,9 +38,15 @@ local companion = {
   updateFromGame = function(_, dt, game)
     calls[#calls + 1] = { dt = dt, game = game, ready = game.overworld ~= nil }
   end,
+  dispose = function(_, reason)
+    calls.disposed = (calls.disposed or 0) + 1
+    calls.disposeReason = reason
+    return true
+  end,
 }
 
-check(type(Lifecycle.install(mod, companion)) == "function",
+local uninstall = Lifecycle.install(mod, companion)
+check(type(uninstall) == "function",
   "install returns the public hook removal handle")
 equal(wrappedName, "core.update", "lifecycle binds only to public core.update")
 
@@ -69,5 +75,43 @@ companion.updateFromGame = function() error("synthetic lifecycle fault", 0) end
 wrapped(function() end, game, 0.016)
 wrapped(function() end, game, 0.016)
 equal(#messages, 1, "a repeated lifecycle fault is logged once")
+
+check(uninstall(), "uninstall removes the public hook")
+equal(calls.disposed, 1, "uninstall disposes the companion exactly once")
+equal(calls.disposeReason, "host_uninstall",
+  "uninstall uses the canonical cleanup reason")
+check(uninstall(), "repeated uninstall is safe")
+equal(calls.disposed, 1, "repeated uninstall does not dispose twice")
+
+local removeAttempts, disposeAttempts = 0, 0
+local retryMod = {
+  hooks = {
+    wrap = function()
+      return function()
+        removeAttempts = removeAttempts + 1
+        return true
+      end
+    end,
+  },
+  log = { error = function() end },
+}
+local failDispose = true
+local retryCompanion = {
+  updateFromGame = function() end,
+  dispose = function()
+    disposeAttempts = disposeAttempts + 1
+    if failDispose then return nil, "synthetic cleanup refusal" end
+    return true
+  end,
+}
+local retryUninstall = Lifecycle.install(retryMod, retryCompanion)
+local firstCleanup = pcall(retryUninstall)
+equal(firstCleanup, false, "failed uninstall cleanup is reported")
+equal(removeAttempts, 1, "failed cleanup removes the hook once")
+equal(disposeAttempts, 1, "failed cleanup attempts disposal once")
+failDispose = false
+check(retryUninstall(), "uninstall cleanup can resume after a failure")
+equal(removeAttempts, 1, "cleanup retry does not remove the hook twice")
+equal(disposeAttempts, 2, "cleanup retry runs disposal again")
 
 io.write(('%d checks passed (Voxel Companion core lifecycle)\n'):format(checks))

--- a/tests/companion_main_uninstall_integration_test.lua
+++ b/tests/companion_main_uninstall_integration_test.lua
@@ -1,0 +1,382 @@
+-- ROM-free end-to-end regression for main.lua's native unload wiring.
+
+local checks = 0
+
+local function check(value, message)
+  checks = checks + 1
+  if not value then error("FAIL: " .. message, 0) end
+end
+
+local function equal(actual, expected, message)
+  checks = checks + 1
+  if actual ~= expected then
+    error(("FAIL: %s (expected %s, got %s)")
+      :format(message, tostring(expected), tostring(actual)), 0)
+  end
+end
+
+local function readFile(path)
+  local file = assert(io.open(path, "rb"))
+  local source = assert(file:read("*a"))
+  file:close()
+  return source
+end
+
+local hooks, events = {}, {}
+local updateRemovals = 0
+
+local function removeEntry(list, entry)
+  for index, candidate in ipairs(list) do
+    if candidate == entry then
+      table.remove(list, index)
+      return true
+    end
+  end
+  return false
+end
+
+local hookFacade = {}
+function hookFacade:wrap(name, callback)
+  local list = hooks[name] or {}
+  hooks[name] = list
+  local entry = { callback = callback }
+  list[#list + 1] = entry
+  return function()
+    local removed = removeEntry(list, entry)
+    if removed and name == "core.update" then
+      updateRemovals = updateRemovals + 1
+    end
+    return true
+  end
+end
+
+local function callHook(name, vanilla, ...)
+  local list = hooks[name] or {}
+  local function run(index, ...)
+    local entry = list[index]
+    if not entry then return vanilla(...) end
+    return entry.callback(function(...) return run(index + 1, ...) end, ...)
+  end
+  return run(1, ...)
+end
+
+local eventFacade = {}
+function eventFacade:on(name, callback)
+  local list = events[name] or {}
+  events[name] = list
+  list[#list + 1] = callback
+  return function() return removeEntry(list, callback) end
+end
+
+local function emit(name, payload)
+  for _, callback in ipairs(events[name] or {}) do callback(payload) end
+end
+
+local settingSource = [=[
+local setting = { key = "test-setting" }
+function setting:schema(description)
+  return { key = self.key, description = description, default = 1 }
+end
+function setting:get() return "static" end
+function setting:setIndex() return true end
+function setting:cycle() return true end
+function setting:sync() return true end
+
+local settings = {
+  setting = true, trainerSetting = true, playerArtSetting = true,
+  playerAnimationSetting = true, frontAnimationSetting = true,
+  backAnimationSetting = true, duplicateSetting = true, viewSetting = true,
+  frontFlipSetting = true, backPlacementSetting = true,
+  hudScaleSetting = true, spriteLight = true, hudColor = true,
+  arenaFill = true, stadiumCircle = true, backdropOffset = true,
+  bossBg = true, textboxFill = true,
+}
+
+local module = {}
+return setmetatable(module, { __index = function(_, key)
+  if settings[key] then return setting end
+  if key == "export" then return function() return {} end end
+  if key == "installed" then return function() return false end end
+  if key == "enabled" then return function() return true end end
+  return function() return true end
+end })
+]=]
+
+local mat4Source = [=[
+return {
+  identity = function() return { "identity" } end,
+  mul = function(a, b) return { a, b } end,
+  translate = function(x, y, z) return { "translate", x, y, z } end,
+  scale = function(x, y, z) return { "scale", x, y, z } end,
+  rotateX = function(value) return { "rotateX", value } end,
+  rotateY = function(value) return { "rotateY", value } end,
+  rotateZ = function(value) return { "rotateZ", value } end,
+}
+]=]
+
+local voxelStateSource = [=[
+local setting = { key = "voxel" }
+function setting:schema(description) return { key = self.key, description = description } end
+function setting:get() return 1 end
+function setting:setIndex() return true end
+function setting:cycle() return true end
+function setting:sync() return true end
+return {
+  ANGLE_LABELS = { "OFF", "FULL" }, HOTKEY_ORDER = { 0, 1 }, setting = setting,
+  isFirstPerson = function() return true end,
+  isThirdPerson = function() return false end,
+  isFull = function() return false end,
+  active = function() return false end,
+  nextHotkeyLevel = function() return 0 end,
+  update = function() end,
+  seedOptions = function() return false end,
+}
+]=]
+
+local tileShapeSource = [=[
+local shapes = {
+  [0] = { class = "ground", h = 0 },
+  [4] = { class = "signpost", h = 16 },
+}
+return {
+  forMap = function() return shapes end,
+  propBg = function() return nil end,
+}
+]=]
+
+local chunkMesherSource = [=[
+local V = ...
+local SIGN_ID = "BATTLE_ART_VOXEL_FORK:signpost:PALLET_TOWN:1:0"
+local original = { id = "original-sign-color" }
+local shadow = { id = "original-sign-shadow" }
+local terrain = { id = "terrain" }
+local M = {}
+function M.visualObjectAnnotated(_, id) return id == SIGN_ID end
+function M.pair()
+  local hidden = V.companion and V.companion:suppressesVisualObject(SIGN_ID)
+  return terrain, nil, hidden and {} or { original }, { shadow }
+end
+return setmetatable(M, { __index = function() return function() return true end end })
+]=]
+
+local meshResources, textureResources = {}, {}
+local voxel3D = {
+  FACE_CORNERS = {}, FACE_SHADE = {}, eye = { 0, 16, 32 },
+  camera = { eye = { 0, 16, 32 }, focus = { 0, 0, 0 },
+    up = { 0, 1, 0 }, fov = math.rad(65) },
+}
+for direction = 1, 6 do
+  voxel3D.FACE_CORNERS[direction] = {
+    { 0, 0, 0 }, { 1, 0, 0 }, { 1, 1, 0 }, { 0, 1, 0 },
+  }
+  voxel3D.FACE_SHADE[direction] = 1
+end
+function voxel3D.pushQuad(indices, offset) indices[#indices + 1] = offset end
+function voxel3D.newMesh()
+  local mesh = { releases = 0 }
+  function mesh:setTexture(texture) self.texture = texture end
+  function mesh:release() self.releases = self.releases + 1 end
+  meshResources[#meshResources + 1] = mesh
+  return mesh
+end
+function voxel3D.draw() end
+function voxel3D.glass() end
+
+love = {
+  system = { getOS = function() return "Windows" end },
+  image = { newImageData = function()
+    return { setPixel = function() end }
+  end },
+  graphics = {
+    push = function() end, pop = function() end,
+    setColor = function() end, setDepthMode = function() end,
+    setBlendMode = function() end,
+    newImage = function()
+      local texture = { releases = 0, setFilter = function() end }
+      function texture:release() self.releases = self.releases + 1 end
+      textureResources[#textureResources + 1] = texture
+      return texture
+    end,
+  },
+}
+
+local fakeMapModule = {
+  isOutdoor = function() return true end,
+  setBlock = function(self, bx, by, block)
+    self.blocks = self.blocks or {}
+    self.blocks[by * 100 + bx] = block
+  end,
+}
+local fakeGame = {
+  save = { version = "red", options = {} },
+  keypressed = function() end,
+  writeOptions = function() end,
+}
+local fakePipelines = {
+  level = function() return 0 end, canToggle = function() return false end,
+  hotkey = function() return false end, setLevel = function() end,
+  syncOptions = function() end, maxLevel = function() return 0 end,
+}
+local fakeOptionsMenu = {
+  update = function() end,
+  new = function() return { rows = {} } end,
+}
+package.loaded["src.world.Map"] = fakeMapModule
+package.loaded["src.core.Game"] = fakeGame
+package.loaded["src.render.Pipelines"] = fakePipelines
+package.loaded["src.ui.OptionsMenu"] = fakeOptionsMenu
+
+local actualModules = {
+  CompanionLifecycle = true,
+  VoxelCompanion = true,
+  VoxelCompanionAPI = true,
+  VoxelVisualObjects = true,
+}
+
+local moduleSources = {
+  Mat4 = mat4Source,
+  VoxelState = voxelStateSource,
+  TileShape = tileShapeSource,
+  ChunkMesher = chunkMesherSource,
+  Voxel3D = "return ... and _G.__COMPANION_TEST_VOXEL3D",
+  DayNight = [=[
+    local setting = { key = "daynight" }
+    function setting:schema(description) return { key = self.key, description = description } end
+    function setting:get() return "day" end
+    function setting:setIndex() return true end
+    function setting:cycle() return true end
+    function setting:sync() return true end
+    return { setting = setting, isCanopy = function() return false end,
+      tod = function() return "DAY" end, time = function() return 12 end,
+      update = function() end, forceSync = function() end,
+      store = function() end, restore = function() end }
+  ]=],
+}
+_G.__COMPANION_TEST_VOXEL3D = voxel3D
+
+local registries = setmetatable({}, { __index = function(self, name)
+  local registry = { records = {} }
+  function registry:register(id, value)
+    self.records[id] = value
+    return value
+  end
+  rawset(self, name, registry)
+  return registry
+end })
+
+local mod = {
+  id = "BATTLE_ART_VOXEL_FORK",
+  path = ".",
+  hooks = hookFacade,
+  events = eventFacade,
+  content = registries,
+  exports = {},
+  options = { define = function() end },
+  log = { error = function(_, format, value)
+    error(tostring(format):format(value), 0)
+  end },
+}
+function mod:read(relative)
+  local name = relative:match("^lib/(.+)%.lua$")
+  if actualModules[name] then return readFile(relative) end
+  return moduleSources[name] or settingSource
+end
+
+assert(loadfile("main.lua"))(mod)
+_G.__COMPANION_TEST_VOXEL3D = nil
+
+equal(#(hooks["core.update"] or {}), 1,
+  "main.lua installs one companion update hook")
+equal(#(hooks["core.quit_to_launcher"] or {}), 1,
+  "main.lua binds the returned disposer to the native unload hook")
+
+local host = mod.exports.lib.companion
+local ChunkMesher = mod.exports.lib.require("ChunkMesher")
+local signId = "BATTLE_ART_VOXEL_FORK:signpost:PALLET_TOWN:1:0"
+local extensionDisposals, claimed, claimError, replacement = 0
+local handle
+handle = assert(mod.exports.voxel_companion.register({
+  api = 1,
+  id = "test.main-uninstall-owner",
+  requires = { "visual_object_overrides", "world_snapshot", "render_phases" },
+  worldChanged = function(snapshot)
+    replacement = assert(snapshot.visualObjects[1])
+    claimed, claimError = handle:claim_visual_objects({ replacement.id })
+  end,
+  render = {
+    opaque_after_terrain = function(context)
+      local ok, err = context.draw.visual_object({
+        schemaVersion = 1,
+        kind = "visual_object_replacement",
+        objectId = replacement.id,
+        geometry = { {
+          shape = "box",
+          position = { x = 0, y = 0, z = 0 },
+          rotation = { yaw = 0, pitch = 0, roll = 0 },
+          scale = { x = 1, y = 1, z = 1 },
+          pivot = "bottom_center",
+          dimensions = { width = 16, height = 16, depth = 2 },
+          material = { color = { 0.55, 0.32, 0.16, 1 } },
+        } },
+        text = {},
+      }, context)
+      if not ok then error(err, 0) end
+    end,
+  },
+  dispose = function() extensionDisposals = extensionDisposals + 1 end,
+}))
+
+emit("mods.loaded", { data = {} })
+local map = {
+  id = "PALLET_TOWN", widthCells = 2, heightCells = 2,
+  def = { width = 1, height = 1, tileset = "OVERWORLD" },
+  tileset = { id = "OVERWORLD", image = "synthetic-atlas" },
+}
+function map:cellTile(x, z) return x == 1 and z == 0 and 4 or 0 end
+function map:isWalkableCell(x, z) return not (x == 1 and z == 0) end
+function map:isWaterCell() return false end
+function map:isGrassCell() return false end
+function map:warpAtCell() return nil end
+function map:isWarpTileCell() return false end
+local player = { id = "player", px = 0, py = 0, cellX = 0, cellY = 0,
+  facing = "down", gh = 0 }
+local state = { map = map, player = player, entities = { player }, neighbors = {} }
+local game = { overworld = state }
+callHook("core.update", function() return "updated" end, game, 0.016)
+check(claimed, claimError or "the annotated sign claim succeeds")
+equal(handle:status().visualClaims, 1, "the live extension owns one sign")
+check(host:suppressesVisualObject(signId), "the claimed sign suppresses original color")
+equal(#select(3, ChunkMesher.pair(map, false)), 0,
+  "the claimed sign's original color sidecar is hidden")
+check(host:render("opaque_after_terrain", state),
+  "the claimed replacement renders through the real adapter")
+equal(#meshResources, 1, "one host-owned GPU mesh is allocated")
+equal(#textureResources, 1, "one host-owned adapter texture is allocated")
+
+local firstQuit = callHook("core.quit_to_launcher",
+  function() return "first-unload" end)
+equal(firstQuit, "first-unload", "native unload preserves the host result")
+equal(host:status().visualOverrides, 0, "actual unload clears all claims")
+equal(handle:status().visualClaims, 0, "the extension claim count becomes zero")
+check(not host:suppressesVisualObject(signId),
+  "actual unload stops suppressing the original sign")
+equal(#select(3, ChunkMesher.pair(map, false)), 1,
+  "the original sign color is restored immediately")
+equal(extensionDisposals, 1, "extension disposal runs exactly once")
+equal(meshResources[1].releases, 1, "the host GPU mesh releases exactly once")
+equal(textureResources[1].releases, 1,
+  "the host adapter texture releases exactly once")
+equal(updateRemovals, 1, "actual unload removes the companion update hook")
+equal(#(hooks["core.update"] or {}), 0,
+  "the companion update hook is absent after unload")
+
+local secondQuit = callHook("core.quit_to_launcher",
+  function() return "second-unload" end)
+equal(secondQuit, "second-unload", "a second native unload is safe")
+equal(extensionDisposals, 1, "the second unload does not dispose twice")
+equal(meshResources[1].releases, 1, "the second unload does not release the mesh twice")
+equal(textureResources[1].releases, 1,
+  "the second unload does not release the texture twice")
+equal(updateRemovals, 1, "the second unload does not remove the update hook twice")
+
+print(("%d checks passed (main.lua companion uninstall integration)"):format(checks))

--- a/tests/voxel_companion_api_v1_test.lua
+++ b/tests/voxel_companion_api_v1_test.lua
@@ -216,6 +216,7 @@ local fakeShapes = {
   [1] = { class = "wall", h = 8 },
   [2] = { class = "tree", h = 12 },
   [3] = { class = "water", h = 0 },
+  [4] = { class = "signpost", h = 16 },
 }
 
 local fakeTileShape = {
@@ -224,6 +225,14 @@ local fakeTileShape = {
 
 local fakeMapModule = {
   isOutdoor = function() return true end,
+}
+
+local visualRefreshes = {}
+local fakeChunkMesher = {
+  refreshVisualObjects = function(mapId)
+    visualRefreshes[#visualRefreshes + 1] = mapId
+    return true
+  end,
 }
 
 local fakeGame = { save = { version = "red" } }
@@ -250,6 +259,7 @@ local function namespace(mod)
     VoxelCompanionAPI = API,
     Mat4 = fakeMat4,
     TileShape = fakeTileShape,
+    ChunkMesher = fakeChunkMesher,
     VoxelState = fakeVoxelState,
     Voxel3D = fakeVoxel3D,
     DayNight = fakeDayNight,
@@ -372,6 +382,265 @@ local function wireCommand(kind, phase, sequence, fields)
   command.sortKey = command.sortKey or command.cacheKey
   command.material = command.material or "test:material"
   return command
+end
+
+do
+  local function signMap(id, signX, signZ)
+    local map = {
+      id = id,
+      widthCells = 2,
+      heightCells = 2,
+      def = { width = 1, height = 1, tileset = "OVERWORLD" },
+      tileset = { id = "OVERWORLD", image = "synthetic-atlas" },
+    }
+    function map:cellTile(x, z)
+      return x == signX and z == signZ and 4 or 0
+    end
+    function map:isWalkableCell(x, z) return not (x == signX and z == signZ) end
+    function map:isWaterCell() return false end
+    function map:isGrassCell() return false end
+    function map:warpAtCell() return nil end
+    function map:isWarpTileCell() return false end
+    return map
+  end
+
+  local current = signMap("PALLET_TOWN", 1, 0)
+  local neighbor = signMap("ROUTE_1", 0, 1)
+  local player = { id = "player", px = 0, py = 0, cellX = 0, cellY = 0,
+    facing = "down", gh = 0 }
+  local visualState = {
+    map = current,
+    player = player,
+    entities = { player },
+    neighbors = { { map = neighbor, ox = 64, oy = -32 } },
+  }
+
+  local ambiguousCount
+  local ambiguousHost = VoxelCompanion.new({ mod = cleanMod() })
+  assert(ambiguousHost.provider.register({
+    api = 1,
+    id = "test.visual-ambiguous-placement",
+    requires = { "world_snapshot" },
+    worldChanged = function(snapshot) ambiguousCount = #snapshot.visualObjects end,
+  }))
+  check(ambiguousHost:start(), "ambiguous-placement host starts")
+  check(ambiguousHost:update(0.016, {
+    map = current,
+    player = player,
+    entities = { player },
+    neighbors = { { map = current, ox = 64, oy = 0 } },
+  }), "duplicate map placement snapshot dispatches")
+  equal(ambiguousCount, 0,
+    "one stable ID with two rendered transforms is omitted fail closed")
+  check(ambiguousHost:dispose("ambiguous-placement-test"),
+    "ambiguous-placement host disposes cleanly")
+
+  local function visualSignature(objects)
+    local out = {}
+    for _, object in ipairs(objects or {}) do
+      local t, d = object.transform, object.dimensions
+      out[#out + 1] = table.concat({ object.id, object.map.role,
+        object.map.offsetX, object.map.offsetZ, object.cell.x, object.cell.z,
+        t.localPosition.x, t.localPosition.y, t.localPosition.z,
+        t.worldPosition.x, t.worldPosition.y, t.worldPosition.z,
+        t.rotation.yaw, t.rotation.pitch, t.rotation.roll,
+        object.pivot.kind, object.pivot.x, object.pivot.y, object.pivot.z,
+        d.width, d.height, d.depth, object.material.phase }, "|")
+    end
+    return table.concat(out, "\n")
+  end
+
+  local host = VoxelCompanion.new({ mod = cleanMod() })
+  local handle, callbackClaimed, callbackClaimError
+  local claimedIds, replacements, callbackModes = {}, {}, {}
+  local invalidations, disposals = 0, 0
+  handle = assert(host.provider.register({
+    api = 1,
+    id = "test.visual-owner",
+    requires = { "visual_object_overrides", "world_snapshot", "render_phases" },
+    worldChanged = function(snapshot)
+      claimedIds, replacements = {}, {}
+      for _, object in ipairs(snapshot.visualObjects or {}) do
+        claimedIds[#claimedIds + 1] = object.id
+        replacements[#replacements + 1] = {
+          id = object.id,
+          x = object.transform.worldPosition.x,
+          y = object.transform.worldPosition.y + object.dimensions.height * 0.5,
+          z = object.transform.worldPosition.z,
+          width = object.dimensions.width,
+          height = object.dimensions.height,
+          depth = object.dimensions.depth,
+        }
+      end
+      callbackClaimed, callbackClaimError = handle:claim_visual_objects(claimedIds)
+    end,
+    render = {
+      opaque_after_terrain = function(context)
+        local mode = context.camera.mode
+        callbackModes[mode] = callbackModes[mode] or {}
+        for index, object in ipairs(replacements) do
+          local accepted, drawError = context.draw.mesh(wireCommand(
+            "mesh", "opaque_after_terrain", 300 + index, {
+              cacheKey = "visual.replace:" .. tostring(index),
+              owner = "test.visual-owner",
+              sortKey = "visual-replacement:" .. tostring(index),
+              material = "test:visual-replacement",
+              geometry = {
+                primitive = "box", x = object.x, y = object.y, z = object.z,
+                width = object.width, height = object.height, depth = object.depth,
+              },
+            }), context)
+          if not accepted then error(drawError, 0) end
+          callbackModes[mode][object.id] = fakeVoxel3D.drawLog[#fakeVoxel3D.drawLog].model
+        end
+      end,
+    },
+    invalidate = function() invalidations = invalidations + 1 end,
+    dispose = function() disposals = disposals + 1 end,
+  }))
+  check(host:start(), "visual-object host starts")
+  visualRefreshes = {}
+  fakeCameraMode = "first_person"
+  check(host:update(0.016, visualState), "visual-object current/neighbor snapshot dispatches")
+  check(callbackClaimed, callbackClaimError or "known visual IDs are claimed")
+
+  local first = assert(host.world.snapshot())
+  equal(#first.visualObjects, 2,
+    "current and rendered-neighbor signposts receive public descriptors")
+  local byMap = {}
+  for _, object in ipairs(first.visualObjects) do byMap[object.map.id] = object end
+  local currentObject, neighborObject = byMap.PALLET_TOWN, byMap.ROUTE_1
+  check(currentObject and neighborObject, "both map identities are present")
+  equal(currentObject.map.role, "current", "current-map object keeps its role")
+  equal(neighborObject.map.role, "neighbor", "neighbor object keeps its role")
+  equal(currentObject.id,
+    "BATTLE_ART_VOXEL_FORK:signpost:PALLET_TOWN:1:0",
+    "current signpost ID is deterministic and safe")
+  equal(neighborObject.id,
+    "BATTLE_ART_VOXEL_FORK:signpost:ROUTE_1:0:1",
+    "neighbor signpost ID is deterministic and safe")
+  equal(currentObject.transform.localPosition.x, 24,
+    "current object local transform uses its cell")
+  equal(currentObject.transform.localPosition.z, 12,
+    "signpost pivot uses the exact two-unit host depth band")
+  equal(neighborObject.transform.localPosition.z, 28,
+    "neighbor local transform remains map-local")
+  equal(neighborObject.transform.worldPosition.x, 72,
+    "neighbor world transform includes the connection X offset")
+  equal(neighborObject.transform.worldPosition.z, -4,
+    "neighbor world transform includes the connection Z offset")
+  equal(currentObject.dimensions.depth, 2, "descriptor reports exact signpost depth")
+  equal(currentObject.material.phase, "opaque_after_terrain",
+    "descriptor reports the eligible replacement phase")
+  check(currentObject.material.castsShadow and currentObject.material.receivesShadow,
+    "descriptor reports host shadow material facts")
+  check(host:suppressesVisualObject(currentObject.id),
+    "a valid known-ID claim suppresses the current original")
+  check(host:suppressesVisualObject(neighborObject.id),
+    "a valid known-ID claim suppresses the neighbor original")
+
+  local originalX = host.world.snapshot().visualObjects[1].transform.worldPosition.x
+  first.visualObjects[1].transform.worldPosition.x = 9999
+  equal(host.world.snapshot().visualObjects[1].transform.worldPosition.x, originalX,
+    "visual descriptors are defensive data copies")
+
+  local firstSignature = visualSignature(host.world.snapshot().visualObjects)
+  check(host:render("opaque_after_terrain", visualState),
+    "first-person replacement uses the normal opaque render seam")
+  for _, object in ipairs(host.world.snapshot().visualObjects) do
+    local translation = findTagged(callbackModes.first_person[object.id], "translate")[1]
+    equal(translation[2], object.transform.worldPosition.x,
+      "first-person replacement uses descriptor world X")
+    equal(translation[3], object.transform.worldPosition.y + object.dimensions.height * 0.5,
+      "first-person replacement derives its center from the descriptor pivot")
+    equal(translation[4], object.transform.worldPosition.z,
+      "first-person replacement uses descriptor world Z")
+  end
+
+  fakeCameraMode = "third_person"
+  host:worldChanged("camera-mode-test")
+  check(host:update(0.016, visualState), "third-person visual snapshot dispatches")
+  equal(visualSignature(host.world.snapshot().visualObjects), firstSignature,
+    "first- and third-person use identical IDs and transforms")
+  check(host:render("opaque_after_terrain", visualState),
+    "third-person replacement uses the same opaque render seam")
+  for _, object in ipairs(host.world.snapshot().visualObjects) do
+    equal(treeSignature(callbackModes.third_person[object.id]),
+      treeSignature(callbackModes.first_person[object.id]),
+      "first- and third-person replacement matrices match for " .. object.id)
+  end
+
+  local duplicateOk, duplicateError = handle:claim_visual_objects({
+    currentObject.id, currentObject.id,
+  })
+  equal(duplicateOk, nil, "duplicate claims fail closed")
+  contains(duplicateError, "duplicate id", "duplicate claim explains the fault")
+  check(not host:suppressesVisualObject(currentObject.id)
+      and not host:suppressesVisualObject(neighborObject.id),
+    "a malformed replacement registration restores all originals for its owner")
+
+  local malformedOk, malformedError = handle:claim_visual_objects("not-an-array")
+  equal(malformedOk, nil, "malformed claim registration fails closed")
+  contains(malformedError, "must be an array",
+    "malformed claim registration explains the array contract")
+
+  local invalidIdOk, invalidIdError = handle:claim_visual_objects({ "bad/id" })
+  equal(invalidIdOk, nil, "malformed visual ID fails closed")
+  contains(invalidIdError, "safe ASCII identifier characters",
+    "malformed visual ID explains the safe-ID contract")
+
+  local noOpaque = assert(host.provider.register({
+    api = 1, id = "test.visual-no-opaque", update = function() end,
+  }))
+  local noOpaqueOk, noOpaqueError = noOpaque:claim_visual_objects({ currentObject.id })
+  equal(noOpaqueOk, nil, "claim without the eligible render path fails closed")
+  contains(noOpaqueError, "opaque_after_terrain",
+    "missing render path reports the eligibility rule")
+  check(not host:suppressesVisualObject(currentObject.id),
+    "ineligible registration never hides the original")
+
+  local unknownOk, unknownError = handle:claim_visual_objects({ "UNKNOWN:visual:object" })
+  equal(unknownOk, nil, "unknown visual ID fails closed")
+  contains(unknownError, "unknown visual object id", "unknown claim is diagnostic")
+  check(not host:suppressesVisualObject(currentObject.id),
+    "unknown registration leaves the known original visible")
+  check(handle:claim_visual_objects(claimedIds), "valid claims can be restored")
+
+  local contender = assert(host.provider.register({
+    api = 1,
+    id = "test.visual-contender",
+    render = { opaque_after_terrain = function() end },
+  }))
+  local conflictOk, conflictError = contender:claim_visual_objects({ currentObject.id })
+  equal(conflictOk, nil, "conflicting owner fails closed")
+  contains(conflictError, "ownership conflict", "conflict has a deterministic diagnostic")
+  check(not host:suppressesVisualObject(currentObject.id),
+    "conflicting ownership keeps the current original visible")
+  check(host:suppressesVisualObject(neighborObject.id),
+    "conflict invalidates only the contested visual object")
+  check(contender:dispose({}, "conflict-release"), "conflicting owner disposes")
+  check(host:suppressesVisualObject(currentObject.id),
+    "removing the contender deterministically restores the unique owner")
+
+  check(handle:invalidate({}, "visual-invalidate"), "owner invalidation succeeds")
+  check(not host:suppressesVisualObject(currentObject.id)
+      and not host:suppressesVisualObject(neighborObject.id),
+    "owner invalidation restores current and neighbor originals")
+  check(handle:invalidate({}, "visual-invalidate-repeat"),
+    "repeated owner invalidation is safe")
+  equal(invalidations, 2, "existing invalidation lifecycle remains authoritative")
+  check(handle:claim_visual_objects(claimedIds), "owner can reclaim known objects")
+  check(handle:dispose({}, "visual-dispose"), "visual owner disposes")
+  check(handle:dispose({}, "visual-dispose-repeat"), "repeated visual disposal is safe")
+  equal(disposals, 1, "existing disposal lifecycle releases owner resources once")
+  check(not host:suppressesVisualObject(currentObject.id)
+      and not host:suppressesVisualObject(neighborObject.id),
+    "owner disposal restores originals without touching another extension")
+  check(#visualRefreshes >= 2,
+    "ownership transitions invalidate only named visual-map terrain caches")
+  check(host:dispose("visual-object-test"), "visual-object host disposes cleanly")
+  fakeCameraMode = "first_person"
+  pushCount, popCount = 0, 0
 end
 
 do
@@ -633,7 +902,7 @@ equal(provider.host.id, "BATTLE_ART_VOXEL_FORK", "provider reports stable host i
 equal(provider.host.version, "1.9.7", "provider preserves upstream version")
 for _, capability in ipairs({
   "world_snapshot", "camera_delta", "render_phases", "quality_tier",
-  "integrity_status",
+  "integrity_status", "visual_object_overrides",
 }) do
   equal(provider.capabilities[capability], 1, "provider advertises " .. capability)
 end

--- a/tests/voxel_companion_api_v1_test.lua
+++ b/tests/voxel_companion_api_v1_test.lua
@@ -40,6 +40,7 @@ end
 
 local API = assert(loadfile("lib/VoxelCompanionAPI.lua"))()
 equal(API.VERSION, 1, "vendored dispatcher reports API v1")
+local VisualObjects = assert(loadfile("lib/VoxelVisualObjects.lua"))()
 local DrawFixture = assert(loadfile("tests/fixtures/voxel_companion_draw_v1.lua"))()
 
 local function newRunningDispatcher()
@@ -227,13 +228,7 @@ local fakeMapModule = {
   isOutdoor = function() return true end,
 }
 
-local visualRefreshes = {}
-local fakeChunkMesher = {
-  refreshVisualObjects = function(mapId)
-    visualRefreshes[#visualRefreshes + 1] = mapId
-    return true
-  end,
-}
+local fakeChunkMesher = {}
 
 local fakeGame = { save = { version = "red" } }
 package.loaded["src.world.Map"] = fakeMapModule
@@ -257,6 +252,7 @@ end
 local function namespace(mod)
   local modules = {
     VoxelCompanionAPI = API,
+    VoxelVisualObjects = VisualObjects,
     Mat4 = fakeMat4,
     TileShape = fakeTileShape,
     ChunkMesher = fakeChunkMesher,
@@ -414,6 +410,50 @@ do
     entities = { player },
     neighbors = { { map = neighbor, ox = 64, oy = -32 } },
   }
+
+  local mutationHost = VoxelCompanion.new({ mod = cleanMod() })
+  local observedAfterMutation
+  assert(mutationHost.provider.register({
+    api = 1,
+    id = "test.visual-mutator",
+    priority = -10,
+    requires = { "world_snapshot" },
+    worldChanged = function(snapshot)
+      local descriptor = snapshot.visualObjects[1]
+      descriptor.id = "MUTATED"
+      descriptor.tags[1] = "mutated-tag"
+      descriptor.transform.worldPosition.x = 9999
+    end,
+  }))
+  assert(mutationHost.provider.register({
+    api = 1,
+    id = "test.visual-observer",
+    priority = 10,
+    requires = { "world_snapshot" },
+    worldChanged = function(snapshot)
+      local descriptor = snapshot.visualObjects[1]
+      observedAfterMutation = {
+        id = descriptor.id,
+        tag = descriptor.tags[1],
+        x = descriptor.transform.worldPosition.x,
+      }
+    end,
+  }))
+  check(mutationHost:start(), "two-companion mutation host starts")
+  check(mutationHost:update(0.016, visualState),
+    "two-companion mutation snapshot dispatches")
+  equal(observedAfterMutation.id,
+    "BATTLE_ART_VOXEL_FORK:signpost:PALLET_TOWN:1:0",
+    "one companion cannot mutate the next companion's visual ID")
+  equal(observedAfterMutation.tag, "host_geometry",
+    "one companion cannot mutate the next companion's visual tags")
+  equal(observedAfterMutation.x, 24,
+    "one companion cannot mutate the next companion's visual transform")
+  equal(mutationHost.world.snapshot().visualObjects[1].id,
+    "BATTLE_ART_VOXEL_FORK:signpost:PALLET_TOWN:1:0",
+    "companion mutation cannot change the host visual catalog")
+  check(mutationHost:dispose("two-companion-mutation-test"),
+    "two-companion mutation host disposes cleanly")
 
   local ambiguousCount
   local ambiguousHost = VoxelCompanion.new({ mod = cleanMod() })
@@ -575,19 +615,24 @@ do
   })
   equal(duplicateOk, nil, "duplicate claims fail closed")
   contains(duplicateError, "duplicate id", "duplicate claim explains the fault")
-  check(not host:suppressesVisualObject(currentObject.id)
-      and not host:suppressesVisualObject(neighborObject.id),
-    "a malformed replacement registration restores all originals for its owner")
+  check(host:suppressesVisualObject(currentObject.id)
+      and host:suppressesVisualObject(neighborObject.id),
+    "a rejected duplicate changes no accepted claim")
 
   local malformedOk, malformedError = handle:claim_visual_objects("not-an-array")
   equal(malformedOk, nil, "malformed claim registration fails closed")
   contains(malformedError, "must be an array",
     "malformed claim registration explains the array contract")
+  check(host:suppressesVisualObject(currentObject.id)
+      and host:suppressesVisualObject(neighborObject.id),
+    "a rejected malformed call changes no accepted claim")
 
   local invalidIdOk, invalidIdError = handle:claim_visual_objects({ "bad/id" })
   equal(invalidIdOk, nil, "malformed visual ID fails closed")
   contains(invalidIdError, "safe ASCII identifier characters",
     "malformed visual ID explains the safe-ID contract")
+  check(host:suppressesVisualObject(currentObject.id),
+    "a rejected unsafe ID changes no accepted claim")
 
   local noOpaque = assert(host.provider.register({
     api = 1, id = "test.visual-no-opaque", update = function() end,
@@ -596,15 +641,14 @@ do
   equal(noOpaqueOk, nil, "claim without the eligible render path fails closed")
   contains(noOpaqueError, "opaque_after_terrain",
     "missing render path reports the eligibility rule")
-  check(not host:suppressesVisualObject(currentObject.id),
-    "ineligible registration never hides the original")
+  check(host:suppressesVisualObject(currentObject.id),
+    "ineligible registration cannot change the accepted owner")
 
   local unknownOk, unknownError = handle:claim_visual_objects({ "UNKNOWN:visual:object" })
   equal(unknownOk, nil, "unknown visual ID fails closed")
   contains(unknownError, "unknown visual object id", "unknown claim is diagnostic")
-  check(not host:suppressesVisualObject(currentObject.id),
-    "unknown registration leaves the known original visible")
-  check(handle:claim_visual_objects(claimedIds), "valid claims can be restored")
+  check(host:suppressesVisualObject(currentObject.id),
+    "unknown registration leaves the accepted owner unchanged")
 
   local contender = assert(host.provider.register({
     api = 1,
@@ -614,18 +658,15 @@ do
   local conflictOk, conflictError = contender:claim_visual_objects({ currentObject.id })
   equal(conflictOk, nil, "conflicting owner fails closed")
   contains(conflictError, "ownership conflict", "conflict has a deterministic diagnostic")
-  check(not host:suppressesVisualObject(currentObject.id),
-    "conflicting ownership keeps the current original visible")
-  check(host:suppressesVisualObject(neighborObject.id),
-    "conflict invalidates only the contested visual object")
-  check(contender:dispose({}, "conflict-release"), "conflicting owner disposes")
   check(host:suppressesVisualObject(currentObject.id),
-    "removing the contender deterministically restores the unique owner")
-
+    "conflict rejection preserves the accepted owner")
+  check(host:suppressesVisualObject(neighborObject.id),
+    "conflict rejection preserves unrelated accepted ownership")
   check(handle:invalidate({}, "visual-invalidate"), "owner invalidation succeeds")
   check(not host:suppressesVisualObject(currentObject.id)
       and not host:suppressesVisualObject(neighborObject.id),
-    "owner invalidation restores current and neighbor originals")
+    "owner invalidation restores originals with no rejected pending owner")
+  check(contender:dispose({}, "conflict-release"), "rejected contender disposes")
   check(handle:invalidate({}, "visual-invalidate-repeat"),
     "repeated owner invalidation is safe")
   equal(invalidations, 2, "existing invalidation lifecycle remains authoritative")
@@ -636,8 +677,6 @@ do
   check(not host:suppressesVisualObject(currentObject.id)
       and not host:suppressesVisualObject(neighborObject.id),
     "owner disposal restores originals without touching another extension")
-  check(#visualRefreshes >= 2,
-    "ownership transitions invalidate only named visual-map terrain caches")
   check(host:dispose("visual-object-test"), "visual-object host disposes cleanly")
   fakeCameraMode = "first_person"
   pushCount, popCount = 0, 0

--- a/tests/voxel_companion_api_v1_test.lua
+++ b/tests/voxel_companion_api_v1_test.lua
@@ -229,6 +229,18 @@ local fakeMapModule = {
 }
 
 local fakeChunkMesher = {}
+function fakeChunkMesher.visualObjectAnnotated(map, id)
+  for z = 0, (map.heightCells or 0) - 1 do
+    for x = 0, (map.widthCells or 0) - 1 do
+      if map:cellTile(x, z) == 4
+          and VisualObjects.id("BATTLE_ART_VOXEL_FORK", "signpost",
+            map.id, x, z) == id then
+        return true
+      end
+    end
+  end
+  return false
+end
 
 local fakeGame = { save = { version = "red" } }
 package.loaded["src.world.Map"] = fakeMapModule

--- a/tests/voxel_companion_api_v1_test.lua
+++ b/tests/voxel_companion_api_v1_test.lua
@@ -196,6 +196,8 @@ local fakeMat4 = {
   translate = function(x, y, z) return { "translate", x, y, z } end,
   scale = function(x, y, z) return { "scale", x, y, z } end,
   rotateY = function(value) return { "rotateY", value } end,
+  rotateX = function(value) return { "rotateX", value } end,
+  rotateZ = function(value) return { "rotateZ", value } end,
 }
 
 local fakeCameraMode = "first_person"
@@ -505,7 +507,45 @@ do
   local host = VoxelCompanion.new({ mod = cleanMod() })
   local handle, callbackClaimed, callbackClaimError
   local claimedIds, replacements, callbackModes = {}, {}, {}
+  local callbackRejections = {}
   local invalidations, disposals = 0, 0
+
+  local function replacementCommand(object)
+    return {
+      schemaVersion = 1,
+      kind = "visual_object_replacement",
+      objectId = object.id,
+      geometry = {
+        {
+          shape = "box",
+          position = { x = 0, y = 0, z = 0 },
+          rotation = { yaw = 0, pitch = 0, roll = 0 },
+          scale = { x = 1, y = 1, z = 1 },
+          pivot = "bottom_center",
+          dimensions = {
+            width = object.dimensions.width,
+            height = object.dimensions.height,
+            depth = object.dimensions.depth,
+          },
+          material = { color = { 0.55, 0.32, 0.16, 1 } },
+        },
+      },
+      text = {
+        {
+          value = object.map.id:gsub("_", " "),
+          encoding = "ascii-5x7",
+          position = { x = 0, y = 6, z = 1.1 },
+          rotation = { yaw = 0, pitch = 0, roll = 0 },
+          scale = { x = 0.2, y = 0.2, z = 1 },
+          orientation = "object",
+          align = "center",
+          material = { color = { 1, 1, 1, 1 } },
+        },
+      },
+    }
+  end
+  local currentReplacementCommand = replacementCommand
+
   handle = assert(host.provider.register({
     api = 1,
     id = "test.visual-owner",
@@ -514,15 +554,7 @@ do
       claimedIds, replacements = {}, {}
       for _, object in ipairs(snapshot.visualObjects or {}) do
         claimedIds[#claimedIds + 1] = object.id
-        replacements[#replacements + 1] = {
-          id = object.id,
-          x = object.transform.worldPosition.x,
-          y = object.transform.worldPosition.y + object.dimensions.height * 0.5,
-          z = object.transform.worldPosition.z,
-          width = object.dimensions.width,
-          height = object.dimensions.height,
-          depth = object.dimensions.depth,
-        }
+        replacements[#replacements + 1] = object
       end
       callbackClaimed, callbackClaimError = handle:claim_visual_objects(claimedIds)
     end,
@@ -530,20 +562,29 @@ do
       opaque_after_terrain = function(context)
         local mode = context.camera.mode
         callbackModes[mode] = callbackModes[mode] or {}
-        for index, object in ipairs(replacements) do
-          local accepted, drawError = context.draw.mesh(wireCommand(
-            "mesh", "opaque_after_terrain", 300 + index, {
-              cacheKey = "visual.replace:" .. tostring(index),
-              owner = "test.visual-owner",
-              sortKey = "visual-replacement:" .. tostring(index),
-              material = "test:visual-replacement",
-              geometry = {
-                primitive = "box", x = object.x, y = object.y, z = object.z,
-                width = object.width, height = object.height, depth = object.depth,
-              },
-            }), context)
+        if not callbackRejections.checked and replacements[1] then
+          callbackRejections.checked = true
+          local before = #fakeVoxel3D.drawLog
+          local invalidTransform = replacementCommand(replacements[1])
+          invalidTransform.geometry[1].position.x = math.huge
+          callbackRejections.transform, callbackRejections.transformError =
+            context.draw.visual_object(invalidTransform, context)
+          local invalidText = replacementCommand(replacements[1])
+          invalidText.text[1].value = "Pallet Town"
+          callbackRejections.text, callbackRejections.textError =
+            context.draw.visual_object(invalidText, context)
+          local rawResource = replacementCommand(replacements[1])
+          rawResource.texture = { private = true }
+          callbackRejections.resource, callbackRejections.resourceError =
+            context.draw.visual_object(rawResource, context)
+          callbackRejections.draws = #fakeVoxel3D.drawLog - before
+        end
+        for _, object in ipairs(replacements) do
+          local drawStart = #fakeVoxel3D.drawLog
+          local accepted, drawError = context.draw.visual_object(
+            currentReplacementCommand(object), context)
           if not accepted then error(drawError, 0) end
-          callbackModes[mode][object.id] = fakeVoxel3D.drawLog[#fakeVoxel3D.drawLog].model
+          callbackModes[mode][object.id] = fakeVoxel3D.drawLog[drawStart + 1].model
         end
       end,
     },
@@ -563,6 +604,12 @@ do
   for _, object in ipairs(first.visualObjects) do byMap[object.map.id] = object end
   local currentObject, neighborObject = byMap.PALLET_TOWN, byMap.ROUTE_1
   check(currentObject and neighborObject, "both map identities are present")
+  equal(next(handle), nil, "public visual handle has no enumerable private state")
+  for _, field in ipairs({ "host", "raw", "record", "mesh", "renderer",
+                            "scene", "texture", "font", "shader" }) do
+    equal(rawget(handle, field), nil,
+      "public visual handle does not leak private field " .. field)
+  end
   equal(currentObject.map.role, "current", "current-map object keeps its role")
   equal(neighborObject.map.role, "neighbor", "neighbor object keeps its role")
   equal(currentObject.id,
@@ -591,6 +638,101 @@ do
   check(host:suppressesVisualObject(neighborObject.id),
     "a valid known-ID claim suppresses the neighbor original")
 
+  local validReplacement, primitiveCount =
+    VisualObjects.validateReplacementCommand(
+      replacementCommand(currentObject), currentObject)
+  check(validReplacement and primitiveCount > 1,
+    "bounded geometry and readable text command validates")
+  equal(validReplacement.text[1].value, "PALLET TOWN",
+    "validated text keeps its allowed ASCII lettering")
+  local billboardCommand = replacementCommand(currentObject)
+  billboardCommand.text[1].orientation = "billboard_yaw"
+  local validBillboard = VisualObjects.validateReplacementCommand(
+    billboardCommand, currentObject)
+  check(validBillboard, "upright camera-yaw text orientation validates")
+  local planeCommand = replacementCommand(currentObject)
+  planeCommand.text = {}
+  planeCommand.geometry[1].shape = "plane"
+  planeCommand.geometry[1].pivot = "center"
+  planeCommand.geometry[1].dimensions = { width = 8, height = 4 }
+  check(VisualObjects.validateReplacementCommand(planeCommand, currentObject),
+    "bounded host-owned plane geometry validates")
+
+  local descriptorGuard = VisualObjects.new()
+  check(descriptorGuard:setCatalog({ currentObject }),
+    "bounded descriptor guard accepts the current transform")
+  local badDescriptor = assert(VisualObjects.copy(currentObject))
+  badDescriptor.transform.worldPosition.x = math.huge
+  local badCatalog, badCatalogError = descriptorGuard:setCatalog({ badDescriptor })
+  equal(badCatalog, nil, "non-finite descriptor transform fails closed")
+  contains(badCatalogError, "finite", "non-finite descriptor has a diagnostic")
+  badDescriptor = assert(VisualObjects.copy(currentObject))
+  badDescriptor.transform.rotation.yaw = math.pi * 2 + 0.01
+  badCatalog, badCatalogError = descriptorGuard:setCatalog({ badDescriptor })
+  equal(badCatalog, nil, "out-of-range descriptor rotation fails closed")
+  contains(badCatalogError, "rotation bound",
+    "out-of-range descriptor rotation has a diagnostic")
+  badDescriptor = assert(VisualObjects.copy(currentObject))
+  badDescriptor.transform.scale.z = 0
+  badCatalog, badCatalogError = descriptorGuard:setCatalog({ badDescriptor })
+  equal(badCatalog, nil, "non-positive descriptor scale fails closed")
+  contains(badCatalogError, "must be positive",
+    "non-positive descriptor scale has a diagnostic")
+  equal(descriptorGuard:status().visualObjects, 1,
+    "rejected descriptor transforms preserve the accepted catalog")
+
+  local function rejectedCommand(change, fragment, message)
+    local command = replacementCommand(currentObject)
+    change(command)
+    local accepted, validationError =
+      VisualObjects.validateReplacementCommand(command, currentObject)
+    equal(accepted, nil, message .. " fails closed")
+    contains(validationError, fragment, message .. " has a bounded diagnostic")
+  end
+
+  rejectedCommand(function(command)
+    command.geometry[1].position.x = 0 / 0
+  end, "finite range", "non-finite geometry position")
+  rejectedCommand(function(command)
+    command.geometry[1].rotation.roll = math.pi * 2 + 0.01
+  end, "finite range", "out-of-range geometry rotation")
+  rejectedCommand(function(command)
+    command.geometry[1].scale.y = 0
+  end, "positive", "non-positive geometry scale")
+  rejectedCommand(function(command)
+    command.geometry[1].dimensions.width = 257
+  end, "finite range", "out-of-range geometry dimension")
+  rejectedCommand(function(command)
+    command.geometry[1].vertices = { { 0, 0, 0 } }
+  end, "unsupported field", "arbitrary geometry vertices")
+  rejectedCommand(function(command)
+    command.text[1].value = "Pallet Town"
+  end, "accepts only", "text outside the allowed glyph policy")
+  rejectedCommand(function(command)
+    command.text[1].value = string.rep("A", 65)
+  end, "1..64 ASCII bytes", "overlength text")
+  rejectedCommand(function(command)
+    command.text[1].encoding = "utf-8"
+  end, "ascii-5x7", "unsupported text encoding")
+  rejectedCommand(function(command)
+    command.text[1].orientation = "billboard_yaw"
+    command.text[1].rotation.pitch = 0.1
+  end, "zero pitch and roll", "tilted yaw billboard")
+  rejectedCommand(function(command)
+    command.text[1].material.color[4] = 0.5
+  end, "alpha must be 1", "translucent text material")
+  for _, field in ipairs({ "mesh", "renderer", "texture", "font", "scene",
+                            "model", "resource", "shader", "vertices" }) do
+    rejectedCommand(function(command) command[field] = {} end,
+      "unsupported field", "private/resource field " .. field)
+  end
+
+  local outsideDraw, outsideError = host.draw.visual_object(
+    replacementCommand(currentObject), {})
+  equal(outsideDraw, false, "visual command outside its borrowed callback fails closed")
+  contains(outsideError, "only in the owner's opaque_after_terrain callback",
+    "out-of-lifecycle visual command reports its lifecycle rule")
+
   local originalX = host.world.snapshot().visualObjects[1].transform.worldPosition.x
   first.visualObjects[1].transform.worldPosition.x = 9999
   equal(host.world.snapshot().visualObjects[1].transform.worldPosition.x, originalX,
@@ -599,14 +741,30 @@ do
   local firstSignature = visualSignature(host.world.snapshot().visualObjects)
   check(host:render("opaque_after_terrain", visualState),
     "first-person replacement uses the normal opaque render seam")
+  equal(callbackRejections.transform, false,
+    "invalid transform command fails closed at the borrowed draw boundary")
+  contains(callbackRejections.transformError, "finite range",
+    "invalid transform draw has a bounded diagnostic")
+  equal(callbackRejections.text, false,
+    "invalid text command fails closed at the borrowed draw boundary")
+  contains(callbackRejections.textError, "accepts only",
+    "invalid text draw has a bounded diagnostic")
+  equal(callbackRejections.resource, false,
+    "raw resource command fails closed at the borrowed draw boundary")
+  contains(callbackRejections.resourceError, "unsupported field",
+    "raw resource draw has a bounded diagnostic")
+  equal(callbackRejections.draws, 0,
+    "rejected visual commands submit no partial geometry")
   for _, object in ipairs(host.world.snapshot().visualObjects) do
-    local translation = findTagged(callbackModes.first_person[object.id], "translate")[1]
-    equal(translation[2], object.transform.worldPosition.x,
+    local translations = findTagged(callbackModes.first_person[object.id], "translate")
+    equal(translations[1][2], object.transform.worldPosition.x,
       "first-person replacement uses descriptor world X")
-    equal(translation[3], object.transform.worldPosition.y + object.dimensions.height * 0.5,
-      "first-person replacement derives its center from the descriptor pivot")
-    equal(translation[4], object.transform.worldPosition.z,
+    equal(translations[1][3], object.transform.worldPosition.y,
+      "first-person replacement uses descriptor world Y")
+    equal(translations[1][4], object.transform.worldPosition.z,
       "first-person replacement uses descriptor world Z")
+    equal(translations[3][3], object.dimensions.height * 0.5,
+      "first-person replacement derives its center from the declared pivot")
   end
 
   fakeCameraMode = "third_person"
@@ -621,6 +779,91 @@ do
       treeSignature(callbackModes.first_person[object.id]),
       "first- and third-person replacement matrices match for " .. object.id)
   end
+
+  local catalog = host.world.snapshot().visualObjects
+  local transformed = assert(VisualObjects.copy(currentObject))
+  transformed.transform.worldPosition = { x = 11, y = 12, z = 13 }
+  transformed.transform.rotation = { yaw = 0.2, pitch = -0.3, roll = 0.4 }
+  transformed.transform.scale = { x = 2, y = 3, z = 4 }
+  check(host.visuals:setCatalog({ transformed }),
+    "bounded transformed descriptor becomes the current catalog")
+  check(handle:claim_visual_objects({ transformed.id }),
+    "owner claims the transformed descriptor")
+  replacements = { transformed }
+  currentReplacementCommand = function(object)
+    local command = replacementCommand(object)
+    command.text = {}
+    local geometry = command.geometry[1]
+    geometry.position = { x = 1, y = 2, z = 3 }
+    geometry.rotation = { yaw = 0.5, pitch = -0.6, roll = 0.7 }
+    geometry.scale = { x = 0.8, y = 0.9, z = 1.1 }
+    geometry.dimensions = { width = 4, height = 5, depth = 6 }
+    return command
+  end
+  check(host:render("opaque_after_terrain", visualState),
+    "full descriptor and local transform render")
+  local fullModel = callbackModes.third_person[transformed.id]
+  local fullTranslations = findTagged(fullModel, "translate")
+  equal(treeSignature(fullTranslations[1]), treeSignature({ "translate", 11, 12, 13 }),
+    "descriptor world translation propagates without reconstruction")
+  equal(treeSignature(fullTranslations[2]), treeSignature({ "translate", 1, 2, 3 }),
+    "replacement local translation propagates")
+  equal(findTagged(fullModel, "rotateY")[1][2], 0.2,
+    "descriptor yaw propagates")
+  equal(findTagged(fullModel, "rotateX")[1][2], -0.3,
+    "descriptor pitch propagates")
+  equal(findTagged(fullModel, "rotateZ")[1][2], 0.4,
+    "descriptor roll propagates")
+  equal(findTagged(fullModel, "rotateY")[2][2], 0.5,
+    "replacement yaw propagates")
+  equal(findTagged(fullModel, "rotateX")[2][2], -0.6,
+    "replacement pitch propagates")
+  equal(findTagged(fullModel, "rotateZ")[2][2], 0.7,
+    "replacement roll propagates")
+  local fullScales = findTagged(fullModel, "scale")
+  equal(treeSignature(fullScales[1]), treeSignature({ "scale", 2, 3, 4 }),
+    "positive descriptor scale propagates")
+  equal(treeSignature(fullScales[2]), treeSignature({ "scale", 0.8, 0.9, 1.1 }),
+    "positive replacement scale propagates")
+  equal(treeSignature(fullScales[3]), treeSignature({ "scale", 4, 5, 6 }),
+    "replacement dimensions propagate")
+
+  currentReplacementCommand = function(object)
+    local command = replacementCommand(object)
+    command.geometry = {}
+    local text = command.text[1]
+    text.value = "A"
+    text.position = { x = 1, y = 2, z = 3 }
+    text.rotation = { yaw = 0.25, pitch = 0, roll = 0 }
+    text.scale = { x = 0.5, y = 0.5, z = 1 }
+    text.orientation = "billboard_yaw"
+    return command
+  end
+  check(host:render("opaque_after_terrain", visualState),
+    "camera-yaw text renders at the transformed descriptor anchor")
+  local billboardModel = callbackModes.third_person[transformed.id]
+  local bx, by, bz = 2, 6, 12
+  local cr, sr = math.cos(0.4), math.sin(0.4)
+  bx, by = bx * cr - by * sr, bx * sr + by * cr
+  local cp, sp = math.cos(-0.3), math.sin(-0.3)
+  by, bz = by * cp - bz * sp, by * sp + bz * cp
+  local cy, sy = math.cos(0.2), math.sin(0.2)
+  bx, bz = bx * cy + bz * sy, -bx * sy + bz * cy
+  local billboardTranslation = findTagged(billboardModel, "translate")[1]
+  equal(billboardTranslation[2], 11 + bx,
+    "billboard anchor applies descriptor yaw, pitch, roll, and scale to X")
+  equal(billboardTranslation[3], 12 + by,
+    "billboard anchor applies descriptor yaw, pitch, roll, and scale to Y")
+  equal(billboardTranslation[4], 13 + bz,
+    "billboard anchor applies descriptor yaw, pitch, roll, and scale to Z")
+  equal(treeSignature(findTagged(billboardModel, "scale")[1]),
+    treeSignature({ "scale", 1, 1.5, 4 }),
+    "billboard keeps positive descriptor and text scale")
+
+  check(host.visuals:setCatalog(catalog), "normal visual catalog is restored")
+  check(handle:claim_visual_objects(claimedIds), "normal claims are restored")
+  replacements = catalog
+  currentReplacementCommand = replacementCommand
 
   local duplicateOk, duplicateError = handle:claim_visual_objects({
     currentObject.id, currentObject.id,
@@ -690,6 +933,46 @@ do
       and not host:suppressesVisualObject(neighborObject.id),
     "owner disposal restores originals without touching another extension")
   check(host:dispose("visual-object-test"), "visual-object host disposes cleanly")
+
+  local phaseHost = VoxelCompanion.new({ mod = cleanMod() })
+  local phaseHandle, phaseClaimed, phaseError, phaseMapId
+  phaseHandle = assert(phaseHost.provider.register({
+    api = 1,
+    id = "test.visual-phase-map-change",
+    requires = { "visual_object_overrides", "world_snapshot", "render_phases" },
+    phases = {
+      map_changed = function(snapshot)
+        phaseMapId = snapshot.id
+        local ids = {}
+        for _, object in ipairs(snapshot.visualObjects) do ids[#ids + 1] = object.id end
+        phaseClaimed, phaseError = phaseHandle:claim_visual_objects(ids)
+      end,
+      opaque_after_terrain = function() end,
+    },
+  }))
+  local phaseState = {
+    map = current, player = player, entities = { player }, neighbors = {},
+  }
+  check(phaseHost:start(), "phase-table map-change host starts")
+  check(phaseHost:update(0.016, phaseState),
+    "phase-table map-change snapshot dispatches")
+  check(phaseClaimed, phaseError or "phase-table callback can claim")
+  equal(phaseMapId, "PALLET_TOWN",
+    "phase-table callback receives the defensive current snapshot")
+  check(phaseHost:suppressesVisualObject(currentObject.id),
+    "phase-table callback activates the current-map claim")
+  phaseState.map = neighbor
+  check(phaseHost:update(0.016, phaseState), "map scene transition dispatches")
+  check(phaseClaimed, phaseError or "transition claim succeeds")
+  equal(phaseMapId, "ROUTE_1", "map scene transition publishes the new identity")
+  check(not phaseHost:suppressesVisualObject(currentObject.id),
+    "scene transition releases the stale object claim")
+  check(phaseHost:suppressesVisualObject(neighborObject.id),
+    "scene transition claims the new object at its stable transform")
+  check(phaseHost:dispose("phase-table-map-change-test"),
+    "phase-table map-change host disposes cleanly")
+  check(not phaseHost:suppressesVisualObject(neighborObject.id),
+    "host disposal restores the scene-transition original")
   fakeCameraMode = "first_person"
   pushCount, popCount = 0, 0
 end
@@ -953,10 +1236,12 @@ equal(provider.host.id, "BATTLE_ART_VOXEL_FORK", "provider reports stable host i
 equal(provider.host.version, "1.9.7", "provider preserves upstream version")
 for _, capability in ipairs({
   "world_snapshot", "camera_delta", "render_phases", "quality_tier",
-  "integrity_status", "visual_object_overrides",
+  "integrity_status",
 }) do
   equal(provider.capabilities[capability], 1, "provider advertises " .. capability)
 end
+equal(provider.capabilities.visual_object_overrides, 2,
+  "provider advertises the bounded visual-object draw extension version")
 for _, capability in ipairs({
   "terrain_patch", "shadow_pass", "battle_pass", "materials", "draw",
 }) do

--- a/tests/voxel_visual_object_filter_test.lua
+++ b/tests/voxel_visual_object_filter_test.lua
@@ -286,4 +286,146 @@ equal(#(disposedShadows or {}), 1,
   "disposal keeps the original shadow behavior")
 check(host:dispose("integration-host-dispose"), "the integration host disposes")
 
+local function touchingMap(id, horizontal)
+  local map = {
+    id = id,
+    widthCells = 2,
+    heightCells = 2,
+    def = { width = 1, height = 1, tileset = "OVERWORLD" },
+    tileset = {
+      id = "OVERWORLD", image = "synthetic-atlas", tilesPerRow = 16,
+      imageWidth = 128, imageHeight = 48,
+    },
+  }
+  function map:tileAt() return 0 end
+  function map:cellTile(x, z)
+    if horizontal then return (z == 0 and (x == 0 or x == 1)) and 4 or 0 end
+    return (x == 0 and (z == 0 or z == 1)) and 4 or 0
+  end
+  function map:isWalkableCell(x, z) return self:cellTile(x, z) ~= 4 end
+  function map:isWaterCell() return false end
+  function map:isGrassCell() return false end
+  function map:warpAtCell() return nil end
+  function map:isWarpTileCell() return false end
+
+  local sign = { class = "signpost", authored = true, art = "upright", h = 16 }
+  local S = {
+    shapeAt = {}, tileAt = {}, outdoor = true,
+    runs = {}, skip = {}, ground = {}, doorFold = {}, objectQuads = {},
+    grassQuads = {}, flowerQuads = {}, roundStamps = {}, figures = {},
+  }
+  local maxX, maxZ = horizontal and 3 or 1, horizontal and 1 or 3
+  local tiles = {}
+  for z = 0, maxZ do
+    for x = 0, maxX do
+      tiles[#tiles + 1] = { x, z }
+      S.shapeAt[keyOf(x, z)] = sign
+      S.tileAt[keyOf(x, z)] = 0
+    end
+  end
+  local region = {
+    minX = 0, maxX = maxX, minY = 0, maxY = maxZ, tiles = tiles,
+  }
+  Structures.extractObjects(S, map, region,
+    { getPixel = function() return 0, 0, 0, 1 end }, 16, true)
+  check(#S.objectQuads > 0, id .. " keeps extracted original geometry")
+  for _, quad in ipairs(S.objectQuads) do
+    equal(quad.visualObjectId, nil,
+      id .. " crossing cluster is not advertised as suppressible")
+  end
+  analyses[id] = S
+  return map
+end
+
+local function checkOmittedTouchingMap(map, cells, label)
+  local terrain = assert(ChunkMesher.get(map, false))
+  local pairedTerrain, _, visuals, shadows = ChunkMesher.pair(map, false)
+  equal(pairedTerrain, terrain, label .. " original stays in base terrain")
+  equal(#(visuals or {}), 0, label .. " has no color sidecar")
+  equal(#(shadows or {}), 0, label .. " has no shadow sidecar")
+
+  local omittedIds = {}
+  for _, cell in ipairs(cells) do
+    omittedIds[#omittedIds + 1] = assert(VisualObjects.id(
+      "BATTLE_ART_VOXEL_FORK", "signpost", map.id, cell[1], cell[2]))
+  end
+  local omittedCount, claimResult, claimError
+  local omittedHost = VoxelCompanion.new({ mod = cleanMod() })
+  local handle
+  handle = assert(omittedHost.provider.register({
+    api = 1,
+    id = "integration.omitted." .. label,
+    requires = { "visual_object_overrides", "world_snapshot" },
+    worldChanged = function(snapshot)
+      omittedCount = #snapshot.visualObjects
+      claimResult, claimError = handle:claim_visual_objects(omittedIds)
+    end,
+    render = { opaque_after_terrain = function() end },
+  }))
+  namespace.companion = omittedHost
+  check(omittedHost:start(), label .. " host starts")
+  check(omittedHost:update(0.016, {
+    map = map, player = player, entities = { player }, neighbors = {},
+  }), label .. " snapshot dispatches")
+  equal(omittedCount, 0, label .. " descriptors are omitted")
+  equal(claimResult, nil, label .. " omitted IDs cannot be claimed")
+  contains(claimError, "unknown visual object id",
+    label .. " omitted claim fails closed")
+  for _, id in ipairs(omittedIds) do
+    check(not omittedHost:suppressesVisualObject(id),
+      label .. " omitted ID gains no owner")
+  end
+  local afterTerrain, _, afterVisuals = ChunkMesher.pair(map, false)
+  equal(afterTerrain, terrain, label .. " failed claim keeps original terrain")
+  equal(#(afterVisuals or {}), 0,
+    label .. " failed claim does not invent a replacement sidecar")
+  check(omittedHost:dispose(label .. "-dispose"), label .. " host disposes")
+end
+
+checkOmittedTouchingMap(touchingMap("TOUCH_HORIZONTAL", true),
+  { { 0, 0 }, { 1, 0 } }, "horizontal-touch")
+checkOmittedTouchingMap(touchingMap("TOUCH_VERTICAL", false),
+  { { 0, 0 }, { 0, 1 } }, "vertical-touch")
+
+do
+  local originalAnalysis = Structures.forMap
+  Structures.forMap = function(map)
+    if map == current then error("synthetic annotation build failure", 0) end
+    return originalAnalysis(map)
+  end
+  local omittedCount, claimResult, claimError
+  local failedHost = VoxelCompanion.new({ mod = cleanMod() })
+  local handle
+  handle = assert(failedHost.provider.register({
+    api = 1,
+    id = "integration.annotation-failure",
+    requires = { "visual_object_overrides", "world_snapshot" },
+    worldChanged = function(snapshot)
+      omittedCount = #snapshot.visualObjects
+      claimResult, claimError = handle:claim_visual_objects({ currentId })
+    end,
+    render = { opaque_after_terrain = function() end },
+  }))
+  namespace.companion = failedHost
+  check(failedHost:start(), "annotation-failure host starts")
+  check(failedHost:update(0.016, {
+    map = current, player = player, entities = { player }, neighbors = {},
+  }), "annotation-failure snapshot dispatches")
+  equal(omittedCount, 0, "annotation failure omits the public descriptor")
+  equal(claimResult, nil, "annotation failure rejects the omitted ID")
+  contains(claimError, "unknown visual object id",
+    "annotation failure rejects ownership fail closed")
+  check(not failedHost:suppressesVisualObject(currentId),
+    "annotation failure creates no owner")
+  local terrain, _, visible, shadows = ChunkMesher.pair(current, false)
+  equal(terrain, beforeTerrain, "annotation failure keeps cached terrain")
+  equal(#(visible or {}), 1,
+    "annotation failure keeps the isolated original color visible")
+  equal(#(shadows or {}), 1,
+    "annotation failure keeps the isolated original shadow visible")
+  check(failedHost:dispose("annotation-failure-dispose"),
+    "annotation-failure host disposes")
+  Structures.forMap = originalAnalysis
+end
+
 print(("%d checks passed (visual-object cache transition integration)"):format(checks))

--- a/tests/voxel_visual_object_filter_test.lua
+++ b/tests/voxel_visual_object_filter_test.lua
@@ -1,0 +1,58 @@
+-- ROM-free checks for the terrain visual-object filter and cache boundary.
+local checks = 0
+local function check(value, message)
+  checks = checks + 1
+  if not value then error("FAIL: " .. message, 0) end
+end
+
+local invalidations = 0
+package.loaded["src.render.Assets"] = {
+  register = function() end,
+}
+
+local structures = {
+  invalidate = function() invalidations = invalidations + 1 end,
+}
+local namespace = {
+  companion = nil,
+  require = function(name)
+    local modules = {
+      Structures = structures,
+      TileShape = {},
+      Voxel3D = { pushQuad = function() end },
+      BuildBudget = { tick = function() end },
+      VoxelMeshDisk = {
+        available = function() return false end,
+        legacy = function() return false end,
+        purge = function() return true end,
+      },
+    }
+    return assert(modules[name], "unexpected module " .. tostring(name))
+  end,
+}
+
+local ChunkMesher = assert(loadfile("lib/ChunkMesher.lua"))(namespace)
+local known = "BATTLE_ART_VOXEL_FORK:signpost:PALLET_TOWN:7:9"
+
+check(ChunkMesher.visualObjectVisible(known),
+  "an absent Companion owner preserves original geometry")
+namespace.companion = {
+  suppressesVisualObject = function(_, id) return id == known end,
+  hasVisualObjectOverrides = function(_, mapId) return mapId == "PALLET_TOWN" end,
+}
+check(not ChunkMesher.visualObjectVisible(known),
+  "a valid active owner suppresses only its annotated object quads")
+check(ChunkMesher.visualObjectVisible("BATTLE_ART_VOXEL_FORK:signpost:ROUTE_1:9:27"),
+  "an unclaimed object keeps its original geometry")
+namespace.companion.suppressesVisualObject = function() error("synthetic owner fault", 0) end
+check(ChunkMesher.visualObjectVisible(known),
+  "a suppression lookup fault fails open")
+
+check(ChunkMesher.refreshVisualObjects("PALLET_TOWN"),
+  "a named visual cache refresh is accepted")
+check(invalidations == 0,
+  "visual ownership does not invalidate structure analysis or unrelated auxiliary caches")
+check(ChunkMesher.refreshVisualObjects(nil) == false,
+  "a malformed visual cache target fails closed")
+
+print(("%d checks passed (visual-object terrain filter)"):format(checks))

--- a/tests/voxel_visual_object_filter_test.lua
+++ b/tests/voxel_visual_object_filter_test.lua
@@ -1,58 +1,289 @@
--- ROM-free checks for the terrain visual-object filter and cache boundary.
+-- ROM-free integration checks for annotated sign ownership and cached terrain.
 local checks = 0
 local function check(value, message)
   checks = checks + 1
   if not value then error("FAIL: " .. message, 0) end
 end
+local function equal(actual, expected, message)
+  checks = checks + 1
+  if actual ~= expected then
+    error(("FAIL: %s (expected %s, got %s)")
+      :format(message, tostring(expected), tostring(actual)), 0)
+  end
+end
+local function contains(text, fragment, message)
+  check(type(text) == "string" and text:find(fragment, 1, true) ~= nil, message)
+end
 
-local invalidations = 0
-package.loaded["src.render.Assets"] = {
-  register = function() end,
+local API = assert(loadfile("lib/VoxelCompanionAPI.lua"))()
+local VisualObjects = assert(loadfile("lib/VoxelVisualObjects.lua"))()
+local Budget = {
+  tick = function() end, check = function() end,
+  begin = function() end, finish = function() end,
 }
+local Buildings = {
+  build = function() end, invalidate = function() end,
+}
+local TileShape = { propBg = function() return nil end }
+local Assets = { register = function() end }
+package.loaded["src.render.Assets"] = Assets
+package.loaded["src.world.Map"] = { isOutdoor = function() return true end }
+package.loaded["src.core.Game"] = { save = { version = "red" } }
 
-local structures = {
-  invalidate = function() invalidations = invalidations + 1 end,
-}
-local namespace = {
-  companion = nil,
+local structureNamespace = {
   require = function(name)
-    local modules = {
-      Structures = structures,
-      TileShape = {},
-      Voxel3D = { pushQuad = function() end },
-      BuildBudget = { tick = function() end },
-      VoxelMeshDisk = {
-        available = function() return false end,
-        legacy = function() return false end,
-        purge = function() return true end,
-      },
-    }
-    return assert(modules[name], "unexpected module " .. tostring(name))
+    return assert(({
+      Buildings = Buildings,
+      TileShape = TileShape,
+      BuildBudget = Budget,
+      VoxelVisualObjects = VisualObjects,
+    })[name], "unexpected Structures module " .. tostring(name))
   end,
 }
+local Structures = assert(loadfile("lib/Structures.lua"))(structureNamespace)
+local keyOf = function(x, z) return (z + 64) * 4096 + (x + 64) end
 
-local ChunkMesher = assert(loadfile("lib/ChunkMesher.lua"))(namespace)
-local known = "BATTLE_ART_VOXEL_FORK:signpost:PALLET_TOWN:7:9"
+local analyses = {}
+local function annotatedMap(id)
+  local map = {
+    id = id,
+    widthCells = 2,
+    heightCells = 2,
+    def = { width = 1, height = 1, tileset = "OVERWORLD" },
+    tileset = {
+      id = "OVERWORLD", image = "synthetic-atlas", tilesPerRow = 16,
+      imageWidth = 128, imageHeight = 48,
+    },
+  }
+  function map:tileAt(x, z) return (x == 2 and z == 0) and 1 or 0 end
+  function map:cellTile(x, z) return (x == 0 and z == 0) and 4 or 0 end
+  function map:isWalkableCell(x, z) return not (x == 0 and z == 0) end
+  function map:isWaterCell() return false end
+  function map:isGrassCell() return false end
+  function map:warpAtCell() return nil end
+  function map:isWarpTileCell() return false end
 
-check(ChunkMesher.visualObjectVisible(known),
-  "an absent Companion owner preserves original geometry")
-namespace.companion = {
-  suppressesVisualObject = function(_, id) return id == known end,
-  hasVisualObjectOverrides = function(_, mapId) return mapId == "PALLET_TOWN" end,
+  local sign = { class = "signpost", authored = true, art = "upright", h = 16 }
+  local ground = { class = "ground", flat = true, art = "flat", h = 0 }
+  local S = {
+    shapeAt = {}, tileAt = {}, outdoor = true,
+    runs = {}, skip = {}, ground = {}, doorFold = {}, objectQuads = {},
+    grassQuads = {}, flowerQuads = {}, roundStamps = {}, figures = {},
+  }
+  local tiles = { { 0, 0 }, { 1, 0 }, { 0, 1 }, { 1, 1 } }
+  for _, cell in ipairs(tiles) do
+    S.shapeAt[keyOf(cell[1], cell[2])] = sign
+    S.tileAt[keyOf(cell[1], cell[2])] = 0
+  end
+  S.shapeAt[keyOf(2, 0)], S.tileAt[keyOf(2, 0)] = ground, 1
+  local region = { minX = 0, maxX = 1, minY = 0, maxY = 1, tiles = tiles }
+  local data = { getPixel = function() return 0, 0, 0, 1 end }
+  Structures.extractObjects(S, map, region, data, 16, true)
+  check(#S.objectQuads > 0, "Structures emits a real pinned sign mesh")
+  local expected = assert(VisualObjects.id("BATTLE_ART_VOXEL_FORK",
+    "signpost", id, 0, 0))
+  for _, quad in ipairs(S.objectQuads) do
+    equal(quad.visualObjectId, expected,
+      "Structures annotates every sign quad with one stable object ID")
+  end
+  analyses[id] = S
+  return map, expected
+end
+
+local current, currentId = annotatedMap("PALLET_TOWN")
+local neighbor, neighborId = annotatedMap("ROUTE_1")
+Structures.forMap = function(map) return analyses[map.id] end
+
+local meshSequence = 0
+local Voxel3D = {
+  FORMAT = {}, FACE_CORNERS = {}, FACE_SHADE = {},
+  pushQuad = function(indices, quad)
+    local first = quad * 4 + 1
+    for _, index in ipairs({ first, first + 1, first + 2,
+                              first, first + 2, first + 3 }) do
+      indices[#indices + 1] = index
+    end
+  end,
+  newMesh = function(vertices, indices)
+    meshSequence = meshSequence + 1
+    return {
+      id = meshSequence, vertices = vertices, indices = indices,
+      release = function(self) self.released = true end,
+    }
+  end,
 }
-check(not ChunkMesher.visualObjectVisible(known),
-  "a valid active owner suppresses only its annotated object quads")
-check(ChunkMesher.visualObjectVisible("BATTLE_ART_VOXEL_FORK:signpost:ROUTE_1:9:27"),
-  "an unclaimed object keeps its original geometry")
-namespace.companion.suppressesVisualObject = function() error("synthetic owner fault", 0) end
-check(ChunkMesher.visualObjectVisible(known),
-  "a suppression lookup fault fails open")
+local MeshDisk = {
+  available = function() return false end,
+  legacy = function() return false end,
+  loadTerrain = function() return nil end,
+  saveTerrain = function() return false, "disabled in ROM-free test" end,
+  loadAux = function() return nil end,
+  saveAux = function() return false, "disabled in ROM-free test" end,
+  purge = function() return true end,
+}
+local namespace = { companion = nil }
+function namespace.require(name)
+  return assert(({
+    Structures = Structures, TileShape = TileShape, Voxel3D = Voxel3D,
+    BuildBudget = Budget, VoxelMeshDisk = MeshDisk,
+  })[name], "unexpected ChunkMesher module " .. tostring(name))
+end
+local ChunkMesher = assert(loadfile("lib/ChunkMesher.lua"))(namespace)
 
-check(ChunkMesher.refreshVisualObjects("PALLET_TOWN"),
-  "a named visual cache refresh is accepted")
-check(invalidations == 0,
-  "visual ownership does not invalidate structure analysis or unrelated auxiliary caches")
-check(ChunkMesher.refreshVisualObjects(nil) == false,
-  "a malformed visual cache target fails closed")
+local currentFull = assert(ChunkMesher.get(current, false))
+local currentBody = assert(ChunkMesher.get(current, true))
+local neighborFull = assert(ChunkMesher.get(neighbor, false))
+local neighborBody = assert(ChunkMesher.get(neighbor, true))
+check(currentFull ~= currentBody and neighborFull ~= neighborBody,
+  "full and body terrain variants are cached independently")
+local beforeTerrain, _, beforeVisuals, beforeShadows = ChunkMesher.pair(current, false)
+equal(beforeTerrain, currentFull, "the cached full terrain identity is stable")
+equal(#(beforeVisuals or {}), 1, "the canonical color variant includes the sign")
+equal(#(beforeShadows or {}), 1, "the canonical shadow variant includes the sign")
 
-print(("%d checks passed (visual-object terrain filter)"):format(checks))
+local cameraMode = "first_person"
+local fakeVoxelState = {
+  isFirstPerson = function() return cameraMode == "first_person" end,
+  isThirdPerson = function() return cameraMode == "third_person" end,
+}
+local fakeShapes = {
+  [0] = { class = "ground", h = 0 },
+  [4] = { class = "signpost", h = 16 },
+}
+TileShape.forMap = function() return fakeShapes end
+local fakeDayNight = {
+  tod = function() return "DAY" end,
+  time = function() return 12 end,
+  isCanopy = function() return false end,
+}
+local fakeMat4 = {
+  identity = function() return {} end,
+  mul = function(a, b) return { a, b } end,
+  translate = function() return {} end,
+  scale = function() return {} end,
+  rotateX = function() return {} end,
+  rotateY = function() return {} end,
+  rotateZ = function() return {} end,
+}
+local cleanMod = function()
+  return {
+    read = function() return "-- clean\n" end,
+    log = { error = function() end, warn = function() end },
+  }
+end
+local companionNamespace = { mod = cleanMod() }
+function companionNamespace.require(name)
+  return assert(({
+    VoxelCompanionAPI = API, VoxelVisualObjects = VisualObjects,
+    Mat4 = fakeMat4, TileShape = TileShape, ChunkMesher = ChunkMesher,
+    VoxelState = fakeVoxelState, Voxel3D = Voxel3D, DayNight = fakeDayNight,
+  })[name], "unexpected Companion module " .. tostring(name))
+end
+local VoxelCompanion = assert(loadfile("lib/VoxelCompanion.lua"))(companionNamespace)
+love = {
+  system = { getOS = function() return "Windows" end },
+  graphics = { push = function() end, pop = function() end },
+}
+
+local host = VoxelCompanion.new({ mod = companionNamespace.mod })
+namespace.companion = host
+local owner, firstSignature, thirdSignature, replacementFrames
+local callbackClaimed, callbackClaimError
+replacementFrames = 0
+owner = assert(host.provider.register({
+  api = 1,
+  id = "integration.owner",
+  requires = { "visual_object_overrides", "world_snapshot", "render_phases" },
+  worldChanged = function(snapshot)
+    local rows, ids = {}, {}
+    for _, descriptor in ipairs(snapshot.visualObjects) do
+      ids[#ids + 1] = descriptor.id
+      rows[#rows + 1] = table.concat({ descriptor.id, descriptor.map.id,
+        descriptor.map.role, descriptor.map.offsetX, descriptor.map.offsetZ,
+        descriptor.transform.localPosition.x,
+        descriptor.transform.worldPosition.x }, "|")
+    end
+    local signature = table.concat(rows, "\n")
+    if snapshot.mode == "first_person" then firstSignature = signature end
+    if snapshot.mode == "third_person" then thirdSignature = signature end
+    callbackClaimed, callbackClaimError = owner:claim_visual_objects(ids)
+  end,
+  render = {
+    opaque_after_terrain = function() replacementFrames = replacementFrames + 1 end,
+  },
+}))
+local player = { id = "player", px = 0, py = 0, cellX = 0, cellY = 0 }
+local state = {
+  map = current, player = player, entities = { player },
+  neighbors = { { map = neighbor, ox = 64, oy = -32 } },
+}
+check(host:start(), "the integration host starts")
+check(host:update(0.016, state), "first-person descriptors dispatch")
+check(callbackClaimed, callbackClaimError
+  or table.concat(host:status().diagnostics or {}, "; ")
+  or "the integration callback claims objects")
+check(host:suppressesVisualObject(currentId),
+  "the accepted current-map claim becomes active")
+check(host:suppressesVisualObject(neighborId),
+  "the accepted neighbor-map claim becomes active")
+local claimedTerrain, _, claimedVisuals, claimedShadows = ChunkMesher.pair(current, false)
+equal(claimedTerrain, beforeTerrain,
+  "claim activation keeps the selected cached terrain identity")
+equal(#(claimedVisuals or {}), 0,
+  "claim activation removes the original color sidecar immediately")
+equal(#(claimedShadows or {}), 1,
+  "claim activation preserves the original shadow caster")
+check(host:render("opaque_after_terrain", state),
+  "the replacement renders through the bounded opaque phase")
+equal(replacementFrames, 1,
+  "the replacement starts only with the override color variant selected")
+
+local contender = assert(host.provider.register({
+  api = 1, id = "integration.rejected",
+  render = { opaque_after_terrain = function() end },
+}))
+local conflict, conflictError = contender:claim_visual_objects({ currentId })
+equal(conflict, nil, "a conflicting owner is rejected")
+contains(conflictError, "ownership conflict", "conflict rejection is diagnostic")
+equal(#(select(3, ChunkMesher.pair(current, false)) or {}), 0,
+  "conflict rejection does not change the selected override variant")
+local duplicate, duplicateError = owner:claim_visual_objects({ currentId, currentId })
+equal(duplicate, nil, "a duplicate claim call is rejected")
+contains(duplicateError, "duplicate id", "duplicate rejection is diagnostic")
+equal(#(select(3, ChunkMesher.pair(neighbor, true)) or {}), 0,
+  "duplicate rejection preserves every accepted map claim")
+
+cameraMode = "third_person"
+host:worldChanged("third-person-identity")
+check(host:update(0.016, state), "third-person descriptors dispatch")
+equal(thirdSignature, firstSignature,
+  "first- and third-person read the same map, neighbor, ID, and transform identity")
+
+check(owner:invalidate({}, "integration-invalidate"), "owner invalidation succeeds")
+local invalidatedTerrain, _, invalidatedVisuals, invalidatedShadows =
+  ChunkMesher.pair(current, false)
+equal(invalidatedTerrain, beforeTerrain,
+  "invalidation restores without a terrain rebuild or future pump")
+equal(#(invalidatedVisuals or {}), 1,
+  "invalidation restores the original color sidecar immediately")
+equal(#(invalidatedShadows or {}), 1,
+  "invalidation keeps the original shadow behavior")
+check(not host:suppressesVisualObject(currentId),
+  "the rejected conflict does not become a future owner")
+check(contender:dispose({}, "integration-rejected-dispose"),
+  "the rejected contender disposes cleanly")
+
+check(owner:claim_visual_objects({ currentId, neighborId }),
+  "the accepted owner can reclaim both cached map identities")
+check(owner:dispose({}, "integration-owner-dispose"), "owner disposal succeeds")
+local disposedTerrain, _, disposedVisuals, disposedShadows =
+  ChunkMesher.pair(current, false)
+equal(disposedTerrain, beforeTerrain,
+  "disposal restores without a terrain rebuild or future pump")
+equal(#(disposedVisuals or {}), 1,
+  "disposal restores the original color sidecar immediately")
+equal(#(disposedShadows or {}), 1,
+  "disposal keeps the original shadow behavior")
+check(host:dispose("integration-host-dispose"), "the integration host disposes")
+
+print(("%d checks passed (visual-object cache transition integration)"):format(checks))


### PR DESCRIPTION
## Summary

Adds a small, companion-owned visual-object override hook for generated signposts.

- Stable sign IDs and descriptor transforms for uniquely suppressible generated signs.
- One owner claim surface; conflicting, unknown, or unsupported IDs fail closed.
- Replacement rendering uses the existing bounded draw facade at the original transform.
- Original collision, interaction, map/game data, and staged-battle sign rendering stay unchanged.
- Release, invalidate, dispose, and unload restore the original overworld visual deterministically.
- Raw mesh access remains private.

## Validation

- Exact commit: `fbb5eecba66540dcdbf2595d6129555b52e51ab4`
- Independent rereview: PASS, P0/P1/P2 `0/0/0`; one non-blocking API-form P3.
- Focused ROM-free lifecycle, cache, touching-sign, and BattleScene checks passed.
- Repository verification: 16 tests passed; one existing baseline mismatch and five unavailable suites are documented.
- Privacy, secret, protected-content, rights, manifest, package-allowlist, and archive checks passed.

## Scope and limits

This PR adds no assets, runtime capture, ROM/save/profile data, or PokePath code. It does not claim live GPU/runtime evidence. BattleScene deliberately renders original signs and does not permit companion replacement rendering there.