### PR TITLE
fix: stop water shading itself dark along a map connection

### DIFF
--- a/.modkitignore
+++ b/.modkitignore
@@ -7,6 +7,7 @@
 tests/arena_pick.lua
 tests/battle_shots.lua
 tests/battle_art_voxel_fork_test.lua
+tests/voxel_seam_ao_test.lua
 tests/voxel_anim_probe.lua
 tests/voxel_door_probe.lua
 tests/voxel_mem_probe.lua

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **No more dark band on water at a map connection.** The corner AO probe
+  counted the border ring as a raised neighbour on every map edge, including
+  the edges a connection covers, where the ring is never drawn. Water sits
+  below everything so it took the full step, and both maps shaded their own
+  side, which is what made the band symmetric. Cells past a connected edge
+  are now treated as flush. Bumps the static mesh cache revision, since the
+  shading is baked into vertex colours.
+
 - **Exact KFP world semantics.** The companion snapshot now separates verified
   OVERWORLD tree supports from boulder-tree candidates, rejects walkable and
   unknown cylinder ghosts, and marks mountain seeds and their bounded support

--- a/lib/ChunkMesher.lua
+++ b/lib/ChunkMesher.lua
@@ -416,6 +416,8 @@ local function runGeometry(map, bodyOnly, masks, sink, waterSink, visualSinks)
   local waterPush = waterSink and waterSink.push or nil
   local tileset = map.tileset
   local S = Structures.forMap(map)
+  local def = map.def
+  local tw, th = def.width * 4, def.height * 4         -- map size in tiles
   local perRow = tileset.tilesPerRow or 16
   local atlasW = tileset.imageWidth or (perRow * 8)
   local atlasH = tileset.imageHeight or 48
@@ -427,6 +429,51 @@ local function runGeometry(map, bodyOnly, masks, sink, waterSink, visualSinks)
     if run then return run.h end
     local s = S.shapeAt[k]
     return s and s.h or 0
+  end
+
+  -- Does the cell one step past the body belong to a CONNECTED NEIGHBOUR
+  -- rather than to the border ring?
+  --
+  -- Structures fills the whole ring with the map's border block, and
+  -- heightAt answers out of that analysis wherever it is asked -- so a
+  -- cell just outside the body always reports a neighbour standing there,
+  -- and outdoors that neighbour is the solid tree wall. Where the map ENDS
+  -- that is the truth. Where it CONNECTS it is not: the ring is not drawn
+  -- there at all (`masks` suppress it under the neighbour's body, and a
+  -- body-only build emits no ring in the first place) and the neighbour's
+  -- own ground runs flush with the seam.
+  --
+  -- Only the AO probe asks. The faces themselves still read heightAt
+  -- straight, because a face is a hole if it is wrong and a crease is only
+  -- a shade.
+  --
+  -- A cell outside the body on BOTH axes is not flush whatever connects: a
+  -- neighbour to the east is not also north of itself, and the ring really
+  -- does stand in the corner past the end of the seam.
+  local conn = def.connections
+  local cN = (conn and conn.north) ~= nil
+  local cS = (conn and conn.south) ~= nil
+  local cE = (conn and conn.east) ~= nil
+  local cW = (conn and conn.west) ~= nil
+  local anyConn = cN or cS or cE or cW
+  local function flush(tx, ty)
+    if not anyConn then return false end
+    if ty >= 0 and ty < th then
+      if tx >= tw then return cE end
+      if tx < 0 then return cW end
+    end
+    if tx >= 0 and tx < tw then
+      if ty >= th then return cS end
+      if ty < 0 then return cN end
+    end
+    return false
+  end
+
+  -- The AO probe's own neighbour test: raised enough to crowd this corner,
+  -- and actually THERE to do it.
+  local function crowds(tx, ty, h)
+    if flush(tx, ty) then return false end
+    return heightAt(tx, ty) > h
   end
 
   -- one atlas-rect UV, optionally cropped to art rows [vTop, vBot] of 8
@@ -478,14 +525,14 @@ local function runGeometry(map, bodyOnly, masks, sink, waterSink, visualSinks)
   -- A top face's four corners, each occluded by the three cells that touch
   -- it: two edge neighbours and the diagonal between them.
   local function aoShades(tx, ty, h, shade)
-    local n = heightAt(tx, ty - 1) > h
-    local s = heightAt(tx, ty + 1) > h
-    local e = heightAt(tx + 1, ty) > h
-    local w = heightAt(tx - 1, ty) > h
-    local nw = heightAt(tx - 1, ty - 1) > h
-    local ne = heightAt(tx + 1, ty - 1) > h
-    local sw = heightAt(tx - 1, ty + 1) > h
-    local se = heightAt(tx + 1, ty + 1) > h
+    local n = crowds(tx, ty - 1, h)
+    local s = crowds(tx, ty + 1, h)
+    local e = crowds(tx + 1, ty, h)
+    local w = crowds(tx - 1, ty, h)
+    local nw = crowds(tx - 1, ty - 1, h)
+    local ne = crowds(tx + 1, ty - 1, h)
+    local sw = crowds(tx - 1, ty + 1, h)
+    local se = crowds(tx + 1, ty + 1, h)
     if not (n or s or e or w or nw or ne or sw or se) then return shade end
     local function corner(a, b, d)
       local k = 0
@@ -580,8 +627,6 @@ local function runGeometry(map, bodyOnly, masks, sink, waterSink, visualSinks)
     push(c, { { u0, v1 }, { u1, v1 }, { u1, v0 }, { u0, v0 } }, shade)
   end
 
-  local def = map.def
-  local tw, th = def.width * 4, def.height * 4         -- map size in tiles
   local r = bodyOnly and 0 or RING * 4
 
   -- true when the (ring) position lies under a connected neighbour's body

--- a/lib/VoxelMeshDisk.lua
+++ b/lib/VoxelMeshDisk.lua
@@ -56,10 +56,13 @@ end
 -- playthrough identity.
 local STATIC_PLAYTHROUGH = "bavc_static_mesh_v2"
 
--- Revision 6 restores visual-object quads to ordinary cached terrain when no
--- extension can replace them. Revision 5 stripped signposts unconditionally,
--- then bypassed its own cache on Continue to reconstruct their sidecars.
-Disk.CACHE_REVISION = 6
+-- Revision 7 stops the corner AO probe shading a connected map edge against
+-- border ring the connection hides, which changes the baked vertex shade of
+-- every tile along a seam. Revision 6 restores visual-object quads to
+-- ordinary cached terrain when no extension can replace them. Revision 5
+-- stripped signposts unconditionally, then bypassed its own cache on Continue
+-- to reconstruct their sidecars.
+Disk.CACHE_REVISION = 7
 -- Patch releases which do not change emitted vertices must keep the existing
 -- world cache usable. This token matches the first static-mesh-cache-v2 build;
 -- CACHE_REVISION, not the public mod version, owns geometry compatibility.

--- a/tests/voxel_seam_ao_test.lua
+++ b/tests/voxel_seam_ao_test.lua
@@ -1,0 +1,108 @@
+-- A map CONNECTION is not a wall: the seam must not shade itself.
+--
+-- The corner AO probe in ChunkMesher reads the cells crowding a top face
+-- out of Structures' analysis, and that analysis covers the BORDER RING as
+-- well as the body -- ring cells carrying the map's border block, which
+-- outdoors is the solid tree wall. So one tile past the body edge always
+-- reads as a raised neighbour: every edge tile counts two crowders on its
+-- outer corners and comes out at 1 - 2*AO_STEP.
+--
+-- Where the map ENDS that is right. Where it CONNECTS it is not. The ring
+-- there is not drawn at all -- runGeometry's `masks` suppress it under the
+-- neighbour's body, and a body-only build (which is how every neighbour is
+-- meshed) never emits a ring in the first place -- and the neighbour's own
+-- ground runs flush with the seam. Shading against a wall nobody can see
+-- lays a dark line down every connection, and both sides do it, each
+-- against its own ring, so it comes out symmetric: a tile of linear
+-- falloff either side of the seam bottoming out at 1 - 2*AO_STEP, which is
+-- 0.568.
+--
+-- On land the tile art mostly swallows it. On the one surface in the game
+-- with no art to hide behind -- open water spanning a connection -- it
+-- reads as a shadow floating on the sea.
+--
+--   luajit tests/voxel_seam_ao_test.lua      (from the game root)
+
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.modkit")
+
+local Data = T.fixtures.load()
+local MOD_PATH = os.getenv("DS_MOD_PATH") or "mods/DramaticShapeVoxelMod"
+local run = T.sdk.loadMod(MOD_PATH, { data = Data })
+T.eq(#run.errors, 0,
+  "BATTLE_ART_VOXEL_FORK loads clean: " .. table.concat(run.errors, "; "))
+
+local lib = run.loader.exports.BATTLE_ART_VOXEL_FORK.lib
+local ChunkMesher = lib.require("ChunkMesher")
+local Structures = lib.require("Structures")
+local Shapes = lib.require("TileShape")
+
+-- Open sea, two blocks square, connected EASTWARD and walled on the other
+-- three sides -- so one fixture states both halves of the invariant. No
+-- atlas, no GPU and no fixture map: geometry() is pure arithmetic.
+local SEA_TILE = 20
+local seaMap = {
+  id = "SEAM_AO_TEST",
+  tileset = { id = "SEAM_AO_SET", image = "gfx/tilesets/seam_ao.png",
+              tilesPerRow = 16, imageWidth = 128, imageHeight = 48,
+              blocks = {}, grassTile = -1 },
+  def = { width = 2, height = 2, tileset = "SEAM_AO_SET",
+          connections = { east = { map = "SEAM_AO_TEST_EAST", offset = 0 } } },
+  walkable = {},
+  waterTiles = { [SEA_TILE] = true },
+  doorTiles = {},
+  tileAt = function() return SEA_TILE end,
+  cellTile = function() return SEA_TILE end,
+  isWaterCell = function() return true end,
+  isWalkableCell = function() return false end,
+  inBounds = function(_, cx, cy)
+    return cx >= 0 and cy >= 0 and cx < 4 and cy < 4
+  end,
+}
+
+Structures.invalidate(seaMap.id)
+local _, _, _, seaVerts = ChunkMesher.geometry(seaMap, true, nil, true)
+
+-- The body is 8 tiles square, so its west face stands at x=0 and its east
+-- face at x=64. The corners at z=0 and z=64 are the map's own north and
+-- south edges, ringed for real, and are left out: what is under test is
+-- the seam, not the corners it runs between.
+local EAST, WEST, SPAN = 64, 0, 64
+local eastLit, eastDark, westDark, worst = 0, 0, 0, 1
+for _, v in ipairs(seaVerts) do
+  local x, z, shade = v[1], v[3], v[6]
+  if z > 0 and z < SPAN then
+    if x == EAST then
+      if shade < 1 then
+        eastDark = eastDark + 1
+        worst = math.min(worst, shade)
+      else
+        eastLit = eastLit + 1
+      end
+    elseif x == WEST and shade < 1 then
+      westDark = westDark + 1
+      worst = math.min(worst, shade)
+    end
+  end
+end
+
+T.check(eastLit > 0, "the connected edge carries water corners at all")
+T.eq(eastDark, 0,
+  "no water corner on a CONNECTED edge is occlusion-shaded: the border "
+  .. "ring it would shade against is suppressed under the neighbour's "
+  .. "body, and the neighbour's own water runs flush to the seam")
+T.check(westDark > 0,
+  "while the WALLED edge still is -- the fix is the connection, not a "
+  .. "blanket amnesty for every cell that happens to sit on a map edge")
+T.check(worst > 0.56 and worst < 0.58,
+  "and the shade a real wall lays is the two-crowder step, 1 - 2*AO_STEP "
+  .. "= 0.568 -- the value measured off the seam band this fixes")
+
+Structures.invalidate(seaMap.id)
+ChunkMesher.invalidate(seaMap.id)
+Shapes.invalidate()
+
+if run.release then run.release() end
+
+T.finish("BATTLE_ART_VOXEL_FORK")


### PR DESCRIPTION
Standing on the Vermilion waterfront there is a dark vertical band across the water where the city meets Route 11, about two tiles wide. It reads as a shadow but nothing is casting it. Cerulean is worse, it has one on three sides.

It is the corner AO in the mesher, not the shadow map.

`Structures` fills the whole border ring with the map's border block, which outdoors is the solid tree wall, and `heightAt` answers out of that analysis wherever it is asked. So the cell one tile past the body edge always comes back raised. Water sits at height -2 and loses to anything, so every edge water tile counts two crowders on its outer corners and the rasteriser interpolates the step across the tile. The neighbouring map does the same to its own edge, which is why the band is symmetric with the seam down the middle.

Where a map actually ends, that is correct. Where it connects it is not. The ring is never drawn there (`masks` suppress it under the neighbour's body, and a body-only build, which is how every neighbour gets meshed, emits no ring at all) and the neighbour's water runs flush to the seam. So it is shading against a wall nobody can see.

The probe now treats a cell past a connected edge as flush, so it crowds nothing. The faces themselves still read `heightAt` straight, because a face that is wrong leaves a hole while a crease that is wrong is only a shade. A cell outside the body on both axes still counts, since the ring does stand in the corner past the end of a seam.

If you want to confirm the diagnosis without reading any of this: the darkest point of the band is a multiplier of exactly `1 - 2*AO_STEP`, which is 0.568. Sampling water either side of the seam off a phone screenshot gives 0.569.

### Cache revision

This also bumps `Disk.CACHE_REVISION` to 7. The shading is baked into vertex colours and the static mesh cache is keyed on the revision rather than the mod version, so without the bump nobody with a warm cache sees any difference. I found that out the slow way, testing on my phone and wondering why nothing had changed.

### Test

`tests/voxel_seam_ao_test.lua`. Open sea two blocks square, connected east and walled on the other three sides, so one fixture states both halves of it: nothing shaded on the connected edge, and the walled edge still measuring the two-crowder step. That second assertion is the one that matters, it is what stops a fix like this from just flattening all the contact shading. On master the test fails with 14 shaded corners on the connected edge.

It requires an engine module, so it is listed in `.modkitignore` along with the rest of the suite.

I could not run `tests/battle_art_voxel_fork_test.lua` to check for fallout. It does not compile here, "main function has more than 200 local variables" at line 2604. If that is just me, let me know and I will run it. The standalone ones all pass unchanged: `building_canopy_regression`, `world_fill_props`, `voxel_figure`, `oaks_lab_profile`, and `voxel_mesh_disk_storage` (6/6, run from the mod directory).

### How much of the game this touches

Scanning `data/generated/maps.lua` for connections whose body edge carries water tiles: 26 edges, 469 tiles. They come in matched pairs, both sides of each seam with the same count, which is the same "each map shades its own edge" behaviour showing up in the map data rather than in the pixels.

```
CERULEAN_CITY   north -> ROUTE_24         36/ 80 edge tiles are water
ROUTE_14        east  -> ROUTE_13         67/108
ROUTE_20        east  -> ROUTE_19         32/ 36
ROUTE_21        south -> CINNABAR_ISLAND  32/ 40
VERMILION_CITY  east  -> ROUTE_11         30/ 72
...
```

Happy to attach the full list and the script if it is useful.

<img width="1290" height="610" alt="seam-before-after" src="https://github.com/user-attachments/assets/d8f3e345-e23b-47ce-99c7-05a1771905ed" />


