### PR TITLE
Fix the water shader failing to build on Mali GPUs

### DIFF
--- a/lib/Water.lua
+++ b/lib/Water.lua
@@ -988,15 +988,36 @@ vec2 waveUV(vec2 tc, vec2 col) {
   return org + (mod(col, 8.0) + 0.5) * texel;
 }
 
-// The float parameters are pinned to mediump BECAUSE the stage default is
-// not: LOVE's own header forward-declares effect() under its default, and
-// at least one mobile compiler (Samsung's Xclipse, in so many words) holds
-// that a definition whose parameter precisions differ from its prototype's
-// is a second function of the same name, and refuses the pair. The params
-// can afford it -- the colour is a colour, and tc/sc arrived through
-// LOVE's mediump plumbing whatever this signature says -- and the maths
-// below runs on the stage default the moment the values touch a local.
-vec4 effect(mediump vec4 color, Image tex, mediump vec2 tc, mediump vec2 sc) {
+// The float parameters are pinned BECAUSE the stage default is not: LOVE's
+// own header forward-declares effect() under its default, and at least one
+// mobile compiler (Samsung's Xclipse, in so many words) holds that a
+// definition whose parameter precisions differ from its prototype's is a
+// second function of the same name, and refuses the pair. The params can
+// afford it -- the colour is a colour, and tc/sc arrived through LOVE's
+// mediump plumbing whatever this signature says -- and the maths below runs
+// on the stage default the moment the values touch a local.
+//
+// THE RETURN TYPE IS PINNED THE SAME WAY, and for a while it was not, which
+// is what put this whole pass on the flat fallback on Mali. The stage lifts
+// its float default to highp a few hundred lines up, so a bare return type
+// is a HIGHP one, against a prototype whose default return is mediump --
+// and Mali's compiler calls that what it is:
+//
+//   0:563: S0023: Function 'effect' redeclared with a different
+//   precision qualifier on the return type
+//
+// Matching the parameters is not enough on its own; the return has to agree
+// too. Read off a Pixel 9 (Mali-G715) in logcat, which is why it is quoted
+// rather than described.
+//
+// WHICH precision it must be is not ours to know, so it is a define the Lua
+// side fills in, and Water.shader compiles the pinned form first and the
+// bare one only if that is refused. LOVE 12 forward-declares effect() under
+// a different default, and pins that match 11's prototype are the mismatch
+// there -- the same refusal from the other side. Whichever prototype a
+// runtime brought, one of the two agrees with it.
+EFFECT_PREC vec4 effect(EFFECT_PREC vec4 color, Image tex, EFFECT_PREC vec2 tc,
+                        EFFECT_PREC vec2 sc) {
   // THE DEPTH TEST, done here because the buffer that would have done it is
   // detached for the length of this pass so it can be READ (see the header).
   // Same comparison, same buffer, same result: a building in front of a pond
@@ -1212,13 +1233,19 @@ end
 
 Water._trainSource = trainSource       -- named for the suite
 
-local function source(grid, skyOnly)
+-- `bare` leaves effect()'s precision qualifiers off entirely, for a runtime
+-- whose forward declaration of it carries no explicit precision. See the
+-- prototype's own comment: one of the two forms agrees with any given
+-- runtime, and which one is not knowable from here.
+local function source(grid, skyOnly, bare)
   local src = SHADER_SRC:gsub("//@CRATERS", (craterSource():gsub("%%", "%%%%")))
   src = src:gsub("//@TRAINS", (trainSource():gsub("%%", "%%%%")))
   local head = ("#define RAY_STEPS %d\n#define RAY_REFINE %d\n"
                 .. "#define WAVE_STEPS %d\n#define WAVE_STRIDE %.1f\n")
     :format(Water.RAY_STEPS, Water.RAY_REFINE, Water.WAVE_STEPS,
             Water.WAVE_STRIDE)
+  head = head .. (bare and "#define EFFECT_PREC\n"
+                        or "#define EFFECT_PREC mediump\n")
   if grid then head = head .. "#define VOXEL_GRID 1\n" end
   if skyOnly then head = head .. "#define SKY_ONLY 1\n" end
   return head .. src
@@ -1240,9 +1267,17 @@ function Water.shader(grid, skyOnly)
   local family = skyOnly and shaders.sky or shaders.full
   if family[grid] == nil then
     if not (love.graphics and love.graphics.newShader) then
-      shaders[grid] = false
+      family[grid] = false
     else
       local ok, sh = pcall(love.graphics.newShader, source(grid, skyOnly))
+      if not ok then
+        -- The pinned prototype was the wrong one for this runtime, and the
+        -- bare one is the only other shape there is. A driver that refuses
+        -- both was never going to draw this water anyway.
+        local bareOk, bareSh = pcall(love.graphics.newShader,
+                                     source(grid, skyOnly, true))
+        if bareOk then ok, sh = bareOk, bareSh end
+      end
       if not ok and V and V.mod and V.mod.log then
         -- once, where it can be read: the fallback is flat water, which is
         -- easy to look at and impossible to diagnose without this line

--- a/tests/water_effect_precision_test.lua
+++ b/tests/water_effect_precision_test.lua
@@ -1,0 +1,135 @@
+-- effect()'s precision qualifiers, which decide whether this mod has water
+-- at all on a Mali GPU.
+--
+-- LOVE forward-declares effect() in its own header, under its own default
+-- precision. A definition whose qualifiers differ from that declaration is,
+-- to an ES compiler, a second function of the same name. It refuses the
+-- pair, the shader does not build, and Water.shader falls back to flat
+-- water -- quietly, by design, and indistinguishably from the row being
+-- switched off.
+--
+-- The parameters were pinned for this reason already. THE RETURN TYPE WAS
+-- NOT, and that is the whole bug: the pixel stage lifts its float default to
+-- highp a few hundred lines above effect(), so a bare return type is a highp
+-- one against a mediump-default prototype. Read off a Pixel 9 (Mali-G715)
+-- in logcat:
+--
+--   water shader did not compile: Cannot compile pixel shader code:
+--   0:563: S0023: Function 'effect' redeclared with a different
+--   precision qualifier on the return type -- lakes draw flat
+--
+-- Which precision is correct is not knowable from here: LOVE 12 declares it
+-- under a different default, where a pin that matches 11 is the mismatch.
+-- So both forms are generated and Water.shader tries the pinned one first.
+
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.modkit")
+local root = os.getenv("DS_MOD_PATH") or "mods/BattleArtVoxelFork"
+
+local loaded = {}
+local V = {
+  mod = {
+    id = "BATTLE_ART_VOXEL_FORK",
+    options = { get = function() return nil end },
+  },
+}
+
+local fakes = {
+  Sky = {
+    ramp = function() return nil, 0 end,
+    discRadius = function() return 4 end,
+    discShades = function() return { { 255, 255, 255 } } end,
+    GLOW_REACH = 0.5, MOON_CRATERS = {},
+  },
+  DayNight = { body = function() return nil end,
+               glow = function() return 0, nil end },
+  ShadowMap = { active = function() return nil end,
+                texture = function() return nil end,
+                uvVP = nil, bias = 0.001, res = 1024 },
+  Voxel3D = { FACE_SHADE = { 0.9, 0.8, 1.0, 1.0, 0.85, 0.95 },
+              SHADOW_ALPHA = 0.5, tint = { 1, 1, 1 } },
+  TerrainAtlas = { _animFrame = function() return 0 end },
+}
+
+function V.require(name)
+  if fakes[name] then return fakes[name] end
+  if loaded[name] then return loaded[name] end
+  local chunk = assert(loadfile(root .. "/lib/" .. name .. ".lua"))
+  local module = chunk(V)
+  loaded[name] = module
+  return module
+end
+
+local Water = V.require("Water")
+
+-- ------- the return type is qualified by the same define as the params
+
+local pinned = Water._source(false, false, false)
+local bare = Water._source(false, false, true)
+
+-- the signature must not carry a hardcoded qualifier anywhere: every slot,
+-- the return included, moves together or the pair cannot match a prototype
+T.check(pinned:find("EFFECT_PREC vec4 effect(EFFECT_PREC vec4 color", 1, true)
+        ~= nil, "the return type and the first parameter share the define")
+T.check(pinned:find("vec4 effect(mediump vec4 color", 1, true) == nil,
+  "no qualifier is baked into the signature any more")
+
+-- and every parameter, so nothing is left on the stage default by accident
+local sig = pinned:match("EFFECT_PREC vec4 effect%b()")
+T.check(sig ~= nil, "the signature is found")
+local slots = 0
+for _ in sig:gmatch("EFFECT_PREC") do slots = slots + 1 end
+T.eq(slots, 4, "return plus colour, tc and sc are all qualified together")
+T.check(sig:find("Image tex", 1, true) ~= nil,
+  "the sampler is left alone, since samplers do not take a float precision")
+
+-- ------- both forms are generated
+
+T.check(pinned:find("#define EFFECT_PREC mediump", 1, true) ~= nil,
+  "the pinned form defines the qualifier as mediump")
+T.check(bare:find("#define EFFECT_PREC\n", 1, true) ~= nil,
+  "and the bare form defines it away entirely")
+T.check(bare:find("#define EFFECT_PREC mediump", 1, true) == nil,
+  "the bare form is not merely the pinned one with extra text")
+
+-- the two differ ONLY in that define: a fallback that changed anything else
+-- would be a second shader to reason about rather than the same one
+T.eq(pinned:gsub("#define EFFECT_PREC mediump\n", "#define EFFECT_PREC\n"),
+     bare,
+     "pinned and bare are the same shader under a different qualifier")
+
+-- ------- the fallback is actually reachable
+
+-- Water.shader must try the bare form when the pinned one is refused, or
+-- generating it buys nothing. Driven with a newShader that refuses the
+-- pinned source the way a Mali compiler does.
+local seen = {}
+local realNewShader = love.graphics and love.graphics.newShader
+love.graphics = love.graphics or {}
+love.graphics.newShader = function(src)
+  seen[#seen + 1] = src:find("#define EFFECT_PREC mediump", 1, true)
+                    and "pinned" or "bare"
+  if seen[#seen] == "pinned" then
+    error("S0023: Function 'effect' redeclared with a different precision"
+          .. " qualifier on the return type", 0)
+  end
+  return { send = function() end }
+end
+
+Water.invalidate()
+local sh = Water.shader(false, false)
+T.check(sh ~= nil, "a refusal of the pinned form still yields a shader")
+T.same(seen, { "pinned", "bare" },
+  "the pinned form is tried first and the bare one only after it is refused")
+
+-- and a driver that refuses BOTH falls back to flat water rather than erroring
+love.graphics.newShader = function() error("no", 0) end
+Water.invalidate()
+T.eq(Water.shader(false, false), nil,
+  "refusing both leaves no shader, which is the flat fallback")
+
+love.graphics.newShader = realNewShader
+Water.invalidate()
+
+T.finish("water effect precision")


### PR DESCRIPTION
The water shader has never built on Mali, and it fails in a way you can't
see: the pass falls back to flat water quietly and by design, which looks
exactly like the WATER row being switched off. I only found it because I
went looking for an Android gate that doesn't exist in this fork.

From logcat on a Pixel 9 (Mali-G715):

    water shader did not compile: Cannot compile pixel shader code:
    0:563: S0023: Function 'effect' redeclared with a different
    precision qualifier on the return type -- lakes draw flat

LOVE forward-declares effect() under its own default precision, and an ES
compiler treats a definition whose qualifiers differ from that declaration as
a different function. The parameters were already pinned for that exact
reason, but the return type wasn't, and since the pixel stage lifts its float
default to highp a few hundred lines further up, the bare return was highp
against a mediump-default prototype. Matching the parameters isn't enough on
its own.

Which precision is right isn't knowable from the shader, since LOVE 12
declares effect() under a different default and a pin matching 11 is the
mismatch there. So it's a define the Lua side fills in, and Water.shader
tries the pinned form first and the bare one only if that's refused.

I think the reason this survived is that the existing Android work in this
shader was done on a Galaxy Z Fold 7, which accepts the mismatched pair.
Mali doesn't.

Confirmed on the device: shader builds, water reflects, S0023 gone from
logcat. Added tests/water_effect_precision_test.lua, which pins the
signature and drives Water.shader with a newShader that refuses the pinned
source the way Mali does, so the fallback is actually exercised rather than
just generated. Also compiled all eight variants (pinned and bare, with and
without the grid and sky defines) through LOVE on desktop.

One unrelated thing in the same function: `shaders[grid] = false` should be
`family[grid] = false`, it was writing to the wrong table so the
no-love.graphics branch never cached. Only reachable headless. Happy to pull
it out if you'd rather it was separate.
