### PR TITLE
Reflect the player and NPCs in water

### DIFF
--- a/docs/WATER_CAST_REFLECTION.md
+++ b/docs/WATER_CAST_REFLECTION.md
@@ -1,0 +1,230 @@
+# Reflecting the cast in water
+
+Design for a positionally accurate reflection of the player and NPCs in
+water, visible at the near-overhead cameras this game is actually played at.
+
+Implemented in `lib/Voxel3D.lua` (`beginCast`/`endCast`), `lib/VoxelScene.lua`
+(`reflectPlane`, `billboardMatrix`, `drawWater`) and `lib/Water.lua` (the
+`castTex` composite). Covered by `tests/water_cast_reflection_test.lua`.
+
+## The problem
+
+A cast reflection already exists. `VoxelScene.drawWater` passes `drawCast`
+into `Voxel3D.beginWater`, which paints every character into the copy of the
+frame the water reflects, and the screen-space march is supposed to find them:
+a sprite is not in the depth buffer, so a ray aimed at one passes through to
+the terrain behind it and reads the copy there, where the sprite is already
+painted.
+
+It does not survive contact with the ordinary camera, for two reasons.
+
+**The horizon lean aims every ray away from anything nearby.** `Water.lean`
+reaches 1 at a descent of 0.55, well before the camera reaches its steepest
+rung, and at full lean a column's reflected ray is set to `LEAN_ELEV` (about
+17.5 degrees) toward the horizon. That is deliberate and it is what puts sky,
+sun and moon on the water at a steep camera. It also means water one tile from
+a character's feet reflects the far distance rather than the person standing
+beside it.
+
+**Rays crossing water land on nothing.** With the world curve off the water
+surface is never written to the depth buffer, so a low ray leaving a pier
+travels out over open harbour and finds no depth to hit. It misses, and the
+sky answers instead. On a pier ringed by water that is most directions.
+
+Screen-space reflection is simply the wrong instrument for a nearby object at
+a steep camera, and no tuning of it reaches the problem.
+
+### What is not a problem
+
+A correct mirror image is easy to see, and this is worth stating because it
+was initially got backwards.
+
+World up projects to screen up: `skyPos` maps upward directions into rows `0`
+to `skyEdge`, the sky's band at the top of the frame, and every building and
+tree in the scene extends upward from its base. So *lowering* an object moves
+it *down* the screen, toward the viewer.
+
+A reflection mirrored about the water plane therefore lands below the
+character on screen, in front of them, in clear view. Accuracy and visibility
+do not conflict, and no stylised displacement is needed to reconcile them. An
+earlier draft of this design proposed one. It was solving an imaginary
+problem.
+
+## The approach
+
+Draw the cast a second time, each card reflected in the water plane and
+flipped, into a canvas of its own, and let the water shader sample it at each
+fragment's own screen position. The reflection was drawn to exactly the place
+a mirror would put it, so the fragment's own uv is the right place to look.
+No offset to tune, no correspondence to maintain.
+
+Masking comes free. The water shader runs on water fragments and nothing
+else, so the reflection is confined to water exactly, with no stencil and no
+clipping. This matters because a stencil is not available: the scene's depth
+canvas prefers plain `depth24` (`lib/Voxel3D.lua:372`), so on most drivers
+there is no stencil buffer at all, and reordering that list changes
+allocation for the whole renderer.
+
+### Not by mirroring the camera
+
+The obvious implementation is to render the cast through a view-projection
+premultiplied by a reflection in the plane, and reuse `drawCast` untouched.
+An earlier draft of this design said exactly that. It does not work, and the
+reason is worth recording because it is not obvious until it is on screen.
+
+A character is a BILLBOARD. Its card leans back by exactly the camera's pitch
+so it reads face-on. Mirror the camera and the card is caught leaning away,
+so what lands in the water is a foreshortened sliver: too small, and with no
+legible flip. That is the correct picture of the flat quad the card really
+is, and useless as a reflection of the person it is pretending to be.
+
+A billboard is a fake that works from one side only, so its reflection has to
+be faked the same way. `billboardMatrix` reflects the POSITION, keeps the
+card facing the camera, and flips it about its own feet:
+
+- the anchor moves to `2 * plane - y`, so a card standing ON the plane is its
+  own anchor and the waterline still agrees exactly
+- the card's local y is negated, which hangs it downward from that anchor and
+  carries its texture with it
+
+Same lean, same size, upside down. Which is what a reflection looks like.
+
+`reflectPlane` is ambient state for the duration of the pass rather than a
+parameter threaded through the four functions between `drawWater` and the
+draw, matching how `Voxel3D.glass` and `Voxel3D.seams` already switch a
+pass's character. It is cleared through `pcall` so a throwing `cast()` cannot
+leave the rest of the frame's cards upside down.
+
+Authored figures are skipped in the reflection pass. A figure is not a card:
+it is a mesh in its own local space placed by `Mat4.figure`, so the card flip
+does not reach it, and it is a person drawn into furniture, indoors, which is
+not where water is.
+
+### The mirror plane
+
+One plane, at the water class height. `TileShape`'s `FALLBACK_HEIGHTS` gives
+`water = -2` against `ground = 0`, and it is a per-class constant that
+`data/voxel_heights.lua` may override with another single number. Every water
+surface in the world therefore lies in the same plane, so one height serves
+the whole frame exactly rather than approximately.
+
+The height is read from `TileShape` rather than restated, so an override
+moves the reflection with the water.
+
+### Pipeline
+
+1. `Voxel3D.beginCast()` lazily creates `held.cast`, a full-size
+   `PixelCanvas`, binds it colour-only, and clears it to transparent. No
+   depth attachment: what would be tested against is the world's depth, and
+   this canvas holds reflected cards that share none of it. The water
+   shader's own depth test has already decided which water fragments
+   survive, and a reflection only ever lands on those.
+2. `VoxelScene` sets `reflectPlane` and draws the cast through the existing
+   `drawCast` closure, then clears it.
+3. `Voxel3D.endCast()` rebinds the scene canvas.
+4. `VoxelScene.drawWater` passes the texture to `Water.begin`.
+5. The water shader samples it and composites.
+
+This runs BEFORE `beginWater`, which rebinds canvases and detaches the depth
+buffer; the cast pass wants the frame intact.
+
+The existing `drawCast` paint into the mirror copy stays as it is. It is
+what the screen-space march finds at a low camera, and the two do not
+conflict: one is found by rays, the other is composited in screen space.
+
+### Sampling and compositing
+
+In `effect()`, after the fresnel mix:
+
+- sample `castTex` at the fragment's own screen uv, the same
+  `sc / love_ScreenSize.xy` the depth test already computes, displaced by the
+  wave normal's horizontal components scaled by `CAST_WOBBLE`, so the
+  reflection ripples with the surface carrying it
+- the canvas's alpha gates the blend, which is why it is cleared to
+  transparent
+- composite at `CAST_ALPHA`, **after** the fresnel mix rather than into
+  `refl` before it
+
+That last point is deliberate. Fresnel is smallest looked straight down at,
+so folding the cast reflection into `refl` would fade it out at precisely the
+camera this feature exists to serve.
+
+### Rungs and fallbacks
+
+Available at SKY as well as FULL. It is not a ray march, so it does not need
+`rays`, and a device that cannot afford the march can still afford this.
+
+Every failure degrades to current behaviour and nothing else:
+
+- the canvas cannot be created: no cast reflection, water otherwise unchanged
+- the water row is OFF, or the shader did not compile: the flat fallback, as
+  today
+- Android: already forced to flat water by `Water.onAndroid`, so this does
+  not reach it
+
+`held.cast` joins `releaseSlot`'s list beside `canvas`, `depth` and `mirror`,
+and is created only when something asks for one, so a session that never sees
+a lake never pays for it.
+
+## Cost
+
+- one full-size RGBA canvas per slot, allocated lazily
+- one extra draw of every visible character per frame with water on screen
+- one extra texture sample per water fragment
+
+Characters nowhere near water are still drawn into the canvas, where they
+land on no water fragment and are discarded. Culling to characters within
+some distance of a water cell is an obvious follow-up, left out of the first
+cut so the first version is measurable before it is optimised.
+
+## Tunables
+
+On `Water`, sent as uniforms like every other constant in that file.
+
+| name | meaning |
+| --- | --- |
+| `CAST_ALPHA` | how strongly the reflection composites. |
+| `CAST_WOBBLE` | how far the wave normal displaces the sample. |
+
+There is deliberately no position or offset dial. The mirrored camera fixes
+the geometry, and a knob that moved it could only make it wrong.
+
+## Testing
+
+- **shader compiles**, all four variants (full, full+grid, sky, sky+grid),
+  through a real LOVE GLSL compile rather than by inspection. A syntax error
+  here falls back to flat water silently, which is the failure mode that
+  hides longest.
+- **uniforms are sent.** A uniform can be declared, read, and never fed; that
+  is not a compile error anywhere, and it reads as zero at runtime. Drive
+  `Water.begin` with a recording shader and assert each new name arrives.
+- **the mirror matrix**, which is a pure function and the part with
+  arithmetic worth pinning: that a point at `y = plane` is its own image,
+  that a point one unit above maps one unit below, and that x and z are
+  untouched.
+- **the plane is read, not restated**: overriding `TileShape`'s water height
+  moves the matrix with it.
+- **canvas lifecycle**: `held.cast` is released by `releaseSlot`.
+- **no regressions** against the standalone suite, baselined before and after.
+  `battle_art_voxel_fork_test.lua` does not compile at all (Lua's 200-local
+  limit) and the two MK301 lint errors in `InterfaceSprites` are pre-existing,
+  so neither is a signal.
+
+The look itself cannot be tested here. It needs a screenshot from the same
+spot each time, at a comparable time of day, because the sun's elevation
+moves what the water does.
+
+## Known limits
+
+- **Nothing occludes the reflection.** Only the cast is rendered into the
+  mirrored canvas, so a character standing behind a building still reflects
+  in water in front of it. Fixing this needs terrain in the mirrored pass and
+  a depth buffer to test against, which is a much larger change.
+- **No depth among the characters themselves.** The cast canvas is colour
+  only, so two overlapping reflections resolve by draw order rather than by
+  distance. Draw order is the same one the frame uses, so this is right in
+  the common case and wrong only where one character's reflection genuinely
+  passes behind another's.
+- **A reflection can appear on water the character could not physically see
+  into**, since the water fragment tests only that the plane's image lands
+  there, not that a line of sight exists.

--- a/lib/Voxel3D.lua
+++ b/lib/Voxel3D.lua
@@ -405,7 +405,7 @@ end
 -- water pass reads (see beginWater); it is only ever made if something asks
 -- for one, so a session that never sees a lake never pays for it.
 local function releaseSlot(slotHeld)
-  for _, key in ipairs({ "canvas", "depth", "mirror" }) do
+  for _, key in ipairs({ "canvas", "depth", "mirror", "cast" }) do
     local obj = slotHeld[key]
     if obj and obj.release then pcall(obj.release, obj) end
     slotHeld[key] = nil
@@ -1180,6 +1180,72 @@ function Voxel3D.beginWater(paint)
     return nil
   end
   return held.mirror, held.depth
+end
+
+-- ------- the cast's PLANAR reflection
+--
+-- The other way to get people into the water, and the one that works at the
+-- camera this game is played at.
+--
+-- beginWater paints the cast into the reflection COPY, where the screen-space
+-- march has to go and find it. That works when a ray reaches them, and at a
+-- steep camera it largely does not: the horizon lean aims rays at the
+-- distance, and a sprite is not in the depth buffer anyway, so what a ray
+-- does find is smeared along whatever terrain stands behind the sprite.
+--
+-- This is the other half. The cast is drawn a SECOND time, reflected in the
+-- water plane, into a canvas of its own, and the water shader samples that
+-- canvas at each fragment's own screen position -- which is the right place
+-- to look, because the reflection was drawn to exactly the place a mirror
+-- would put it. There is no offset to tune and no correspondence to keep in
+-- step.
+--
+-- The reflecting is done by VoxelScene, in WORLD space, one card at a time.
+-- Not by mirroring the camera, which is the obvious way and is wrong here: a
+-- character is a billboard leaning back to face the camera, so a mirrored
+-- camera catches it leaning away and lands a foreshortened sliver in the
+-- water. See billboardMatrix, where the position is reflected and the card
+-- is flipped about its own feet instead.
+--
+-- Masking is free. The water shader runs on water fragments and nothing
+-- else, so the reflection is confined to water exactly, with no stencil --
+-- which matters, because DEPTH_FORMATS prefers a depth buffer with no
+-- stencil in it and most drivers hand one over.
+--
+-- COLOUR ONLY, and no depth attachment: what would be tested against is the
+-- world's depth, and this canvas holds a mirrored world that shares none of
+-- it. The water shader's own depth test has already decided which water
+-- fragments survive, and a reflection only ever lands on those.
+--
+-- Returns the canvas, or nil where one could not be made -- in which case
+-- the water draws exactly as it did before this existed.
+function Voxel3D.beginCast()
+  if not (active and canvas and held) then return nil end
+  if not held.cast then
+    local ok, c = PixelCanvas.new(held.w, held.h)
+    if not (ok and c) then return nil end
+    pcall(c.setFilter, c, "nearest", "nearest")
+    pcall(c.setWrap, c, "clamp", "clamp")
+    held.cast = c
+  end
+  if not pcall(love.graphics.setCanvas, held.cast) then
+    pcall(love.graphics.setCanvas, depthTarget())
+    return nil
+  end
+  -- transparent, because the ALPHA is what tells the water shader where the
+  -- reflection actually is; everywhere else it must leave the water alone
+  love.graphics.clear(0, 0, 0, 0)
+  -- nothing to test against on a canvas with no depth
+  love.graphics.setDepthMode("always", false)
+  return held.cast
+end
+
+-- Put the frame back. Safe after a beginCast that failed.
+function Voxel3D.endCast()
+  if not active then return end
+  pcall(love.graphics.setCanvas, depthTarget())
+  pcall(love.graphics.setDepthMode, "lequal", true)
+  love.graphics.setColor(1, 1, 1, 1)
 end
 
 -- Put the frame back: depth reattached, depth test and the scene shader as

--- a/lib/VoxelScene.lua
+++ b/lib/VoxelScene.lua
@@ -273,11 +273,39 @@ end
 -- carries one pose into the other -- the lean eases out as the yaw eases in
 -- -- and cardBlend is zero for every camera that is not the first-person
 -- rig, the battle's placed shot included, so nothing else moves.
+-- While set, billboardMatrix builds every card as its own REFLECTION in the
+-- horizontal plane at this height. Ambient rather than threaded through the
+-- four functions between here and the draw, which is how Voxel3D.glass and
+-- Voxel3D.seams already switch a pass's character.
+local reflectPlane = nil
+
+-- A card is a BILLBOARD, and that is why the reflection cannot simply be the
+-- scene drawn through a mirrored camera.
+--
+-- The card leans back by exactly the camera's pitch so it reads face-on.
+-- Mirror the CAMERA and it leans away instead, and what lands in the water
+-- is a foreshortened sliver rather than a person -- correct for the flat
+-- quad it really is, and useless as a reflection of the character it is
+-- pretending to be. A billboard is a fake that only works from one side, so
+-- reflecting it has to be faked too.
+--
+-- So the POSITION is reflected and the card keeps facing the camera. Its
+-- feet move to the mirrored height (a point on the plane is its own image,
+-- so the waterline still agrees), and the card is flipped about them, which
+-- turns it upside down and takes its texture with it. Same lean, same size,
+-- the right way up for a reflection.
 local function billboardMatrix(px, py, y, mirror)
   local Voxel = V.require("VoxelState")
   local b = FirstPerson.cardBlend()
   local yaw = b > 0 and (FirstPerson.cardYaw(px + 8, py + 8) * b) or 0
   local pitch = (Voxel.angle - math.pi / 2) * (1 - b)
+  if reflectPlane then
+    -- the mesh stands on its own y = 0, so scaling local y by -1 hangs it
+    -- from the anchor instead of standing it on it
+    return Mat4.mul(
+      Mat4.billboard(px, py, 2 * reflectPlane - y, yaw, pitch, mirror),
+      Mat4.scale(1, -1, 1))
+  end
   return Mat4.billboard(px, py, y, yaw, pitch, mirror)
 end
 
@@ -684,7 +712,16 @@ local function drawCast(state, posed, atlasFor)
   Voxel3D.glass(true)
   -- Figures after the walkers, so a player standing in front of the couch
   -- wins the overlap -- the order the flat game draws them in.
+  --
+  -- Left out of a REFLECTION pass: a figure is not a card, it is a mesh in
+  -- its own local space placed by Mat4.figure, so the card flip above does
+  -- not reach it -- and it is a person drawn INTO a piece of furniture,
+  -- indoors, which is not somewhere water is.
   local figPull = billboardPull()
+  if reflectPlane then
+    Voxel3D.seams(true)
+    return
+  end
   eachFigure(state.map, 0, 0, function(mesh, model, caster)
     Voxel3D.draw(mesh, atlasFor(state.map), model, figPull,
                  ShadowMap.snug(caster))
@@ -774,10 +811,35 @@ function VoxelScene.drawWater(draws, cast)
   end
   local plain = not curved
   local reflected = false
+  -- The cast's planar reflection, drawn before the frame is taken apart --
+  -- beginWater rebinds canvases and detaches the depth buffer, and this
+  -- wants the frame intact. Mirrored about the WATER PLANE, read from
+  -- TileShape rather than restated here, so an override in
+  -- data/voxel_heights.lua moves the reflection with the water it belongs
+  -- to. nil where the canvas could not be made, which simply leaves the
+  -- water as it was.
+  -- Gated on depthReadable as well as the row, because the shader that
+  -- COMPOSITES this is the one that needs a readable depth target: without
+  -- it the water falls back to a plain terrain draw, nothing samples the
+  -- canvas, and the whole cast would have been drawn a second time for a
+  -- picture no one reads.
+  local castTex = nil
+  if cast and Water.enabled() and Water.CAST_ALPHA > 0
+     and Voxel3D.depthReadable() then
+    castTex = Voxel3D.beginCast()
+    if castTex then
+      -- cleared unconditionally, so a cast() that throws cannot leave every
+      -- later card in the frame drawn upside down under the pier
+      reflectPlane = (TileShape.heights() or {}).water or 0
+      pcall(cast)
+      reflectPlane = nil
+      Voxel3D.endCast()
+    end
+  end
   local function waterContext(reflect, depth)
     local w, h = Voxel3D.size()
     return {
-      reflect = reflect, depth = depth,
+      reflect = reflect, depth = depth, cast = castTex,
       vp = Voxel3D.vp, eye = Voxel3D.eye, curve = { Voxel3D.curveX or 0,
                                                     Voxel3D.curveZ or 0,
                                                     Voxel3D.curveK or 0 },

--- a/lib/VoxelScene.lua
+++ b/lib/VoxelScene.lua
@@ -301,9 +301,11 @@ local function billboardMatrix(px, py, y, mirror)
   local pitch = (Voxel.angle - math.pi / 2) * (1 - b)
   if reflectPlane then
     -- the mesh stands on its own y = 0, so scaling local y by -1 hangs it
-    -- from the anchor instead of standing it on it
+    -- from the anchor instead of standing it on it. CAST_RAISE lifts the
+    -- anchor off the true mirror toward the surface; see Water.
     return Mat4.mul(
-      Mat4.billboard(px, py, 2 * reflectPlane - y, yaw, pitch, mirror),
+      Mat4.billboard(px, py, 2 * reflectPlane - y + Water.CAST_RAISE,
+                     yaw, pitch, mirror),
       Mat4.scale(1, -1, 1))
   end
   return Mat4.billboard(px, py, y, yaw, pitch, mirror)

--- a/lib/Water.lua
+++ b/lib/Water.lua
@@ -375,6 +375,27 @@ Water.CAST_ALPHA = 0.55
 -- than a few thousandths tears the figure apart rather than disturbing it.
 Water.CAST_WOBBLE = 0.006
 
+-- How far the reflection is lifted from where a true mirror would put it,
+-- in world pixels, toward the surface.
+--
+-- An honest mirror leaves a gap, and surfing is where it shows. Water is a
+-- recessed class and groundAt does not lower what stands on a recessed one,
+-- so a surfing player floats at ground level, two pixels over a surface
+-- drawn at -2. Mirrored, the reflection sits two pixels under it, and the
+-- four between them are open water: correct, and it reads as a reflection
+-- floating loose rather than one belonging to anybody.
+--
+-- Worse than the four, and the reason this is a dial rather than a fix: a
+-- sprite's art does not sit flush with the bottom of its card. Whatever
+-- empty space it carries there appears ABOVE the card upright and BELOW the
+-- anchor flipped, so the visible gap is the geometric one plus twice the
+-- padding, and no amount of correct arithmetic closes it.
+--
+--   0   a true mirror
+--   2   the reflection hangs from the waterline
+--   4   joined at the character's own feet
+Water.CAST_RAISE = 6
+
 -- THE MARCH. Steps are in world pixels and lengthen as they go: near the
 -- surface the reflection needs precision (a shoreline is a few pixels), far
 -- from it reach matters more than accuracy, and a geometric ramp gets both

--- a/lib/Water.lua
+++ b/lib/Water.lua
@@ -357,6 +357,24 @@ Water.WAVE_SLOPE = 3.5
 -- the same tilt on its way past (see LEAN_FROM)
 Water.WAVE_SLOPE_LEAN = 1.5
 
+-- ------- the cast, reflected in the plane rather than marched for
+--
+-- See Voxel3D.beginCast. The cast is drawn a second time through a camera
+-- mirrored about the water plane, and this composites that canvas at each
+-- fragment's OWN screen position, which is exactly where a flat mirror
+-- would put it.
+--
+-- Composited AFTER the fresnel mix rather than into the reflection before
+-- it, and that is deliberate. Fresnel is smallest looked straight down at,
+-- so folding a person into `refl` would fade them out at precisely the
+-- camera this exists to serve -- which is the same mistake the march made
+-- by handing its ray to the horizon lean.
+Water.CAST_ALPHA = 0.55
+-- How far the wave normal drags the lookup, in screen widths. Small: this
+-- ripples a reflection along with the surface carrying it, and much more
+-- than a few thousandths tears the figure apart rather than disturbing it.
+Water.CAST_WOBBLE = 0.006
+
 -- THE MARCH. Steps are in world pixels and lengthen as they go: near the
 -- surface the reflection needs precision (a shoreline is a few pixels), far
 -- from it reach matters more than accuracy, and a geometric ramp gets both
@@ -489,6 +507,20 @@ uniform Image reflectTex;
 uniform LOVE_HIGHP_OR_MEDIUMP Image depthTex;
 uniform float rays;          // 0 = sky only, 1 = march the screen too
 #endif
+
+// The cast, mirrored in the water plane (Voxel3D.beginCast).
+//
+// OUTSIDE the SKY_ONLY guard, unlike the march's own buffers: this is a
+// texture lookup at a fixed uv, not a walk, so the rung that cannot afford
+// to march can still afford to have people in its water.
+//
+// Declared and bound whatever castOn says: an unbound sampler is a
+// driver-dependent crash rather than a fallback, the same reason sunMap is
+// always given something.
+uniform LOVE_HIGHP_OR_MEDIUMP Image castTex;
+uniform float castOn;        // 0 = there is no cast canvas this frame
+uniform float castAlpha;
+uniform float castWobble;
 uniform vec3 lookFlat;       // the way the horizon lies from this camera
 uniform float lean;          // and how far the reflection tilts toward it
 uniform float leanElev;      // the elevation it aims at, in radians
@@ -1084,6 +1116,25 @@ vec4 effect(mediump vec4 color, Image tex, mediump vec2 tc, mediump vec2 sc) {
             + (fresnelCeil - fresnelFloor) * pow(1.0 - ct, fresnelPower);
   vec3 rgb = mix(base, refl, clamp(f, 0.0, 1.0));
 
+  // THE CAST, mirrored in this plane (see CAST_ALPHA). Read at this
+  // fragment's own place on the screen, because that is where the mirrored
+  // camera has already put it -- nothing here has to work out where a
+  // reflection belongs, which is the whole reason this is drawn with a
+  // camera rather than by nudging sprites about.
+  //
+  // The uv is LOVE's own screen size for the same reason the depth test
+  // above uses it: `sc` arrives in canvas pixels, and on a highdpi surface
+  // that is not the same count as `screen`, which is measured in units.
+  //
+  // Dragged by the wave normal so a figure ripples with the surface holding
+  // it rather than lying flat on top of it, and the canvas's ALPHA decides
+  // where there is anything to composite at all.
+  if (castOn > 0.5) {
+    vec2 cuv = sc / love_ScreenSize.xy + n.xz * castWobble;
+    vec4 person = Texel(castTex, cuv);
+    rgb = mix(rgb, person.rgb, clamp(person.a * castAlpha, 0.0, 1.0));
+  }
+
 #ifdef VOXEL_GRID
   rgb *= 1.0 - gridDark * columnSeam(hit, sheet, axis);
 #endif
@@ -1272,6 +1323,17 @@ function Water.begin(ctx, skyOnly)
   local texel = 1 / ShadowMap.res
   send("sunTexel", { texel, texel })
   send("dayTint", Voxel3D.tint or { 1, 1, 1 })
+
+  -- the cast's planar reflection. The sampler is bound whatever happens --
+  -- an unbound one is a driver-dependent crash, not a fallback -- so where
+  -- there is no cast canvas this frame it borrows a texture that certainly
+  -- exists and castOn switches the lookup off. Same shape as sunMap above.
+  local castTex = ctx.cast
+  send("castOn", castTex and 1 or 0)
+  send("castAlpha", Water.CAST_ALPHA)
+  send("castWobble", Water.CAST_WOBBLE)
+  local castBound = castTex or ctx.reflect or Sky.ramp()
+  if castBound then send("castTex", castBound) end
 
   if not skyOnly then send("rays", level >= 2 and 1 or 0) end
   -- the horizon lean, and the direction it leans toward (see Water.lean)

--- a/tests/water_cast_reflection_test.lua
+++ b/tests/water_cast_reflection_test.lua
@@ -24,6 +24,11 @@ local V = {
     id = "BATTLE_ART_VOXEL_FORK",
     options = { get = function() return nil end },
   },
+  -- the SHIPPED heights, not the fallbacks: the water plane this reflection
+  -- is taken in is whatever data/voxel_heights.lua actually says
+  data = function(name)
+    return assert(loadfile(root .. "/data/" .. name .. ".lua"))()
+  end,
 }
 
 local fakes = {
@@ -109,6 +114,55 @@ local _, uy = apply(upright, 0, 10, 0)
 local _, ry = apply(reflected(0, 0, 0), 0, 10, 0)
 T.eq(math.abs(uy - 0), math.abs(ry - (2 * PLANE)),
   "the reflected card is the same height as the upright one")
+
+-- ------- surfing, where the player stands ON the water
+--
+-- The case that cannot be reached without Surf, so it is pinned here
+-- instead. Two facts decide it and both live outside this file:
+--
+--   water is a RECESSED class, so its surface is drawn below ground level
+--   groundAt returns `s.h > 0 and s.h or 0`, so a recessed class does not
+--   lower what stands on it -- a surfing player floats at ground level
+--
+-- Together they put the player a little ABOVE the surface rather than on
+-- it, and the reflection has to answer for that gap rather than pretend it
+-- is not there.
+
+local TileShape = V.require("TileShape")
+local plane = TileShape.heights().water
+
+T.check(plane < 0, "water is recessed below the ground it is cut into")
+-- and it is the number the card section above reflected in, so the two
+-- halves of this file cannot drift apart if the shipped heights change
+T.eq(plane, PLANE, "the shipped water height is the plane the cards use")
+
+-- a surfing player floats at ground level, which is `plane` above the water
+local FLOAT = 0 - plane
+local anchor = 2 * plane - 0
+T.eq(anchor, plane - FLOAT,
+  "the reflection hangs as far below the surface as the player floats above")
+T.check(anchor < plane, "so it is under the water, not standing on it")
+
+-- and the clear water between the two is twice the float, which is honest
+-- mirror geometry rather than a fault: it is what standing above a surface
+-- looks like reflected in it
+T.eq(0 - anchor, 2 * FLOAT,
+  "the gap between feet and reflection is twice the float height")
+
+-- the surf BOB, which pose() puts on the visual y. A mirror moves the
+-- other way, so the two separate and close rather than sliding together.
+local function anchorFor(lift) return 2 * plane - (0 + lift) end
+T.check(anchorFor(2) < anchorFor(0),
+  "bobbing up drives the reflection down")
+T.check(anchorFor(0) < anchorFor(-2),
+  "and bobbing down brings it back up")
+T.eq(anchorFor(0) - anchorFor(2), 2,
+  "by exactly the bob, so the pair open and close at twice its rate")
+
+-- the reflection still hangs downward from wherever the bob leaves it
+local _, bobbedFeet = apply(reflected(0, 0, 1), 0, 0, 0)
+local _, bobbedHead = apply(reflected(0, 0, 1), 0, 10, 0)
+T.check(bobbedHead < bobbedFeet, "upside down at every point of the bob")
 
 -- ------- the shader
 

--- a/tests/water_cast_reflection_test.lua
+++ b/tests/water_cast_reflection_test.lua
@@ -71,6 +71,7 @@ end
 -- camera, then flipped about its own feet.
 
 local Mat4 = V.require("Mat4")
+local Water = V.require("Water")
 
 local function apply(m, x, y, z)
   return m[1] * x + m[2] * y + m[3] * z + m[4],
@@ -90,43 +91,47 @@ T.eq(fz, -4, "and z")
 -- the whole reflected transform, as billboardMatrix composes it
 local PLANE = -2
 local function reflected(px, py, y)
-  return Mat4.mul(Mat4.billboard(px, py, 2 * PLANE - y, 0, 0, false), flip)
+  return Mat4.mul(
+    Mat4.billboard(px, py, 2 * PLANE - y + Water.CAST_RAISE, 0, 0, false),
+    flip)
 end
 
 -- feet: the mesh stands on its own y = 0, so that vertex lands on the anchor
 local _, feet = apply(reflected(0, 0, 6), 0, 0, 0)
-T.eq(feet, 2 * PLANE - 6, "the reflected feet sit at the mirrored height")
+T.eq(feet, 2 * PLANE - 6 + Water.CAST_RAISE,
+  "the reflected feet sit at the mirrored height, lifted by the raise")
 
 -- and the body hangs DOWN from there rather than standing up
 local _, head = apply(reflected(0, 0, 6), 0, 10, 0)
 T.check(head < feet, "the card hangs downward, so it reads upside down")
-T.eq(head, 2 * PLANE - 6 - 10, "by exactly its own height")
+T.eq(head, 2 * PLANE - 6 + Water.CAST_RAISE - 10,
+  "by exactly its own height")
 
 -- a character standing ON the plane is its own reflection's anchor, which is
 -- what keeps the waterline agreeing
 local _, onPlane = apply(reflected(0, 0, PLANE), 0, 0, 0)
-T.eq(onPlane, PLANE, "a card standing on the plane is anchored on it")
+T.eq(onPlane, PLANE + Water.CAST_RAISE,
+  "a card standing on the plane is anchored on it, plus the raise")
 
 -- the flip must not shrink the card: a reflection is the same size as the
 -- thing it reflects, which is the whole reason the camera is not mirrored
 local upright = Mat4.billboard(0, 0, 0, 0, 0, false)
 local _, uy = apply(upright, 0, 10, 0)
 local _, ry = apply(reflected(0, 0, 0), 0, 10, 0)
-T.eq(math.abs(uy - 0), math.abs(ry - (2 * PLANE)),
+T.eq(math.abs(uy - 0), math.abs(ry - (2 * PLANE + Water.CAST_RAISE)),
   "the reflected card is the same height as the upright one")
 
 -- ------- surfing, where the player stands ON the water
 --
 -- The case that cannot be reached without Surf, so it is pinned here
--- instead. Two facts decide it and both live outside this file:
+-- instead. The numbers were measured in a real run rather than assumed:
+-- groundAt returns 0 on a water cell, the surf bob spans -1..0, and the
+-- water plane is -2, so the card's feet are at 0 and the player floats two
+-- pixels over the surface they are sitting on.
 --
---   water is a RECESSED class, so its surface is drawn below ground level
---   groundAt returns `s.h > 0 and s.h or 0`, so a recessed class does not
---   lower what stands on it -- a surfing player floats at ground level
---
--- Together they put the player a little ABOVE the surface rather than on
--- it, and the reflection has to answer for that gap rather than pretend it
--- is not there.
+-- Water is a recessed class and groundAt returns `s.h > 0 and s.h or 0`, so
+-- a recessed class does not lower what stands on it. That float is where
+-- the gap comes from.
 
 local TileShape = V.require("TileShape")
 local plane = TileShape.heights().water
@@ -136,37 +141,46 @@ T.check(plane < 0, "water is recessed below the ground it is cut into")
 -- halves of this file cannot drift apart if the shipped heights change
 T.eq(plane, PLANE, "the shipped water height is the plane the cards use")
 
--- a surfing player floats at ground level, which is `plane` above the water
 local FLOAT = 0 - plane
-local anchor = 2 * plane - 0
-T.eq(anchor, plane - FLOAT,
-  "the reflection hangs as far below the surface as the player floats above")
-T.check(anchor < plane, "so it is under the water, not standing on it")
+T.eq(FLOAT, 2, "a surfing player floats two pixels over the surface")
 
--- and the clear water between the two is twice the float, which is honest
--- mirror geometry rather than a fault: it is what standing above a surface
--- looks like reflected in it
-T.eq(0 - anchor, 2 * FLOAT,
-  "the gap between feet and reflection is twice the float height")
+-- A TRUE mirror doubles that float into open water between the two, which
+-- is correct and looks wrong. CAST_RAISE is what closes it.
+local function anchorFor(lift, raise)
+  return 2 * plane - (0 + lift) + raise
+end
 
--- the surf BOB, which pose() puts on the visual y. A mirror moves the
--- other way, so the two separate and close rather than sliding together.
-local function anchorFor(lift) return 2 * plane - (0 + lift) end
-T.check(anchorFor(2) < anchorFor(0),
+T.eq(anchorFor(0, 0), plane - FLOAT,
+  "an unraised reflection hangs a full float below the surface")
+T.eq(0 - anchorFor(0, 0), 2 * FLOAT,
+  "so the clear water between feet and reflection is twice the float")
+
+-- the raise walks it back up, one world pixel at a time
+T.eq(anchorFor(0, 2), plane, "raised by the float, it hangs from the waterline")
+T.eq(anchorFor(0, 2 * FLOAT), 0,
+  "raised by twice the float, it is joined at the character's own feet")
+T.check(Water.CAST_RAISE >= 2 * FLOAT,
+  "the shipped raise closes the geometric gap for a surfing player")
+
+-- Past that it compensates for the sprite's own bottom padding, which the
+-- card knows nothing about: whatever empty space the art carries under
+-- itself shows once upright and once flipped. That is why the shipped value
+-- is a measured number rather than a derived one.
+
+-- the bob still mirrors, whatever the raise is: a mirror moves the other
+-- way, so the pair open and close rather than sliding together
+T.check(anchorFor(2, Water.CAST_RAISE) < anchorFor(0, Water.CAST_RAISE),
   "bobbing up drives the reflection down")
-T.check(anchorFor(0) < anchorFor(-2),
-  "and bobbing down brings it back up")
-T.eq(anchorFor(0) - anchorFor(2), 2,
+T.eq(anchorFor(0, Water.CAST_RAISE) - anchorFor(2, Water.CAST_RAISE), 2,
   "by exactly the bob, so the pair open and close at twice its rate")
 
--- the reflection still hangs downward from wherever the bob leaves it
+-- and it still hangs downward from wherever the bob leaves it
 local _, bobbedFeet = apply(reflected(0, 0, 1), 0, 0, 0)
 local _, bobbedHead = apply(reflected(0, 0, 1), 0, 10, 0)
 T.check(bobbedHead < bobbedFeet, "upside down at every point of the bob")
 
 -- ------- the shader
 
-local Water = V.require("Water")
 local full = Water._source(false, false)
 local sky = Water._source(false, true)
 

--- a/tests/water_cast_reflection_test.lua
+++ b/tests/water_cast_reflection_test.lua
@@ -1,0 +1,209 @@
+-- The cast's PLANAR reflection: each card reflected in the water plane and
+-- flipped, drawn into a canvas of its own, composited by the water shader at
+-- each fragment's own screen position.
+--
+-- Why not a mirrored CAMERA, which is the obvious way: a character is a
+-- billboard that leans back to face the camera, so a mirrored camera catches
+-- it leaning away and lands a foreshortened sliver in the water. Correct for
+-- the flat quad it really is, useless as a reflection of the person it is
+-- pretending to be. A billboard is a fake that works from one side only, so
+-- reflecting it has to be faked too: reflect the POSITION, keep the card
+-- facing the camera, flip it about its own feet.
+--
+-- What is pinned here is the arithmetic and the wiring, which are the parts
+-- a screenshot cannot check. The LOOK is not testable in this harness.
+
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.modkit")
+local root = os.getenv("DS_MOD_PATH") or "mods/BattleArtVoxelFork"
+
+local loaded = {}
+local V = {
+  mod = {
+    id = "BATTLE_ART_VOXEL_FORK",
+    options = { get = function() return nil end },
+  },
+}
+
+local fakes = {
+  Sky = {
+    ramp = function() return { "ramp" }, 4 end,
+    discRadius = function() return 4 end,
+    discShades = function() return { { 255, 255, 255 } } end,
+    GLOW_REACH = 0.5, MOON_CRATERS = {},
+  },
+  DayNight = {
+    body = function() return nil end,
+    glow = function() return 0, nil end,
+  },
+  ShadowMap = {
+    active = function() return nil end,
+    texture = function() return nil end,
+    uvVP = nil, bias = 0.001, res = 1024,
+  },
+  Voxel3D = {
+    FACE_SHADE = { 0.9, 0.8, 1.0, 1.0, 0.85, 0.95 },
+    SHADOW_ALPHA = 0.5, tint = { 1, 1, 1 },
+  },
+  TerrainAtlas = { _animFrame = function() return 0 end },
+}
+
+function V.require(name)
+  if fakes[name] then return fakes[name] end
+  if loaded[name] then return loaded[name] end
+  local chunk = assert(loadfile(root .. "/lib/" .. name .. ".lua"))
+  local module = chunk(V)
+  loaded[name] = module
+  return module
+end
+
+-- ------- the reflected card
+--
+-- A card is a billboard leaning back to face the camera, so a mirrored
+-- CAMERA catches it leaning away and lands a foreshortened sliver in the
+-- water. The position is reflected instead and the card kept facing the
+-- camera, then flipped about its own feet.
+
+local Mat4 = V.require("Mat4")
+
+local function apply(m, x, y, z)
+  return m[1] * x + m[2] * y + m[3] * z + m[4],
+         m[5] * x + m[6] * y + m[7] * z + m[8],
+         m[9] * x + m[10] * y + m[11] * z + m[12]
+end
+
+-- the flip a reflected card carries: local y negated, so the mesh hangs from
+-- its anchor instead of standing on it, and its texture comes with it
+local flip = Mat4.scale(1, -1, 1)
+local _, fy = apply(flip, 0, 5, 0)
+T.eq(fy, -5, "the card flip negates local height")
+local fx, _, fz = apply(flip, 3, 5, -4)
+T.eq(fx, 3, "and leaves x alone")
+T.eq(fz, -4, "and z")
+
+-- the whole reflected transform, as billboardMatrix composes it
+local PLANE = -2
+local function reflected(px, py, y)
+  return Mat4.mul(Mat4.billboard(px, py, 2 * PLANE - y, 0, 0, false), flip)
+end
+
+-- feet: the mesh stands on its own y = 0, so that vertex lands on the anchor
+local _, feet = apply(reflected(0, 0, 6), 0, 0, 0)
+T.eq(feet, 2 * PLANE - 6, "the reflected feet sit at the mirrored height")
+
+-- and the body hangs DOWN from there rather than standing up
+local _, head = apply(reflected(0, 0, 6), 0, 10, 0)
+T.check(head < feet, "the card hangs downward, so it reads upside down")
+T.eq(head, 2 * PLANE - 6 - 10, "by exactly its own height")
+
+-- a character standing ON the plane is its own reflection's anchor, which is
+-- what keeps the waterline agreeing
+local _, onPlane = apply(reflected(0, 0, PLANE), 0, 0, 0)
+T.eq(onPlane, PLANE, "a card standing on the plane is anchored on it")
+
+-- the flip must not shrink the card: a reflection is the same size as the
+-- thing it reflects, which is the whole reason the camera is not mirrored
+local upright = Mat4.billboard(0, 0, 0, 0, 0, false)
+local _, uy = apply(upright, 0, 10, 0)
+local _, ry = apply(reflected(0, 0, 0), 0, 10, 0)
+T.eq(math.abs(uy - 0), math.abs(ry - (2 * PLANE)),
+  "the reflected card is the same height as the upright one")
+
+-- ------- the shader
+
+local Water = V.require("Water")
+local full = Water._source(false, false)
+local sky = Water._source(false, true)
+
+-- The cast uniforms must sit OUTSIDE the SKY_ONLY guard: this is a lookup,
+-- not a march, so the rung that cannot afford to walk the screen can still
+-- have people in its water.
+--
+-- Checked by POSITION, not by searching the SKY variant for the text.
+-- _source returns the guard intact and the GLSL preprocessor resolves it at
+-- compile time, so both variants carry the same string and a text search
+-- proves nothing. What matters is landing past the #endif that closes the
+-- block `rays` lives in. (The compile harness is what proves the SKY variant
+-- actually builds.)
+local raysAt = full:find("uniform float rays;", 1, true)
+T.check(raysAt ~= nil, "the march's own rung uniform is still declared")
+local guardEnd = full:find("#endif", raysAt, true)
+T.check(guardEnd ~= nil, "and the guard around it still closes")
+
+for _, name in ipairs({ "castOn", "castAlpha", "castWobble" }) do
+  local at = full:find("uniform float " .. name .. ";", 1, true)
+  T.check(at ~= nil, "the shader declares " .. name)
+  T.check(at > guardEnd,
+    name .. " is declared outside the SKY_ONLY guard")
+end
+local texAt = full:find("uniform LOVE_HIGHP_OR_MEDIUMP Image castTex;", 1, true)
+T.check(texAt ~= nil, "the sampler is declared")
+T.check(texAt > guardEnd, "and it is outside the guard too")
+-- the two variants differ only by the define the preprocessor acts on
+T.check(sky:find("#define SKY_ONLY 1", 1, true) ~= nil,
+  "the SKY variant is selected by a define")
+T.check(full:find("#define SKY_ONLY", 1, true) == nil,
+  "and the FULL variant is not")
+
+-- composited AFTER the fresnel mix, not into the reflection before it:
+-- fresnel is smallest looked straight down at, which is the camera this
+-- feature exists for
+local mixAt = full:find("vec3 rgb = mix(base, refl", 1, true)
+local castAt = full:find("if (castOn > 0.5)", 1, true)
+T.check(mixAt ~= nil, "the fresnel mix is still there")
+T.check(castAt ~= nil, "the cast is composited")
+T.check(castAt > mixAt, "and it lands AFTER the fresnel mix, not inside it")
+
+T.check(full:find("sc / love_ScreenSize.xy + n.xz * castWobble", 1, true) ~= nil,
+  "read at the fragment's own screen place, dragged by the wave normal")
+T.check(full:find("person.a * castAlpha", 1, true) ~= nil,
+  "the canvas's alpha decides where there is anything to composite")
+
+-- ------- the uniforms reach the shader
+
+local sent = {}
+local fakeShader = { send = function(_, name, ...) sent[name] = { ... } end }
+Water.shader = function() return fakeShader end
+
+love.graphics = love.graphics or {}
+love.graphics.setShader = love.graphics.setShader or function() end
+love.graphics.setColor = love.graphics.setColor or function() end
+
+local function begin(castTex)
+  sent = {}
+  return Water.begin({
+    vp = {}, eye = { 0, 8, 0 }, curve = { 0, 0, 0 },
+    screen = { 320, 288 }, cell = 1, fov = 1,
+    reflect = { "reflect" }, depth = { "depth" }, cast = castTex,
+    lookFlat = { 0, 0, -1 }, descent = 0.4,
+  }, false)
+end
+
+T.check(begin({ "cast" }), "the pass starts")
+T.eq(sent.castOn[1], 1, "castOn is set when there is a cast canvas")
+T.eq(sent.castAlpha[1], Water.CAST_ALPHA,
+  "the strength is the constant, not a copy kept in step by hand")
+T.eq(sent.castWobble[1], Water.CAST_WOBBLE, "and so is the wobble")
+T.same(sent.castTex[1], { "cast" }, "the canvas itself is bound")
+
+-- and with no cast canvas the sampler is STILL bound: an unbound sampler is
+-- a driver-dependent crash, not a fallback
+T.check(begin(nil), "the pass still starts without a cast canvas")
+T.eq(sent.castOn[1], 0, "castOn is clear when there is no cast canvas")
+T.check(sent.castTex ~= nil,
+  "but the sampler is bound anyway, so the draw cannot fault on it")
+
+-- ------- the canvas is owned, not leaked
+
+local vox = io.open(root .. "/lib/Voxel3D.lua")
+local voxSrc = vox:read("*a")
+vox:close()
+T.check(voxSrc:find('{ "canvas", "depth", "mirror", "cast" }', 1, true) ~= nil,
+  "releaseSlot frees the cast canvas with the rest of the slot")
+T.check(voxSrc:find("function Voxel3D.beginCast", 1, true) ~= nil,
+  "the pass has an opening")
+T.check(voxSrc:find("function Voxel3D.endCast", 1, true) ~= nil,
+  "and a close that puts the camera back")
+
+T.finish("water cast reflection")


### PR DESCRIPTION
Adds a reflection of the player and NPCs in water.

The cast already gets painted into the reflection copy for the screen-space
march to pick up, but you basically never see it at a normal camera. The
horizon lean points the rays at the horizon, and sprites aren't in the depth
buffer, so what does land is smeared across whatever terrain is behind them.

This draws the cast a second time, reflected in the water plane, into its own
canvas, and the water shader samples it at each fragment's own screen
position. Masking is free since the water shader only runs on water fragments
anyway, which is handy because there's no stencil available (DEPTH_FORMATS
asks for plain depth24 first).

Worth knowing if you're reading the diff: it reflects each card's position
rather than mirroring the camera. Mirroring the camera seems like the obvious
approach, but the cards are billboards leaning to face the camera, so through
a mirrored one they lean away and you get a squashed sliver. There's a
writeup in docs/WATER_CAST_REFLECTION.md, happy to drop that file if you'd
rather it just lived here.

Costs a full size canvas per slot, only allocated once there's water on
screen, plus a second draw of each visible character. Skipped entirely unless
the water row is on and the depth target is readable, and it falls back to
current behaviour if the canvas can't be created. CAST_ALPHA, CAST_WOBBLE and
CAST_RAISE are there for tuning.

Tested on Pallet, Vermilion and Cerulean, on foot and surfing. Added
tests/water_cast_reflection_test.lua, and compiled all four shader variants
through LOVE since a syntax error there silently falls back to flat water.
