### PR TITLE
Cave ladders render as ladders instead of staircases

### DIFF
--- a/data/voxel_heights.lua
+++ b/data/voxel_heights.lua
@@ -483,9 +483,9 @@ return {
     -- underwater, and the only class in this file that goes negative is
     -- `water` (-2), which exists to cut the overworld's shoreline lip.
     -- It is deliberately NOT used anywhere in this entry.  The one thing
-    -- that does reach below the datum is the DOWN ladder's stairwell,
-    -- which is a hole on purpose: it is the shaft to the floor below,
-    -- and no walkable surface is drawn in it.
+    -- that does reach below the datum is the DOWN ladder's shaft, which
+    -- is a hole on purpose: it is the way to the floor below, and no
+    -- walkable surface is drawn in it.
     --
     -- What the detector made of it: the rock EDGES towered.  A shelf's
     -- side is drawn as a cap over a run of face tiles over a corner
@@ -607,7 +607,7 @@ return {
       ground = { 32, 33, 42,       -- $20/$21/$2A, the dark lower floor
                  20,               -- $14, the surfable cave water
                  47, 34 },         -- $2F over $22, the drop hole
-      -- ---- 0 to 16: the ladders, the caves' real staircases ----
+      -- ---- 16: the ladders ----
       --
       -- Both ladder graphics are drawn from above as a shaft with two
       -- rails and rungs between them, and which one is which is not a
@@ -621,24 +621,40 @@ return {
       -- to daylight).  $08 is the ladder DOWN, $0A the ladder UP: 77
       -- cells, no exceptions.
       --
-      -- So they take the two classes that MOVE between floors.  $0A
-      -- becomes a rising flight -- four real steps climbing 0 -> 16, the
-      -- height of the rock band it disappears into -- and $08 becomes an
-      -- excavated stairwell, four steps descending below the floor into
-      -- a dark opening.  East for both: the ladder art is symmetric
-      -- about its own centre line so the drawing does not choose a side,
-      -- the cell's east neighbour is the closed (rock) side more often
-      -- than its west, and the rest of this profile's staircases
-      -- (REDS_HOUSE_1, UNDERGROUND) climb east too.  The flight's treads
-      -- land one rung apiece, which is as close to a drawn ladder as
-      -- stepped geometry gets.
+      -- These were `stair_e` / `stair_down_e`, and the note here used to
+      -- concede that a four-step flight was "as close to a drawn ladder as
+      -- stepped geometry gets".  That was the bug: a staircase runs along
+      -- an AXIS, so the pin threw a stepped wedge across a cell whose
+      -- drawing is a ladder lying in it, and in a cave you got stairs.
       --
-      -- All four tiles of each cell are listed, the way REDS_HOUSE_1
-      -- lists its flight: buildStairs anchors on the cell's TOP-LEFT
-      -- tile ($08 / $0A) and claims the other three, but pinning them
-      -- too keeps them out of the region flood and the door fold.
-      stair_e = { 10, 11, 26, 27 },        -- $0A/$0B over $1A/$1B, UP
-      stair_down_e = { 8, 9, 24, 25 },     -- $08/$09 over $18/$19, DOWN
+      -- `ladder` is a STANDEE POOL -- the same per-pixel voxelization
+      -- `billboard`, `post`, `signpost` and `bike` go through, where the
+      -- drawing stands up and its pixels become voxels.  There is no
+      -- ladder-specific geometry anywhere; the class carries its own name
+      -- only so this file reads honestly and so the pool is its own
+      -- (Structures' PINNED_DEPTH gives it 2, the `bike` figure: what a
+      -- ladder and a bicycle have in common is that both are mostly the
+      -- air inside them, and a fatter pool closes that off).
+      --
+      -- Standing the drawing up is the whole trick, and it is free: the
+      -- art is a shaft seen from above, so rotating its depth axis into
+      -- height already gives a ladder ELEVATION -- rails left and right,
+      -- rungs across.
+      --
+      -- ONE CLASS FOR BOTH GRAPHICS, and that is a real concession.  The
+      -- warp table separates them cleanly, but the standee path has no
+      -- notion of a hole: it stands a drawing on the floor plane and does
+      -- nothing else.  So a descending ladder renders standing up like a
+      -- climbing one, where the old pin at least excavated a stairwell.
+      -- Splitting them again needs geometry the shared object pipeline
+      -- does not build, so the up/down distinction is recorded here in
+      -- prose rather than in two classes that would render identically.
+      --
+      -- All eight tiles are listed: the cluster carve claims what it
+      -- covers, and pinning the rest keeps them out of the region flood
+      -- and the door fold.
+      ladder = { 10, 11, 26, 27,           -- $0A/$0B over $1A/$1B, UP
+                 8, 9, 24, 25 },           -- $08/$09 over $18/$19, DOWN
       -- ---- 3: the boulder switches ----
       --
       -- Victory Road's four plates ($2B/$2C over $2D/$2E, on 1F, 2F and

--- a/lib/Structures.lua
+++ b/lib/Structures.lua
@@ -81,7 +81,13 @@ local OBJECT_DEPTH = 6             -- voxel thickness of a detected prop
 -- space is the drawing, and at the 5 voxels `prop` gives, the side faces
 -- of neighbouring strokes close every gap in it off-axis
 local PINNED_DEPTH = { billboard = 10, prop = 5, stool = 10, cutout = 1,
-                       console = 10, post = 6, signpost = 2, bike = 2 }
+                       console = 10, post = 6, signpost = 2, bike = 2,
+                       -- the caves' ladders, on the `bike` reasoning: what a
+                       -- ladder and a bicycle have in common is that both are
+                       -- mostly the air inside them, and a fatter pool closes
+                       -- that off.  Its own pool rather than sharing one, so a
+                       -- ladder never clusters with a bicycle beside it
+                       ladder = 2 }
 
 local MAX_ROWS = 6                 -- volume height cap: 48px
 

--- a/lib/TileShape.lua
+++ b/lib/TileShape.lua
@@ -117,6 +117,12 @@ local FALLBACK_HEIGHTS = {
   stair_w = 16,
   stair_down_e = 16,
   stair_down_w = 16,
+  -- the caves' ladders.  A standee pool like `bike` and `signpost` -- the
+  -- drawing stands up and voxelizes per pixel -- with its own name so the
+  -- profile reads honestly and the depth is its own (Structures'
+  -- PINNED_DEPTH).  NOT a staircase: pinning these cells `stair_e` threw a
+  -- four-step flight across them, which is the bug this replaces
+  ladder = 16,
 }
 
 -- class -> how the mesher draws it (see the header). The last three are
@@ -206,6 +212,7 @@ local ART = {
   stair_w = "stair",
   stair_down_e = "stair",
   stair_down_w = "stair",
+  ladder = "billboard",
 }
 
 local spec = nil          -- the loaded data file, or false when absent

--- a/tests/cave_ladder_test.lua
+++ b/tests/cave_ladder_test.lua
@@ -1,0 +1,154 @@
+-- The cave ladders must be ladders, not staircases.
+--
+-- Gen 1 draws both cave ladder graphics from ABOVE, as a shaft with two
+-- rails and rungs between them, and the warp table says which is which:
+-- across all nineteen cave maps every one of the 37 $08 cells warps to a
+-- lower floor and every one of the 40 $0A cells to a higher one, 77 cells
+-- with no exceptions.
+--
+-- They used to be pinned `stair_e` / `stair_down_e`.  A staircase runs
+-- along an AXIS, so that threw a four-step stepped wedge across a cell
+-- whose drawing is a ladder lying in it -- the profile's own note conceded
+-- the flight was only "as close to a drawn ladder as stepped geometry
+-- gets".  They are a standee pool now: the same per-pixel object pass that
+-- builds signs, posts and bicycles stands the drawing up and voxelizes it.
+--
+-- There is no ladder-specific builder, by design, so the whole fix is
+-- vocabulary and a pin -- which is exactly what can be silently undone.
+-- A pin naming a class TileShape does not know is DEAD (heights() drops it
+-- and the tile falls through to detection saying nothing), and an `art`
+-- that is not "billboard" would route these cells to the box builder and
+-- render a wall wearing ladder art.  Both are checked here.
+--
+--   DS_MOD_PATH=mods/BattleArtVoxelFork \
+--     luajit mods/BattleArtVoxelFork/tests/cave_ladder_test.lua
+
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.harness")
+local MOD_PATH = os.getenv("DS_MOD_PATH") or "mods/DramaticShapeVoxelMod"
+local ROOT = os.getenv("DS_REPO_ROOT") or "."
+local base = ROOT .. "/" .. MOD_PATH
+local modules, dataFiles = {}, {}
+local V = {}
+function V.require(name)
+  if modules[name] ~= nil then return modules[name] end
+  local value = assert(loadfile(base .. "/lib/" .. name .. ".lua"))(V)
+  modules[name] = value
+  return value
+end
+function V.data(name)
+  if dataFiles[name] ~= nil then return dataFiles[name] end
+  local value = assert(loadfile(base .. "/data/" .. name .. ".lua"))(V)
+  dataFiles[name] = value
+  return value
+end
+
+local TileShape = V.require("TileShape")
+local Structures = V.require("Structures")
+local spec = V.data("voxel_heights")
+
+-- PINNED_DEPTH is a file local, and the function that reads it is a local
+-- too, so no exported function closes over it directly -- an exported one
+-- closes over the LOCAL FUNCTION, which closes over the table.  Walk the
+-- upvalue graph rather than naming a function that happens to reach it
+-- today, and identify the table by its shape so a rename does not blind
+-- the check.
+local function findDepthTable(root)
+  local seen = {}
+  local function walk(fn, depth)
+    if depth > 4 or seen[fn] then return nil end
+    seen[fn] = true
+    for i = 1, 200 do
+      local name, value = debug.getupvalue(fn, i)
+      if not name then break end
+      if type(value) == "table" and type(value.bike) == "number"
+         and type(value.billboard) == "number" then
+        return value
+      end
+      if type(value) == "function" then
+        local hit = walk(value, depth + 1)
+        if hit then return hit end
+      end
+    end
+    return nil
+  end
+  for _, v in pairs(root) do
+    if type(v) == "function" then
+      local hit = walk(v, 1)
+      if hit then return hit end
+    end
+  end
+  return nil
+end
+
+-- ---- the class exists and is a standee ----
+
+local heights = TileShape.heights()
+T.eq(heights.ladder, 16, "a ladder stands the height of the rock band")
+
+local cavern = spec.tilesets.CAVERN
+T.eq(table.concat(cavern.ladder or {}, ","), "10,11,26,27,8,9,24,25",
+  "both ladder graphics pin `ladder`: $0A/$0B over $1A/$1B (the cells that "
+  .. "warp UP) and $08/$09 over $18/$19 (the ones that warp DOWN)")
+T.check(cavern.stair_e == nil and cavern.stair_down_e == nil,
+  "and nothing in the caves is pinned to a staircase any more")
+
+-- ---- it reaches the per-pixel object pass ----
+
+local shapes = TileShape.forMap({
+  tileset = { id = "CAVERN", image = "gfx/tilesets/ds_cave.png",
+              tilesPerRow = 16, imageWidth = 128, imageHeight = 48,
+              blocks = {}, grassTile = -1 },
+})
+for _, tile in ipairs({ 10, 11, 26, 27, 8, 9, 24, 25 }) do
+  local s = shapes[tile]
+  T.check(s ~= nil and s.class == "ladder",
+    ("tile %d resolves to `ladder`"):format(tile))
+  T.check(s ~= nil and s.art == "billboard",
+    ("tile %d reaches the per-pixel object pass, not the box builder")
+    :format(tile))
+  T.check(s ~= nil and s.authored == true,
+    ("tile %d is authored, so detection cannot overrule it"):format(tile))
+  T.eq(s and s.h, 16, ("tile %d stands the full rock band"):format(tile))
+end
+
+-- ---- and it carves at the thickness that keeps the rungs apart ----
+
+-- A ladder is mostly the air between its rungs, and that negative space is
+-- what makes it read as a ladder from anywhere but dead-on.  At the 10 the
+-- default standee pool gives, the side faces of neighbouring rungs close
+-- every gap off-axis and the drawing silts up into a plate.  Two is the
+-- `bike` figure and it is here for the same reason a bicycle needs it.
+local depth = findDepthTable(Structures)
+T.check(depth ~= nil, "the standee depth table is reachable to check")
+if depth then
+  T.eq(depth.ladder, 2, "a ladder carves two voxels thick, like `bike`")
+end
+
+-- ---- no dead pins anywhere in the profile ----
+
+-- This has already cost this profile once: Celadon's four staircases were
+-- pinned onto door tiles and silently did nothing.  A tileset entry holds
+-- class pins alongside its own settings (`heights`, `figures`,
+-- `when_above`, ...), and the two are told apart by SHAPE rather than by a
+-- list of reserved names a later setting would fall off of -- a class pin
+-- is an array of tile NUMBERS, every setting is keyed by tile or is an
+-- array of tables.
+local dead = {}
+for setId, entry in pairs(spec.tilesets) do
+  for class, tiles in pairs(entry) do
+    if type(tiles) == "table" and type(tiles[1]) == "number"
+       and heights[class] == nil then
+      dead[#dead + 1] = setId .. "." .. class
+    end
+  end
+end
+table.sort(dead)
+T.eq(#dead, 0, "every class the profile pins is one TileShape resolves: "
+  .. table.concat(dead, ", "))
+
+if T.failures > 0 then
+  error(("cave ladders: %d failure(s)"):format(T.failures))
+end
+print(("PASS cave ladders (%d checks)"):format(T.checks))

--- a/tests/ladder_shots.lua
+++ b/tests/ladder_shots.lua
@@ -1,0 +1,150 @@
+-- Driver: the cave ladders, shot from the south at the orbit rungs.
+--
+-- These cells used to be pinned to the staircase classes and came out as
+-- four-step flights thrown across the cell.  They are a `ladder` standee
+-- now -- the same per-pixel object pass that builds signs, posts and
+-- bicycles -- and this is the shot that says what actually reaches the
+-- screen.
+--
+-- SEAFOAM_ISLANDS_B2F carries one of each with dark floor to the south to
+-- stand on -- an up ladder at cell (5,3) and a down one at (5,13) -- so a
+-- single map states both halves.
+--
+-- It also prints the geometry it shot, because a screenshot cannot be
+-- asserted on: how many quads each ladder cell built and the height band
+-- they span.
+--
+-- BOTH stand on the floor plane, including the descending ladder.  That is
+-- the standee path's one concession and it is deliberate -- the shared
+-- object pipeline stands a drawing up and has no notion of a hole, so a
+-- ladder DOWN cannot be excavated the way the old stairwell pin was.  A
+-- band that dips below 0 would mean something has changed, so the check
+-- below is that nothing does.
+--
+--   POKEPORT_DRIVER=mods/BattleArtVoxelFork/tests/ladder_shots.lua \
+--   SHOT_DIR=.scratchpad/ladder lovec .
+return function(game)
+  local U = dofile("tests/drivers/util.lua")
+  local Pipelines = require("src.render.Pipelines")
+  local PaletteFX = require("src.render.PaletteFX")
+
+  local ROOT = (os.getenv("SHOT_DIR") or "shots/ladder")
+    .. "/" .. (os.getenv("AB_TAG") or "after")
+
+  local handle = game.mods.exports["BATTLE_ART_VOXEL_FORK"]
+  if not (handle and handle.lib) then
+    print("[ladder] BATTLE_ART_VOXEL_FORK not loaded (is the DramaticShape junction still present? they conflict)")
+    love.event.quit(1)
+    return
+  end
+  local V = handle.lib
+  local DayNight = V.require("DayNight")
+  local ChunkMesher = V.require("ChunkMesher")
+  local Structures = V.require("Structures")
+  local Voxel = V.require("VoxelState")
+
+  require("src.world.OverworldController").rollEncounter = function() return nil end
+  local TileRenderer = require("src.render.TileRenderer")
+  TileRenderer.tick = function() end
+  TileRenderer.animFrame = function() return 0 end
+  DayNight.setting:sync("day")
+
+  pcall(os.execute, 'mkdir -p "' .. ROOT .. '" 2>/dev/null')
+  pcall(os.execute, 'mkdir "' .. ROOT:gsub("/", "\\") .. '" 2>nul')
+
+  -- COLOUR PACK.  The engine ships several and the default is `gbc` (SGB),
+  -- which is what an unset run shoots.  SHOT_COLORS takes a mode id --
+  -- `redpp` is the one the options menu calls ADVANCED, the per-tile
+  -- pokered-gbc colorization.  It is set BEFORE the teleport so the map
+  -- loads with the right baked atlas: switching a live map only rebuilds
+  -- it through a reload, and the frames in between are the wrong pack.
+  local COLORS = os.getenv("SHOT_COLORS")
+  if COLORS and COLORS ~= "" then
+    pcall(function()
+      game.save.options.colors = COLORS
+      PaletteFX.setMode(COLORS)
+    end)
+    print(("[ladder] colour pack: %s (%s)"):format(
+          COLORS, PaletteFX.modeLabel and PaletteFX.modeLabel(COLORS) or "?"))
+  end
+
+  local Zoom = require("src.render.Zoom")
+  pcall(function()
+    game.save.options.zoom = 1
+    Zoom.applyOptions(game.save.options)
+  end)
+
+  local function settle()
+    for _ = 1, 900 do
+      if ChunkMesher.pending() == 0 then break end
+      U.wait(1)
+    end
+    for _ = 1, 300 do
+      if Voxel.t >= 1 and Voxel.ready and ChunkMesher.pending() == 0 then break end
+      U.wait(1)
+    end
+    U.wait(30)
+  end
+
+  local SCENES = {
+    { map = "SEAFOAM_ISLANDS_B2F", cx = 5, cy = 3,  x = 5, y = 5,
+      label = "up" },
+    { map = "SEAFOAM_ISLANDS_B2F", cx = 5, cy = 13, x = 5, y = 15,
+      label = "down" },
+  }
+
+  local shots, bad = 0, 0
+  for _, s in ipairs(SCENES) do
+    U.teleport(game, s.map, s.x, s.y, "up")
+    Pipelines.setLevel("voxel", 3)
+    Pipelines.setLevel("tiltshift", 0)
+    settle()
+
+    -- the quads standing in this cell: the ladder is the only thing built
+    -- there, so its footprint names them without tagging the geometry
+    local ow = game.overworld
+    local S = ow and ow.map and Structures.forMap(ow.map)
+    local mx0, mx1 = s.cx * 16, s.cx * 16 + 16
+    local mz0, mz1 = s.cy * 16, s.cy * 16 + 16
+    local n, lo, hi = 0, math.huge, -math.huge
+    for _, q in ipairs((S and S.objectQuads) or {}) do
+      local x, z = q[1][1], q[1][3]
+      if x >= mx0 and x <= mx1 and z >= mz0 and z <= mz1 then
+        n = n + 1
+        for i = 1, 4 do
+          lo = math.min(lo, q[i][2])
+          hi = math.max(hi, q[i][2])
+        end
+      end
+    end
+    if n == 0 then
+      print(("[ladder] %s cell (%d,%d) built NO geometry"):format(
+            s.label, s.cx, s.cy))
+      bad = bad + 1
+    else
+      print(("[ladder] %-4s cell (%2d,%2d): %d quads, y %.1f .. %.1f")
+            :format(s.label, s.cx, s.cy, n, lo, hi))
+      -- a standee stands ON the floor: nothing should reach below it
+      if lo < -0.01 then
+        print(("[ladder]   `%s` dips below the floor plane -- a standee "
+               .. "cannot excavate, so something else built this")
+              :format(s.label))
+        bad = bad + 1
+      end
+    end
+
+    for _, rung in ipairs({ 3, 5 }) do
+      Pipelines.setLevel("voxel", rung)
+      settle()
+      local path = ("%s/%s_v%d.png"):format(ROOT, s.label, rung)
+      game.capturePath = path
+      U.wait(8)
+      local f = io.open(path, "rb")
+      if f then f:close() shots = shots + 1
+      else print("[ladder] capture missed: " .. path) end
+    end
+  end
+
+  print(("[ladder] %d shots into %s, %d problems"):format(shots, ROOT, bad))
+  love.event.quit(bad > 0 and 1 or 0)
+end


### PR DESCRIPTION
The cave ladder cells are pinned `stair_e` and `stair_down_e` in the CAVERN
profile. A staircase class builds a flight that runs along an axis, so those
pins throw a four step stepped wedge across a cell whose art is a ladder
lying flat in it. Every ladder in Mt Moon, Rock Tunnel, Seafoam, Victory
Road, Cerulean Cave and Diglett's Cave currently comes out as a small
staircase.

The profile comment already conceded the point: it described the flight's
treads as landing "one rung apiece, which is as close to a drawn ladder as
stepped geometry gets".

## The fix

Both graphics are drawn from above as a shaft with two rails and rungs
between them. Standing that drawing up is all it needs: rotate its depth
axis into height and it is already a ladder elevation, rails left and right
and rungs across. The standee pools already do that per pixel, so this adds
a `ladder` class routed to the same object pass `billboard`, `post`,
`signpost` and `bike` use.

There is no new geometry code. The whole change is vocabulary plus a pin:

| file | change |
| --- | --- |
| `data/voxel_heights.lua` | `stair_e` / `stair_down_e` become one `ladder` pin |
| `lib/TileShape.lua` | `ladder = 16`, `ladder = "billboard"` |
| `lib/Structures.lua` | `ladder = 2` in `PINNED_DEPTH` |

Depth 2 is the `bike` figure. A ladder is mostly the air between its rungs,
and at the default standee depth of 10 the side faces of neighbouring rungs
close those gaps off axis and the drawing silts up into a plate.

## One concession

Both graphics share a single pin. The warp table separates them cleanly,
with 37 `$08` cells warping down and 40 `$0A` cells warping up across the
nineteen cave maps, but the standee path stands a drawing on the floor plane
and has no notion of a hole. A descending ladder cannot be excavated the way
the old `stair_down_e` pin was, so it renders standing up like a climbing
one. That is a real loss against the old pin, which did open a stairwell.
Splitting them again needs geometry the shared object pipeline does not
build, so the up and down distinction is kept in the profile comment rather
than in two classes that would render identically. Happy to take this
further if you would rather keep the shaft.

## Verifying

`tests/cave_ladder_test.lua` is new and covers the vocabulary, which is what
can be silently undone: a pin naming a class `TileShape` does not know is
dropped without a word, and an art mode other than `"billboard"` would route
these cells to the box builder and render a wall wearing ladder art. It also
walks the upvalue graph to check the depth, and checks no other pin in the
whole profile names an unknown class.

    DS_MOD_PATH=mods/BattleArtVoxelFork \
      luajit mods/BattleArtVoxelFork/tests/cave_ladder_test.lua
    PASS cave ladders (38 checks)

`tests/ladder_shots.lua` drives before and after captures at two orbit
rungs. It takes `SHOT_COLORS` to pick a colour pack, since these read much
better under `redpp` than the default:

    SHOT_COLORS=redpp SHOT_DIR=.scratchpad/ladder \
      POKEPORT_DRIVER=mods/BattleArtVoxelFork/tests/ladder_shots.lua lovec .

Geometry built for the two cells on Seafoam Islands B2F goes from 21 quads
each to 294 for the up ladder and 342 for the down one.

I could not run `tests/battle_art_voxel_fork_test.lua` to check for
regressions: it does not compile here, dying at load with "main function has
more than 200 local variables" at line 2604. That looks independent of this
change, but flagging it in case it is news. The standalone suites I could
run behave identically with and without this patch on my checkout.
