### PR TITLE
fix: put the heal machine overlay on the machine in voxel mode

### DIFF
--- a/lib/HealOverlay.lua
+++ b/lib/HealOverlay.lua
@@ -77,6 +77,27 @@ local BALLS = { { 40, 27 }, { 48, 27, true },
 local MONITOR_INK = { x = 4, y = 3.5 }
 local BALL_INK = { x = 5, y = 5 }
 
+-- How far the whole ball group stands off the drawing's own reading, in
+-- world pixels, applied equally to all six.
+--
+-- The drawing puts them lower than the machine wants them here.  The
+-- cabinet's dark front panel is drawn rows 17..28, so its last row extrudes
+-- to height 3 and the cream lip at the machine's foot takes rows 29..30
+-- below it, while the ball art's ink reaches down to height 2 -- a pixel
+-- past the panel, hanging over the lip.
+--
+-- 1 to 3 is the whole usable range.  Below 1 the bottom row hangs over that
+-- lip; above 3 the top row's ink reaches into the console's screen, the
+-- inset drawn rows 6..8 whose bottom edge stands at height 22, covering the
+-- very surface the monitor tile is drawn on.  Inside the range it is a
+-- matter of looks, and 2 is the one that reads right on the machine.
+--
+-- It moves the WORLD point only, not the ink's place inside its tile --
+-- shifting BALL_INK instead would cancel itself out, because the blit
+-- offsets from the same number the height is measured with.
+HealOverlay.PANEL_ROWS = { 17, 28 }
+HealOverlay.BALL_LIFT = 2
+
 -- FlashSprite8Times XORs rOBP1 ($28): the sprites never disappear, the two
 -- middle shades swap in place.  ha.visible == false is that half of the beat.
 local FLASH_MAP = { [0] = 0, [1] = 2, [2] = 1, [3] = 3 }
@@ -119,7 +140,7 @@ end
 --   x, h, z   the point the piece's ink is centred on -- east, up, south
 --   flip   the right-hand ball column, drawn mirrored like its OAM
 --   ink    where that centre lies inside the 8x8 tile, for the blit
-local function piece(kind, px0, py0, oam, ink, plane)
+local function piece(kind, px0, py0, oam, ink, plane, lift)
   local flip = oam[3] == true
   local gx = oam[1] + GRID_DX
   local row = oam[2] + GRID_DY
@@ -128,7 +149,7 @@ local function piece(kind, px0, py0, oam, ink, plane)
     -- a mirrored tile draws leftward, so its ink centre reflects across the
     -- tile's own width rather than staying put
     x = px0 + gx + (flip and (8 - ink.x) or ink.x),
-    h = GROUND_ROW - (row + ink.y),
+    h = GROUND_ROW - (row + ink.y) + (lift or 0),
     z = py0 + plane,
     flip = flip,
     ink = ink,
@@ -140,7 +161,8 @@ function HealOverlay.points(ha)
   local out = { piece("monitor", px0, py0, MONITOR, MONITOR_INK, CONSOLE_Z) }
   local lit = math.max(0, math.min(tonumber(ha.lit) or 0, #BALLS))
   for i = 1, lit do
-    out[#out + 1] = piece("ball", px0, py0, BALLS[i], BALL_INK, FRONT_Z)
+    out[#out + 1] = piece("ball", px0, py0, BALLS[i], BALL_INK, FRONT_Z,
+                          HealOverlay.BALL_LIFT)
   end
   return out
 end

--- a/lib/HealOverlay.lua
+++ b/lib/HealOverlay.lua
@@ -26,6 +26,10 @@
 -- face inside the inset the drawing cuts for it, and the balls come out on
 -- the cabinet's front panel in the two columns the fascia notches.
 --
+-- Placing a piece is only half of it: it also has to be the right SIZE on
+-- the machine, and the flat renderer's pixels-per-world-pixel is not that
+-- number on every rung.  See `place` below, which measures it.
+--
 -- Kept OUT of the flat and tilt paths, which want the GB's own placement and
 -- already get it.  See tests/heal_overlay_test.lua, which holds every number
 -- below against the center_heal_machine template it was read off.
@@ -137,11 +141,46 @@ local function sheet(state)
   return img, state.healMachineQuads
 end
 
+-- Where a piece lands on the canvas, and how big one world pixel draws
+-- there.  nil when the point is behind the camera.
+--
+-- The size has to be MEASURED, not assumed.  `fallback` is the flat
+-- renderer's own pixels-per-world-pixel, and for the orbit camera that is
+-- very nearly the answer already: the orbit frames exactly `vh` world pixels
+-- top to bottom, so a world pixel is a scale pixel give or take the depth of
+-- the piece.  The 1ST and 3RD rungs are not the orbit.  They ride a PLACED
+-- camera (FirstPerson.frame) whose framing comes from its own 65 degree fov
+-- and how far the eye stands from what it looks at, with no relation to the
+-- view size at all -- standing at the counter a world pixel draws about 3.8
+-- times bigger than `fallback` says, and off the boom about 1.45 times.  Sized
+-- by `fallback` on those rungs the balls and the monitor come out at roughly
+-- a quarter and two thirds of the size of the machine they are painted on.
+--
+-- So step one world pixel along each of the face's own axes, east and up, and
+-- take the longer.  Head on the two agree.  Seen along the machine the east
+-- step collapses while the up step does not, and taking the longer keeps the
+-- piece a sensible size rather than shrinking it away to nothing.
+function HealOverlay.place(project, p, fallback)
+  local sx, sy = project(p.x, p.h, p.z)
+  if not sx then return nil end
+  local ex, ey = project(p.x + 1, p.h, p.z)
+  local ux, uy = project(p.x, p.h + 1, p.z)
+  local east = ex and math.sqrt((ex - sx) ^ 2 + (ey - sy) ^ 2) or 0
+  local up = ux and math.sqrt((ux - sx) ^ 2 + (uy - sy) ^ 2) or 0
+  local s = math.max(east, up)
+  -- a camera that has no answer at all (both neighbours behind it) still has
+  -- to draw something rather than a zero-sized nothing
+  if not (s > 1e-3) then s = fallback end
+  return sx, sy, s
+end
+
 -- Composite the overlay into the finished scene.  `project(wx, wy, wz)`
--- answers in canvas pixels and `scale` is canvas pixels per world pixel --
--- the same two the rest of the FX pass uses.  Deliberately unscaled by
--- depth, like every other billboard here: a piece keeps its authored size
--- and only its anchor moves.
+-- answers in canvas pixels and `scale` is canvas pixels per world pixel as
+-- the flat renderer counts them -- the same two the rest of the FX pass
+-- uses, with `scale` here only the fallback that `place` measures past.
+-- Still unscaled by DEPTH within a piece, like every other billboard here:
+-- a piece keeps its authored proportions and only its anchor and its size
+-- on the machine move.
 function HealOverlay.draw(ha, project, scale, ctx)
   local state = ctx and ctx.state
   if not (ha and state and project and scale) then return false end
@@ -162,14 +201,14 @@ function HealOverlay.draw(ha, project, scale, ctx)
 
   love.graphics.setColor(1, 1, 1, 1)
   for _, p in ipairs(HealOverlay.points(ha)) do
-    local sx, sy = project(p.x, p.h, p.z)
+    local sx, sy, s = HealOverlay.place(project, p, scale)
     if sx then
       local quad = quads[p.kind == "monitor" and 1 or 2]
-      local top = sy - p.ink.y * scale
+      local top = sy - p.ink.y * s
       if p.flip then
-        love.graphics.draw(img, quad, sx + p.ink.x * scale, top, 0, -scale, scale)
+        love.graphics.draw(img, quad, sx + p.ink.x * s, top, 0, -s, s)
       else
-        love.graphics.draw(img, quad, sx - p.ink.x * scale, top, 0, scale, scale)
+        love.graphics.draw(img, quad, sx - p.ink.x * s, top, 0, s, s)
       end
     end
   end

--- a/lib/HealOverlay.lua
+++ b/lib/HealOverlay.lua
@@ -81,6 +81,34 @@ local BALL_INK = { x = 5, y = 5 }
 -- middle shades swap in place.  ha.visible == false is that half of the beat.
 local FLASH_MAP = { [0] = 0, [1] = 2, [2] = 1, [3] = 3 }
 
+-- The overlay's OBJECT palette out of an ADVANCED (RED++) pack's `world`
+-- table, plus the group it came from, or nil when the pack has no OBJ data.
+--
+-- ADVANCED bakes the world true colour and bakes the OBP into every sprite
+-- SHEET as it loads (SpriteRenderer:resolveImage), which is why
+-- ctx.spriteColors answers nil there: nothing is left to colorize.  The heal
+-- sheet is the exception.  It is not a sprite def, nothing bakes it, and it
+-- reaches the canvas in its raw DMG greys -- grey Poke Balls on a fully
+-- coloured machine.
+--
+-- The GB gives the whole overlay one palette (OBP1) and so does this, taking
+-- the pack's own OBJ group 0, the one it assigns the player.  That is not an
+-- arbitrary pick: the ball art is drawn as outline, upper body, lower body
+-- over shades 3, 2 and 1, and group 0 answers those with black, (255,58,8)
+-- red and a pale body -- a Poke Ball, which is what the art is.
+--
+-- Pure, and separate from the pack lookup, so the choice is checkable
+-- without a GPU or a running map.
+function HealOverlay.objPalette(world)
+  local palettes = world and world.spritePalettes
+  local assign = world and world.spriteAssignment
+  local group = assign and assign[0]
+  if not (palettes and type(group) == "number" and palettes[group]) then
+    return nil
+  end
+  return palettes[group], group
+end
+
 -- The plot's north-west corner in world pixels, from the heal cell.
 function HealOverlay.plot(ha)
   return ha.px + PLOT_DX, ha.py + PLOT_DY
@@ -188,11 +216,24 @@ function HealOverlay.draw(ha, project, scale, ctx)
   if not img then return false end
 
   local PaletteFX = require("src.render.PaletteFX")
-  -- the flashed half of the beat recolours the sprites in place, and wins
-  -- over the world's own sprite palette exactly as it does on the flat path
-  local colors = (not ha.visible)
-    and PaletteFX.permute(PaletteFX.GRAYS, FLASH_MAP)
-    or (ctx.spriteColors and ctx.spriteColors() or nil)
+  -- ADVANCED hands out no sprite palette (see objPalette), the SGB modes
+  -- hand out the map's, and the mono ones hand out none and want none
+  local colors
+  if PaletteFX.usesGbcPack() then
+    local pack = PaletteFX.gbcPack()
+    local palette, group = HealOverlay.objPalette(pack and pack.world)
+    colors = palette and PaletteFX.darkObp(palette, group) or nil
+  else
+    colors = ctx.spriteColors and ctx.spriteColors() or nil
+  end
+  -- The flashed half of the beat swaps the two middle shades IN PLACE --
+  -- rOBP1 ^= $28 recolours the sprites, it does not repaint them grey. So
+  -- permute whatever palette is in force rather than always permuting GRAYS
+  -- the way the flat closure does, which is what would otherwise drop a
+  -- coloured overlay to grey twice a second on the ADVANCED pack.
+  if not ha.visible then
+    colors = PaletteFX.permute(colors or PaletteFX.GRAYS, FLASH_MAP)
+  end
   local shader = colors and PaletteFX.shader() or nil
   if shader then
     PaletteFX.sendColors(shader, colors)

--- a/lib/HealOverlay.lua
+++ b/lib/HealOverlay.lua
@@ -169,6 +169,64 @@ local function sheet(state)
   return img, state.healMachineQuads
 end
 
+-- ------- standing behind what stands in front
+
+-- The overlay is composited flat, after the geometry, with the depth test
+-- off -- so it paints over the counter the player is standing at, and in a
+-- low orbit or in first person the balls hang in front of a counter that is
+-- nearer the eye than they are.
+--
+-- The frame's own depth buffer already knows better.  beginOverlay binds the
+-- colour canvas alone, which leaves that texture readable, so the sprites can
+-- do the test the hardware would have done: sample the scene's depth under
+-- each fragment and drop the ones the scene is in front of.  Same comparison,
+-- same window-depth convention, as the water's self-occlusion test.
+--
+-- The palette remap rides along in the same shader because a fragment can
+-- only be discarded where it is coloured; the three thresholds are
+-- PaletteFX.shader()'s, which is the copy to keep this honest against.
+local OCCLUDE_SHADER = [[
+  extern vec3 c0; extern vec3 c1; extern vec3 c2; extern vec3 c3;
+  extern LOVE_HIGHP_OR_MEDIUMP Image depthTex;
+  extern float pieceZ;
+  vec4 effect(vec4 color, Image tex, vec2 tc, vec2 sc) {
+    if (pieceZ > Texel(depthTex, sc / love_ScreenSize.xy).r) discard;
+    vec4 p = Texel(tex, tc);
+    vec3 mapped = p.r > 0.83 ? c0 : (p.r > 0.5 ? c1 : (p.r > 0.17 ? c2 : c3));
+    return vec4(mapped, p.a);
+  }
+]]
+
+local occluder  -- false once the driver has refused to compile it
+
+local function occludeShader()
+  if occluder == nil then
+    local ok, sh = pcall(love.graphics.newShader, OCCLUDE_SHADER)
+    occluder = ok and sh or false
+  end
+  return occluder or nil
+end
+
+-- A piece is painted ON the face it belongs to, so its own depth TIES with
+-- that face's and the test above would throw the whole overlay away.  Nudge
+-- the point the depth is taken at toward the eye first -- the same move
+-- Voxel3D.draw's `pull` makes for a character card leaning over the wall in
+-- front of it.
+--
+-- Two world pixels is the whole margin needed: it clears a tie against the
+-- surface the piece is painted on, and anything that genuinely stands in the
+-- way is a whole tile row nearer, not two pixels.
+HealOverlay.PULL = 2
+
+function HealOverlay.depthPoint(p, eye)
+  if not eye then return p.x, p.h, p.z end
+  local dx, dy, dz = eye[1] - p.x, eye[2] - p.h, eye[3] - p.z
+  local len = math.sqrt(dx * dx + dy * dy + dz * dz)
+  if len < 1e-6 then return p.x, p.h, p.z end
+  local k = HealOverlay.PULL / len
+  return p.x + dx * k, p.h + dy * k, p.z + dz * k
+end
+
 -- Where a piece lands on the canvas, and how big one world pixel draws
 -- there.  nil when the point is behind the camera.
 --
@@ -234,9 +292,27 @@ function HealOverlay.draw(ha, project, scale, ctx)
   if not ha.visible then
     colors = PaletteFX.permute(colors or PaletteFX.GRAYS, FLASH_MAP)
   end
-  local shader = colors and PaletteFX.shader() or nil
+  -- The occluding shader colours as well as discards, so it replaces the
+  -- palette one outright wherever there is a depth texture to test against.
+  -- Where there is not -- a driver with no readable depth, the same case that
+  -- turns the water back into ordinary terrain -- the overlay falls back to
+  -- colour alone and draws in front, which is exactly what it did before.
+  local Voxel3D = V.require("Voxel3D")
+  local depthTex = Voxel3D.depthTexture and Voxel3D.depthTexture() or nil
+  local shader = depthTex and occludeShader() or nil
+  -- only the occluder has a pieceZ to be told about, and a driver that
+  -- refused to compile it must not be sent one
+  local eye = shader and Voxel3D.eye or nil
   if shader then
-    PaletteFX.sendColors(shader, colors)
+    pcall(shader.send, shader, "depthTex", depthTex)
+  else
+    shader = colors and PaletteFX.shader() or nil
+  end
+  -- GRAYS is the identity remap for a DMG sheet, so the occluding shader has
+  -- something to colour with in the modes that hand out no palette at all
+  -- rather than mapping every shade onto an unsent uniform.
+  if shader then
+    PaletteFX.sendColors(shader, colors or PaletteFX.GRAYS)
     love.graphics.setShader(shader)
   end
 
@@ -244,6 +320,10 @@ function HealOverlay.draw(ha, project, scale, ctx)
   for _, p in ipairs(HealOverlay.points(ha)) do
     local sx, sy, s = HealOverlay.place(project, p, scale)
     if sx then
+      if eye then
+        local _, _, _, pz = project(HealOverlay.depthPoint(p, eye))
+        if pz then pcall(shader.send, shader, "pieceZ", pz) end
+      end
       local quad = quads[p.kind == "monitor" and 1 or 2]
       local top = sy - p.ink.y * s
       if p.flip then

--- a/lib/HealOverlay.lua
+++ b/lib/HealOverlay.lua
@@ -1,0 +1,181 @@
+-- The Pokemon Center heal overlay, put where the machine actually is.
+--
+-- AnimateHealingMachine (engine/overworld/healing_machine.asm) is OAM: a
+-- monitor tile over the console's screen and one ball per healed mon in two
+-- mirrored columns, all blinking through the jingle.  The GB draws them at
+-- FIXED screen coordinates with the player's cell BG-aligned at (64,64), and
+-- the engine keeps that: fxHeal paints each tile at `ha.px - 64 + dx`,
+-- `ha.py - 64 + dy`, and ctx.drawFx slides the whole block onto ONE projected
+-- point -- the player's own feet.
+--
+-- That is exactly right for a flat renderer and wrong for this one.  The art
+-- belongs about 60 world pixels north of the player, on a cabinet 17 voxels
+-- tall; a perspective camera foreshortens that lever arm, so a rigid -60px
+-- screen slide overshoots upward and the balls and the monitor hang in the
+-- air over the machine.  Measured against the machine's own surfaces the
+-- block rides ~9px high at the 35 degree rung and ~14px at 50 -- and the
+-- monitor and the balls drift by DIFFERENT amounts, so no single corrected
+-- anchor seats them both.  Only per-piece placement does.
+--
+-- So this hands back world points, not a screen offset.  The drawing that
+-- voxel_heights.lua extrudes into the machine and the drawing the OAM lands
+-- on are the same 32x32 grid, and Buildings extrudes its front elevation by
+-- one rule -- drawn row r stands at height GROUND_ROW - r, from the base's
+-- last row on the floor to the console's lid.  Reading the OAM offsets
+-- through that rule is all it takes: the monitor comes out on the console's
+-- face inside the inset the drawing cuts for it, and the balls come out on
+-- the cabinet's front panel in the two columns the fascia notches.
+--
+-- Kept OUT of the flat and tilt paths, which want the GB's own placement and
+-- already get it.  See tests/heal_overlay_test.lua, which holds every number
+-- below against the center_heal_machine template it was read off.
+
+local V = ...
+
+local HealOverlay = {}
+
+-- The plot, relative to the cell the player healed on.  Not a guess: the
+-- engine paints the monitor tile at flat world (px - 20, py - 44), and that
+-- tile's lit rectangle is the console inset at grid (13, 6) -- so the tile's
+-- top-left is grid (12, 4) and the plot's north-west corner is 32 west and
+-- 48 north of the heal cell.  Whichever machine of the pair the player is
+-- standing at, they are standing at it the same way.
+local PLOT_DX, PLOT_DY = -32, -48
+
+-- The plot's two front planes, in plot-local depth.  The cabinet's box runs
+-- `depthPx` 10 back from `desk.z` 16, and the console stands on its lid,
+-- `depth` 4 from its own `z` 20 -- so the console's face sits 2px behind the
+-- cabinet's, which is why the balls and the monitor do not share a plane.
+local FRONT_Z, CONSOLE_Z = 26, 24
+
+-- The whole front elevation extrudes upward off the floor line: drawn row 31
+-- is the ground, the base band climbs to 14, the fascia's two rows are the
+-- lid's edge at 16 and 15, and the console's facade carries straight on
+-- above it.  One rule the length of the machine.
+local GROUND_ROW = 31
+
+-- The OAM, engine-side (OverworldController's fxHeal and HEAL_BALL_XY): a
+-- tile's top-left goes to flat world (ha.px - 64 + dx, ha.py - 64 + dy), so
+-- its plot grid position is (dx - 32, dy - 16).  `true` is OAM_XFLIP, the
+-- right-hand column.
+local GRID_DX, GRID_DY = -32, -16
+local MONITOR = { 44, 20 }
+local BALLS = { { 40, 27 }, { 48, 27, true },
+                { 40, 32 }, { 48, 32, true },
+                { 40, 37 }, { 48, 37, true } }
+
+-- Where the ink actually sits inside each 8x8 tile of the player's own
+-- extracted heal_machine sheet (PokeCenterFlashingMonitorAndHealBall, found
+-- through field.overworldFx like the engine finds it): the monitor's lit
+-- rectangle is x 1..6, y 2..4, and the ball is x 2..7, y 2..7.  The tile is
+-- mostly margin, and it is the INK that has to land on the machine, so every
+-- point below is the centre of the ink.
+local MONITOR_INK = { x = 4, y = 3.5 }
+local BALL_INK = { x = 5, y = 5 }
+
+-- FlashSprite8Times XORs rOBP1 ($28): the sprites never disappear, the two
+-- middle shades swap in place.  ha.visible == false is that half of the beat.
+local FLASH_MAP = { [0] = 0, [1] = 2, [2] = 1, [3] = 3 }
+
+-- The plot's north-west corner in world pixels, from the heal cell.
+function HealOverlay.plot(ha)
+  return ha.px + PLOT_DX, ha.py + PLOT_DY
+end
+
+-- One record per piece the overlay draws, in world space:
+--   kind   "monitor" or "ball"
+--   x, h, z   the point the piece's ink is centred on -- east, up, south
+--   flip   the right-hand ball column, drawn mirrored like its OAM
+--   ink    where that centre lies inside the 8x8 tile, for the blit
+local function piece(kind, px0, py0, oam, ink, plane)
+  local flip = oam[3] == true
+  local gx = oam[1] + GRID_DX
+  local row = oam[2] + GRID_DY
+  return {
+    kind = kind,
+    -- a mirrored tile draws leftward, so its ink centre reflects across the
+    -- tile's own width rather than staying put
+    x = px0 + gx + (flip and (8 - ink.x) or ink.x),
+    h = GROUND_ROW - (row + ink.y),
+    z = py0 + plane,
+    flip = flip,
+    ink = ink,
+  }
+end
+
+function HealOverlay.points(ha)
+  local px0, py0 = HealOverlay.plot(ha)
+  local out = { piece("monitor", px0, py0, MONITOR, MONITOR_INK, CONSOLE_Z) }
+  local lit = math.max(0, math.min(tonumber(ha.lit) or 0, #BALLS))
+  for i = 1, lit do
+    out[#out + 1] = piece("ball", px0, py0, BALLS[i], BALL_INK, FRONT_Z)
+  end
+  return out
+end
+
+-- The sheet, cached on the overworld state under the ENGINE's own field
+-- names.  fxHeal populates these lazily too, and it still runs on the flat
+-- and tilt paths, so the two share one image and one pair of quads instead
+-- of each holding its own copy of an 8x16 texture.
+local function sheet(state)
+  local Game = require("src.core.Game")
+  local field = Game.data and Game.data.field
+  local def = field and field.overworldFx and field.overworldFx.healMachine
+  if state.healMachineImg == nil and def then
+    local ok, image = pcall(love.graphics.newImage, def.path)
+    state.healMachineImg = ok and image or false
+  end
+  local img = state.healMachineImg
+  if not img then return nil end
+  if not state.healMachineQuads then
+    local w, h = img:getWidth(), img:getHeight()
+    state.healMachineQuads = {
+      love.graphics.newQuad(0, 0, 8, 8, w, h),   -- monitor ($7c)
+      love.graphics.newQuad(0, 8, 8, 8, w, h),   -- ball ($7d)
+    }
+  end
+  return img, state.healMachineQuads
+end
+
+-- Composite the overlay into the finished scene.  `project(wx, wy, wz)`
+-- answers in canvas pixels and `scale` is canvas pixels per world pixel --
+-- the same two the rest of the FX pass uses.  Deliberately unscaled by
+-- depth, like every other billboard here: a piece keeps its authored size
+-- and only its anchor moves.
+function HealOverlay.draw(ha, project, scale, ctx)
+  local state = ctx and ctx.state
+  if not (ha and state and project and scale) then return false end
+  local img, quads = sheet(state)
+  if not img then return false end
+
+  local PaletteFX = require("src.render.PaletteFX")
+  -- the flashed half of the beat recolours the sprites in place, and wins
+  -- over the world's own sprite palette exactly as it does on the flat path
+  local colors = (not ha.visible)
+    and PaletteFX.permute(PaletteFX.GRAYS, FLASH_MAP)
+    or (ctx.spriteColors and ctx.spriteColors() or nil)
+  local shader = colors and PaletteFX.shader() or nil
+  if shader then
+    PaletteFX.sendColors(shader, colors)
+    love.graphics.setShader(shader)
+  end
+
+  love.graphics.setColor(1, 1, 1, 1)
+  for _, p in ipairs(HealOverlay.points(ha)) do
+    local sx, sy = project(p.x, p.h, p.z)
+    if sx then
+      local quad = quads[p.kind == "monitor" and 1 or 2]
+      local top = sy - p.ink.y * scale
+      if p.flip then
+        love.graphics.draw(img, quad, sx + p.ink.x * scale, top, 0, -scale, scale)
+      else
+        love.graphics.draw(img, quad, sx - p.ink.x * scale, top, 0, scale, scale)
+      end
+    end
+  end
+
+  if shader then love.graphics.setShader() end
+  return true
+end
+
+return HealOverlay

--- a/lib/Voxel3D.lua
+++ b/lib/Voxel3D.lua
@@ -1470,7 +1470,23 @@ function Voxel3D.project(wx, wy, wz)
   -- convention, so both axes map the same way here -- no second flip
   local x = (cx / cw * 0.5 + 0.5) * canvasW
   local y = (cy / cw * 0.5 + 0.5) * canvasH
-  return x, y, (Voxel3D.focusW or cw) / cw
+  -- ...and the WINDOW depth of that point, fourth, for an overlay that has
+  -- to know whether the scene stands in front of it. Same expression the
+  -- water's own occlusion test uses on its self depth, so a value from here
+  -- compares directly against a sample of depthTexture below.
+  local cz = m[9] * wx + m[10] * wy + m[11] * wz + m[12]
+  return x, y, (Voxel3D.focusW or cw) / cw, (cz / cw) * 0.5 + 0.5
+end
+
+-- The frame's depth texture, or nil where the driver gave us none.
+--
+-- It outlives the pass: endScene unbinds the canvas, it does not release the
+-- attachment, so an overlay composited afterwards can still test against the
+-- depth the pass wrote. beginOverlay binding the COLOUR canvas alone is what
+-- makes the texture readable at all -- a target cannot be sampled while it is
+-- attached, which is the same constraint beginWater takes the frame apart for.
+function Voxel3D.depthTexture()
+  return held and held.depth or nil
 end
 
 -- Re-bind the scene canvas for ordinary 2D drawing (no depth test), so

--- a/main.lua
+++ b/main.lua
@@ -113,6 +113,7 @@ local FirstPerson = V.require("FirstPerson")
 local FreeMove = V.require("FreeMove")
 local PoisonFlash = V.require("PoisonFlash")
 local MomHealFlash = V.require("MomHealFlash")
+local HealOverlay = V.require("HealOverlay")
 local TransformCompat = V.require("TransformCompat")
 local VoxelCompanion = V.require("VoxelCompanion")
 local CompanionLifecycle = V.require("CompanionLifecycle")
@@ -360,9 +361,36 @@ mod.content.render_pipelines:register("voxel", {
       -- else -- so the scale goes up with it, or the "!" bubble lands the
       -- right place at half the size.  project() already answers in canvas
       -- pixels, so only the scale needs saying.
-      ctx.drawFx(function(wx, wy) return Voxel3D.project(wx, 0, wy) end,
-                 ctx.scale * AntiAlias.factor())
+      local scale = ctx.scale * AntiAlias.factor()
+      -- Every field FX but one is anchored to the ground point of the thing
+      -- it belongs to -- the character wearing the "!", the cell the dust
+      -- puffs on -- so its flat closure lands unchanged through this.  The
+      -- heal machine's is not: it is anchored to the PLAYER, three tiles from
+      -- the art it paints, and slid rigidly onto that one point.  A camera
+      -- with any pitch foreshortens that lever arm, so the balls and the
+      -- monitor float off the cabinet.  Hide it from drawFx -- both the
+      -- dispatch and fxHeal itself read state.healAnim -- and put its pieces
+      -- on the machine's own surfaces instead.
+      --
+      -- healAnim goes back whatever drawFx does with the frame: the heal
+      -- script is waiting on that record to count its jingle out, and losing
+      -- it would strand the player at the counter.
+      local state = ctx.state
+      local healAnim = state and state.healAnim
+      if healAnim then state.healAnim = nil end
+      local drawn, err = pcall(ctx.drawFx,
+                               function(wx, wy) return Voxel3D.project(wx, 0, wy) end,
+                               scale)
+      if healAnim then
+        state.healAnim = healAnim
+        -- cosmetic, and last: a fault here must not retire the pipeline and
+        -- drop the whole world back to 2D mid-heal
+        if not pcall(HealOverlay.draw, healAnim, Voxel3D.project, scale, ctx) then
+          love.graphics.setShader()
+        end
+      end
       Voxel3D.endOverlay()
+      if not drawn then error(err, 0) end
     end
     -- and back to the window's own size, which is what the engine composites
     -- one canvas pixel to one display pixel.  A pass-through when AA is off.

--- a/tests/heal_overlay_test.lua
+++ b/tests/heal_overlay_test.lua
@@ -249,7 +249,34 @@ T.eq(cs, 7, "...and falls back to the flat scale for its size")
 T.eq(HealOverlay.place(function() return nil end, target, 1), nil,
   "a piece behind the camera is not drawn at all")
 
--- ------- and whether it is behind something, which is a third question
+-- ------- the order they are painted in, which decides the overlap
+--
+-- The rows overlap by a pixel or two and nothing here writes depth, so which
+-- ball wins is settled purely by draw order.  points() hands them back in
+-- the OAM's own order, top row first, and draw walks that list with ipairs,
+-- so the bottom row is painted last and sits in front with the upper rows
+-- tucked behind it.  That is the reading the art wants: further up the
+-- machine is further back.
+--
+-- Sorting these by projected depth would invert it.  On the orbit rungs the
+-- eye is above the machine, and on a vertical panel that puts the TOP row
+-- nearer the camera.  So the order has to stay the drawing's rather than the
+-- camera's, and this is here to say so if anyone reaches for a sort.
+local painted = {}
+for _, p in ipairs(HealOverlay.points({ px = 48, py = 48, balls = 6, lit = 6 })) do
+  if p.kind == "ball" then painted[#painted + 1] = p.h end
+end
+local descending = true
+for i = 2, #painted do
+  if painted[i] > painted[i - 1] then descending = false end
+end
+T.check(descending,
+  "the balls are handed back top row first, so the bottom row paints last")
+T.check(painted[#painted] < painted[1],
+  ("the last ball painted is the lowest on the machine (%d against %d)")
+    :format(painted[#painted], painted[1]))
+
+-- ------- and whether it is behind something, which is a fourth question
 --
 -- The overlay composites flat with the depth test off, so it painted over
 -- the counter the player is standing at.  It now tests each fragment against
@@ -297,7 +324,9 @@ T.eq(select(3, HealOverlay.depthPoint(onPanel,
 -- Poke Balls on a fully coloured machine.  objPalette picks the pack's own
 -- OBJ palette for it.
 
-local pack = dofile(ROOT .. "/data/palettes_gbc.lua")
+-- an ENGINE file, so relative to the repo root this runs from, not to
+-- ROOT, which is where the MOD lives and is not the same place
+local pack = dofile("data/palettes_gbc.lua")
 local palette, group = HealOverlay.objPalette(pack and pack.world)
 T.check(palette ~= nil, "the ADVANCED pack yields an object palette")
 T.eq(group, pack.world.spriteAssignment[0],

--- a/tests/heal_overlay_test.lua
+++ b/tests/heal_overlay_test.lua
@@ -124,14 +124,64 @@ for i, b in ipairs(balls) do
   T.check(b.x > px0 + machine.desk.x[1] and b.x < px0 + machine.desk.x[2] + 1,
     ("ball %d stands within the cabinet's own columns (got %s)")
       :format(i, tostring(b.x)))
-  T.check(b.h > 0 and b.h <= plane,
-    ("ball %d is on the panel, not through the floor or the lid (got %s)")
-      :format(i, tostring(b.h)))
+  -- the group rides above the cabinet lid on purpose (see BALL_LIFT), so the
+  -- bounds that matter are the panel below and the console screen above,
+  -- both checked to the pixel further down
+  T.check(b.h > 0,
+    ("ball %d stands above the floor (got %s)"):format(i, tostring(b.h)))
   seenX[b.x] = true
 end
 local columns = 0
 for _ in pairs(seenX) do columns = columns + 1 end
 T.eq(columns, 2, "the balls fill two mirrored columns")
+
+-- ------- and they sit ON the panel, not over the lip below it
+--
+-- The ball art's ink is 6 rows of its tile, so a ball reaches 3 either side
+-- of the point it is centred on.  The dark front panel's last drawn row
+-- extrudes to GROUND_ROW - 28, and rows 29..30 under it are the cream lip at
+-- the machine's foot.  Unlifted, the lowest ball's ink lands one pixel into
+-- that lip and hangs over the cabinet.
+-- the OAM's own row pitch, which the lift must carry rather than squash
+local BALLS_PITCH = 5
+
+-- A FULL party, because the bottom row is the one at risk and a three-ball
+-- fixture never lights it. `balls` above is deliberately a partial party, so
+-- these bounds get their own six.
+local full = {}
+for _, p in ipairs(HealOverlay.points({ px = 48, py = 48, balls = 6, lit = 6 })) do
+  if p.kind == "ball" then full[#full + 1] = p end
+end
+T.eq(#full, 6, "a full party lights all six for the bounds below")
+
+local panelFloor = machine.desk.base[2] - HealOverlay.PANEL_ROWS[2]
+local lowest = math.huge
+for _, b in ipairs(full) do lowest = math.min(lowest, b.h) end
+T.check(lowest - 3 >= panelFloor,
+  ("the lowest ball's ink stays on the panel, whose last row stands at %d "
+   .. "(ink reaches %d)"):format(panelFloor, lowest - 3))
+
+-- The group travels as one, so the pitch the OAM sets is untouched: three
+-- rows, evenly spaced, however far up they sit.
+local seen = {}
+for _, b in ipairs(full) do seen[b.h] = true end
+local rows = {}
+for h in pairs(seen) do rows[#rows + 1] = h end
+table.sort(rows)
+T.eq(#rows, 3, "a full party stands on three rows")
+T.eq(rows[2] - rows[1], BALLS_PITCH, "evenly spaced, at the pitch the OAM sets")
+T.eq(rows[3] - rows[2], BALLS_PITCH,
+  "...and the lift carries the group without squashing it")
+
+-- The ceiling: the console's screen is the inset drawn rows 6..8, and the
+-- balls must stop under it.  Climbing into it would cover the very surface
+-- the monitor tile is drawn on.
+local screenFloor = machine.desk.base[2] - (console.inset.rows[2] + 1)
+local highest = -math.huge
+for _, b in ipairs(full) do highest = math.max(highest, b.h) end
+T.check(highest + 3 < screenFloor,
+  ("the top pair stays clear of the console screen, whose bottom edge is at "
+   .. "%d (ink reaches %d)"):format(screenFloor, highest + 3))
 
 -- and the flip survives: the right column is the left one's OAM_XFLIP
 local flipped = 0

--- a/tests/heal_overlay_test.lua
+++ b/tests/heal_overlay_test.lua
@@ -153,6 +153,52 @@ if monitor then
       :format(tostring(monitor.z), tostring(flatY)))
 end
 
+-- ------- and how big it draws, which is a separate question
+--
+-- The orbit frames exactly `vh` world pixels, so the flat renderer's own
+-- scale is very nearly right there.  1ST and 3RD ride a placed camera whose
+-- framing comes from its fov and how far the eye stands, and a world pixel
+-- draws about 3.8x and 1.45x bigger than that scale respectively -- which is
+-- what shrank the balls and the monitor to a quarter and two thirds size on
+-- those rungs.  `place` measures the size off the projection instead, so
+-- these run it against projections that stand in for each case.
+
+local target = HealOverlay.points(ha)[2]      -- a ball on the front panel
+
+-- a camera that magnifies the world k times, whatever the flat scale says
+local function magnify(k)
+  return function(x, h) return x * k, (100 - h) * k end
+end
+
+local sx, sy, s = HealOverlay.place(magnify(4), target, 1)
+T.eq(sx, target.x * 4, "the piece lands where the projection puts it")
+T.eq(sy, (100 - target.h) * 4, "...on both axes")
+T.eq(s, 4, "a world pixel is measured off the projection, not taken from the "
+        .. "flat renderer's scale (the 1ST/3RD shrink)")
+T.eq(select(3, HealOverlay.place(magnify(1), target, 1)), 1,
+  "and a camera that agrees with the flat scale is left alone")
+
+-- seen along the machine, the east step collapses but the up step does not
+local function edgeOn(k)
+  return function(x, h, z) return z * k, (100 - h) * k end
+end
+T.eq(select(3, HealOverlay.place(edgeOn(5), target, 1)), 5,
+  "an edge-on view sizes off the up step rather than shrinking to nothing")
+
+-- a projection with nothing to say about the neighbours still has to draw
+local function centreOnly(p)
+  return function(x, h)
+    if x == p.x and h == p.h then return 10, 20 end
+    return nil
+  end
+end
+local cx, cy, cs = HealOverlay.place(centreOnly(target), target, 7)
+T.eq(cx, 10, "a centre-only projection still places the piece")
+T.eq(cs, 7, "...and falls back to the flat scale for its size")
+
+T.eq(HealOverlay.place(function() return nil end, target, 1), nil,
+  "a piece behind the camera is not drawn at all")
+
 -- lit balls track the party, and nothing is drawn before the first one lights
 T.eq(#HealOverlay.points({ px = 48, py = 48, balls = 6, lit = 0 }), 1,
   "before any ball lights, only the monitor is drawn")

--- a/tests/heal_overlay_test.lua
+++ b/tests/heal_overlay_test.lua
@@ -1,0 +1,167 @@
+-- The Pokemon Center heal overlay, placed against the machine it belongs to.
+--
+-- The engine draws the monitor tile and the party's Poke Balls
+-- (PokeCenterOAMData) as ordinary 2D sprites at fixed screen offsets from
+-- the cell the player healed on, and ctx.drawFx slides that whole block
+-- rigidly onto ONE projected point -- the player's own feet
+-- (OverworldController's `at(fxHeal, healAnim.px + 8, healAnim.py + 16)`).
+-- The art it paints belongs about 60 world pixels north of there, on a
+-- machine 17 voxels tall, so under a perspective camera the block floats off
+-- the cabinet: measured against the machine's real surfaces it rides ~9px
+-- high at the 35 degree rung and ~14px at 50, and the monitor and the balls
+-- drift by different amounts, so no single offset can seat them both.
+--
+-- HealOverlay answers with world points instead of a screen slide: every
+-- piece is placed on the SURFACE the drawing extrudes it onto, so the same
+-- projection that draws the rest of the scene puts it there too.
+--
+-- These checks are pinned to data/voxel_heights.lua's own machine template
+-- rather than to copied numbers -- if the cabinet's depth, its height or the
+-- console's inset move, the overlay has to move with them.
+--
+--   luajit mods/BattleArtVoxelFork/tests/heal_overlay_test.lua
+
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.harness")
+local MOD_PATH = os.getenv("DS_MOD_PATH") or "mods/BattleArtVoxelFork"
+local ROOT = os.getenv("DS_REPO_ROOT") or "."
+local base = ROOT .. "/" .. MOD_PATH
+local modules, dataFiles = {}, {}
+local V = {}
+function V.require(name)
+  if modules[name] ~= nil then return modules[name] end
+  local value = assert(loadfile(base .. "/lib/" .. name .. ".lua"))(V)
+  modules[name] = value
+  return value
+end
+function V.data(name)
+  if dataFiles[name] ~= nil then return dataFiles[name] end
+  local value = assert(loadfile(base .. "/data/" .. name .. ".lua"))(V)
+  dataFiles[name] = value
+  return value
+end
+
+local HealOverlay = V.require("HealOverlay")
+
+-- ------- the machine, as the mod actually voxelizes it
+
+local function template(id)
+  for _, t in ipairs(V.data("voxel_heights").buildings.POKECENTER) do
+    if t.id == id then return t end
+  end
+end
+
+local machine = template("center_heal_machine_w")
+T.check(machine ~= nil,
+  "the POKECENTER catalogue still carries center_heal_machine_w")
+
+-- Buildings.deskSetModel's own arithmetic, restated: the cabinet's height is
+-- its drawn base band plus its fascia, its box runs `depthPx` back from `z`,
+-- and the console stands on the lid, `depth` deep from its own `z`.
+local plane = (machine.desk.base[2] - machine.desk.base[1] + 1)
+            + (machine.desk.fascia[2] - machine.desk.fascia[1] + 1)
+local frontZ = machine.desk.z + machine.desk.depthPx      -- cabinet front plane
+local console
+for _, p in ipairs(machine.parts) do
+  if p.kind == "upright" and p.inset then console = p end
+end
+local consoleZ = console.z + console.depth                -- console front plane
+local groundRow = machine.desk.base[2]                    -- drawn row of the floor
+
+T.eq(plane, 17, "the heal machine cabinet is 17 voxels tall")
+T.eq(frontZ, 26, "its front face is the z=26 plane of the plot")
+T.eq(consoleZ, 24, "the console's face stands 2px behind the cabinet's")
+
+-- ------- the plot, found from the cell the player healed on
+
+local ha = { px = 48, py = 48, balls = 3, lit = 3, visible = true }
+local px0, py0 = HealOverlay.plot(ha)
+T.eq(px0, 16, "the west machine's plot begins at world x 16")
+T.eq(py0, 0, "...and at world y 0, the back row of the Center")
+
+-- The plot origin is not a guess: the engine paints the monitor tile at flat
+-- world (px - 20, py - 44), and the template puts that tile's lit rectangle
+-- exactly on the console inset the drawing cuts at grid x 13..18.
+T.eq(px0 + console.inset.x[1], ha.px - 20 + 1,
+  "the monitor tile's lit rectangle starts on the console inset's first column")
+T.eq(px0 + console.inset.x[2], ha.px - 20 + 6,
+  "...and ends on its last")
+
+-- ------- where each piece goes
+
+local pieces = HealOverlay.points(ha)
+local monitor, balls = nil, {}
+for _, p in ipairs(pieces) do
+  if p.kind == "monitor" then monitor = p else balls[#balls + 1] = p end
+end
+
+T.check(monitor ~= nil, "the overlay places the monitor")
+T.eq(#balls, 3, "one ball per healed party member, and no more")
+
+-- the monitor rides the console's face, centred on the inset the drawing cuts
+if monitor then
+  T.eq(monitor.z, py0 + consoleZ, "the monitor sits on the console's front face")
+  T.eq(monitor.x, px0 + (console.inset.x[1] + console.inset.x[2] + 1) / 2,
+    "...centred across the inset's columns")
+  -- the front elevation extrudes drawn row r to height groundRow - r, which
+  -- is what puts the fascia's first row at the lid and the base's last on
+  -- the floor; the inset band is that same mapping over its own rows
+  local top = groundRow - console.inset.rows[1]
+  local bottom = groundRow - (console.inset.rows[2] + 1)
+  T.check(monitor.h > bottom and monitor.h < top,
+    ("the monitor's height lands inside the inset band %d..%d (got %s)")
+      :format(bottom, top, tostring(monitor.h)))
+  T.check(monitor.h > plane,
+    "...which is above the cabinet lid, where the console actually stands")
+end
+
+-- the balls ride the cabinet's front panel, in the two columns the fascia
+-- notches, and every one of them is ON the cabinet: no floor, no ceiling
+local seenX = {}
+for i, b in ipairs(balls) do
+  T.eq(b.z, py0 + frontZ, ("ball %d sits on the cabinet's front panel"):format(i))
+  T.check(b.x > px0 + machine.desk.x[1] and b.x < px0 + machine.desk.x[2] + 1,
+    ("ball %d stands within the cabinet's own columns (got %s)")
+      :format(i, tostring(b.x)))
+  T.check(b.h > 0 and b.h <= plane,
+    ("ball %d is on the panel, not through the floor or the lid (got %s)")
+      :format(i, tostring(b.h)))
+  seenX[b.x] = true
+end
+local columns = 0
+for _ in pairs(seenX) do columns = columns + 1 end
+T.eq(columns, 2, "the balls fill two mirrored columns")
+
+-- and the flip survives: the right column is the left one's OAM_XFLIP
+local flipped = 0
+for _, b in ipairs(balls) do if b.flip then flipped = flipped + 1 end end
+T.eq(flipped, 1, "with three balls lit, exactly one of them is the flipped column")
+
+-- ------- the regression this exists to hold
+--
+-- Unaided, ctx.drawFx treats the whole overlay as flat art lying on the
+-- ground plane at its drawn row (main.lua's `Voxel3D.project(wx, 0, wy)`).
+-- Both of those are wrong here by a whole machine.
+if monitor then
+  local flatY = ha.py - 64 + 20 + 3.5     -- the lit rectangle's centre, flat
+  T.check(monitor.h > plane,
+    "the monitor is lifted onto the console instead of lying on the floor")
+  T.check(monitor.z - flatY > 8,
+    ("the monitor is set back onto the machine's face rather than left at its "
+     .. "drawn row (face %s, drawn %s)")
+      :format(tostring(monitor.z), tostring(flatY)))
+end
+
+-- lit balls track the party, and nothing is drawn before the first one lights
+T.eq(#HealOverlay.points({ px = 48, py = 48, balls = 6, lit = 0 }), 1,
+  "before any ball lights, only the monitor is drawn")
+T.eq(#HealOverlay.points({ px = 48, py = 48, balls = 6, lit = 6 }), 7,
+  "a full party lights all six")
+T.eq(#HealOverlay.points({ px = 48, py = 48, balls = 6, lit = 99 }), 7,
+  "and a bad count cannot run off the end of the machine")
+
+if T.failures > 0 then
+  error(("heal overlay placement: %d failure(s)"):format(T.failures))
+end
+print(("PASS heal overlay placement (%d checks)"):format(T.checks))

--- a/tests/heal_overlay_test.lua
+++ b/tests/heal_overlay_test.lua
@@ -199,7 +199,47 @@ T.eq(cs, 7, "...and falls back to the flat scale for its size")
 T.eq(HealOverlay.place(function() return nil end, target, 1), nil,
   "a piece behind the camera is not drawn at all")
 
--- ------- and what colour it draws in, which is a third question
+-- ------- and whether it is behind something, which is a third question
+--
+-- The overlay composites flat with the depth test off, so it painted over
+-- the counter the player is standing at.  It now tests each fragment against
+-- the frame's own depth texture -- but a piece painted ON a face ties with
+-- that face's depth, so the point the depth is taken at is nudged toward the
+-- eye first, the way Voxel3D.draw's `pull` moves a character card off the
+-- wall it leans over.
+
+T.check(HealOverlay.PULL > 0, "the depth sample is pulled toward the eye")
+T.check(HealOverlay.PULL < machine.desk.depthPx,
+  ("...by less than the cabinet is deep (%d), so the pull can never carry a "
+   .. "piece in front of something that genuinely stands nearer")
+    :format(machine.desk.depthPx))
+
+local onPanel = HealOverlay.points(ha)[2]
+
+-- an eye due south of the machine, at counter height
+local eye = { onPanel.x, onPanel.h, onPanel.z + 64 }
+local dx, dy, dz = HealOverlay.depthPoint(onPanel, eye)
+T.eq(dx, onPanel.x, "a head-on eye pulls the sample along z alone")
+T.eq(dy, onPanel.h, "...on both of the other axes")
+T.eq(dz, onPanel.z + HealOverlay.PULL,
+  "...and exactly PULL toward it, off the face the piece is painted on")
+
+-- and from anywhere else it is still exactly PULL, just along the sightline
+local skew = { onPanel.x + 40, onPanel.h + 30, onPanel.z + 50 }
+local sx2, sy2, sz2 = HealOverlay.depthPoint(onPanel, skew)
+local moved = math.sqrt((sx2 - onPanel.x) ^ 2 + (sy2 - onPanel.h) ^ 2
+                        + (sz2 - onPanel.z) ^ 2)
+T.check(math.abs(moved - HealOverlay.PULL) < 1e-9,
+  ("an off-axis eye pulls the same distance along its own sightline (got %.6f)")
+    :format(moved))
+
+T.eq(select(3, HealOverlay.depthPoint(onPanel, nil)), onPanel.z,
+  "with no camera to pull toward, the piece's own point stands")
+T.eq(select(3, HealOverlay.depthPoint(onPanel,
+                                      { onPanel.x, onPanel.h, onPanel.z })),
+  onPanel.z, "and an eye standing in the piece cannot divide by its own zero")
+
+-- ------- and what colour it draws in, which is a fourth question
 --
 -- ADVANCED (RED++) bakes the OBP into every sprite sheet as it loads, so
 -- ctx.spriteColors answers nil there.  The heal sheet is not a sprite def

--- a/tests/heal_overlay_test.lua
+++ b/tests/heal_overlay_test.lua
@@ -199,6 +199,46 @@ T.eq(cs, 7, "...and falls back to the flat scale for its size")
 T.eq(HealOverlay.place(function() return nil end, target, 1), nil,
   "a piece behind the camera is not drawn at all")
 
+-- ------- and what colour it draws in, which is a third question
+--
+-- ADVANCED (RED++) bakes the OBP into every sprite sheet as it loads, so
+-- ctx.spriteColors answers nil there.  The heal sheet is not a sprite def
+-- and nothing bakes it, so it reached the canvas in raw DMG greys: grey
+-- Poke Balls on a fully coloured machine.  objPalette picks the pack's own
+-- OBJ palette for it.
+
+local pack = dofile(ROOT .. "/data/palettes_gbc.lua")
+local palette, group = HealOverlay.objPalette(pack and pack.world)
+T.check(palette ~= nil, "the ADVANCED pack yields an object palette")
+T.eq(group, pack.world.spriteAssignment[0],
+  "it is the pack's own OBJ group for sprite sheet 0, not a number picked here")
+
+-- The ball art draws its outline on shade 3, its upper body on 2 and its
+-- lower body on 1.  A palette that cannot answer those with black, a red and
+-- something pale does not make a Poke Ball, whatever else it is.  Declining
+-- to answer is the grey the overlay had, so a nil stands in as the DMG greys
+-- and fails these rather than skipping them.
+local pal = palette or { { 255, 255, 255 }, { 170, 170, 170 },
+                         { 85, 85, 85 }, { 0, 0, 0 } }
+local band, upper, lower = pal[4], pal[3], pal[2]
+T.check(band[1] == 0 and band[2] == 0 and band[3] == 0,
+  "shade 3 is black, for the ball's outline and its band")
+T.check(upper[1] > 200 and upper[2] < 120 and upper[3] < 120,
+  ("shade 2 is a red, for the ball's upper body (got %d,%d,%d)")
+    :format(upper[1], upper[2], upper[3]))
+T.check(lower[1] > 200 and lower[2] > 120,
+  ("shade 1 is pale, for the ball's lower body (got %d,%d,%d)")
+    :format(lower[1], lower[2], lower[3]))
+T.neq(upper[1] == lower[1] and upper[2] == lower[2] and upper[3] == lower[3],
+  true, "and the two halves of the ball are not the same colour")
+
+T.eq(HealOverlay.objPalette(nil), nil, "no pack yields no palette")
+T.eq(HealOverlay.objPalette({ spritePalettes = {}, spriteAssignment = {} }), nil,
+  "and a pack with no group 0 is declined rather than guessed at")
+T.eq(HealOverlay.objPalette({ spritePalettes = { [0] = { 1, 2, 3, 4 } },
+                              spriteAssignment = { [0] = "random" } }), nil,
+  "a randomized assignment is not a palette index and is declined too")
+
 -- lit balls track the party, and nothing is drawn before the first one lights
 T.eq(#HealOverlay.points({ px = 48, py = 48, balls = 6, lit = 0 }), 1,
   "before any ball lights, only the monitor is drawn")


### PR DESCRIPTION
In voxel mode the Poke Balls and the blinking monitor at a Pokemon Center hang in the air above the healing machine instead of sitting on it.

The overlay is OAM the engine draws flat. `fxHeal` paints each tile at a fixed screen offset from the cell the player healed on, and `ctx.drawFx` slides that whole block onto one projected point, the player's own feet. On a flat renderer that is exact. Here the art belongs three tiles further north, on a cabinet 17 voxels tall, and a camera with any pitch foreshortens that gap, so the block overshoots upward. Against the machine's own surfaces it rides about 9px high at the 35 degree rung and 14px at 50. The monitor and the balls drift by different amounts, so no single corrected anchor seats both.

Each piece gets placed as a world point instead. The `center_heal_machine` template and the OAM the engine paints are two readings of the same 32x32 drawing, and `deskSetModel` extrudes that drawing's front elevation by one rule: drawn row r stands at height `base[2] - r`. Read the OAM offsets through that rule and the monitor lands inside the `inset` the template already cuts for it, and the balls land on the front panel in the two columns the fascia notches.

Two more things turned up while testing it.

**Sizing.** `ctx.scale` is the flat renderer's pixels per world pixel, and the orbit matches it because it frames exactly `vh` world pixels. The 1ST and 3RD rungs do not. They ride the placed camera from `FirstPerson.frame`, where a world pixel draws about 3.8x bigger at the counter and 1.45x off the boom, so the sprites came out at roughly a quarter and two thirds size. `HealOverlay.place` measures the size off the projection rather than assuming it.

**Depth.** The overlay composites with the depth test off, so it drew over the counter. `beginOverlay` binds the colour canvas alone, which leaves the frame's depth texture readable, so the sprites now test against it the same way `Water` tests its own self occlusion. A piece painted on a face ties with that face's depth, so the sample is nudged two world pixels toward the eye first, like the `pull` in `Voxel3D.draw`.

Flat and tilt keep the GB's own placement, which is right for them.

### Changes

- `lib/HealOverlay.lua`: new. Turns the OAM offsets into world points on the machine's surfaces, measures how big a world pixel draws there, resolves a palette, and draws the pieces depth tested
- `lib/Voxel3D.lua`: `project` returns the point's window depth as a fourth value, and `depthTexture` hands back the frame's depth attachment. Both additive, and `project`'s existing callers take three values
- `main.lua`: hides `healAnim` from `ctx.drawFx` on the voxel pipeline and places the pieces itself. `healAnim` goes back whatever the frame does with it, since the heal script counts its jingle out of that record
- `tests/heal_overlay_test.lua`: pins the placement to the machine template rather than to copied numbers, and covers the sizing, the palette choice and the depth pull

### Testing

- 55 checks. Reverting the placement constants fails 11, forcing the size fallback fails 2, declining the object palette fails 4, removing the depth pull fails 2
- Every other standalone test in `tests/` prints identically before and after. `battle_art_voxel_fork_test.lua` does not compile here, 200 local variable limit at line 2604, same on a clean tree
- `modkit validate` reports no loader findings and the same two pre-existing MK301s either way
- Played through a heal on Android at the orbit rungs and on 1ST and 3RD

Left out the version bump and CHANGELOG entry so this does not collide with your release flow. Applied to master with no conflicts.
