### PR TITLE
fix: drop a cut tree from the mesh instead of waiting for the rebuild

### DIFF
--- a/lib/ChunkMesher.lua
+++ b/lib/ChunkMesher.lua
@@ -166,7 +166,10 @@ end
 
 local function newTableSink()
   local verts, indices, quads = {}, {}, 0
+  local spans = newSpans(function() return #verts end)
   return {
+    own = spans.own,
+    spans = spans.runs,
     push = function(c, uv, shade)
       local flat = type(shade) ~= "table"
       for i = 1, 4 do
@@ -178,9 +181,11 @@ local function newTableSink()
       quads = quads + 1
     end,
     results = function()
+      spans.close()
       return verts, indices, quads
     end,
     finish = function()
+      spans.close()
       return Voxel3D.newMesh(verts, indices)
     end,
   }
@@ -193,6 +198,44 @@ local TRI_ORDER = { 1, 2, 3, 1, 3, 4 }
 -- without the historical fallback's table per vertex and million-table heap
 -- pressure on large routes. Strings are folded into moderate chunks as they
 -- are emitted, then uploaded cooperatively just like the FFI path.
+-- ------------------------------------------------------------------ spans
+--
+-- Records where each prop a sink was handed ended up in the vertex stream.
+-- own(x0, z0, x1, z1) closes the previous run and opens one owned by that
+-- world-pixel footprint. Only the prop passes call it. The tile loop's
+-- ground is what a prop stands on, so dropping that would leave a hole.
+--
+-- This is what lets Cut take a tree out of the mesh already on screen. The
+-- rebuild after a block edit takes about a third of a second here and longer
+-- on a phone, and refresh() keeps the old mesh drawing while it runs, so the
+-- tree stayed up for all of it.
+--
+-- One flat array of numbers, four per run (first vertex, vertex count,
+-- footprint center x and z). It rides along with every cached mesh, on disk
+-- as well as in memory, so a table per run would be wasteful.
+local function newSpans(count)
+  local runs, first, cx, cz = {}, nil, 0, 0
+  local function close()
+    if not first then return end
+    local n = count() - first
+    if n > 0 then
+      runs[#runs + 1] = first
+      runs[#runs + 1] = n
+      runs[#runs + 1] = cx
+      runs[#runs + 1] = cz
+    end
+    first = nil
+  end
+  return {
+    own = function(x0, z0, x1, z1)
+      close()
+      first, cx, cz = count(), (x0 + x1) / 2, (z0 + z1) / 2
+    end,
+    close = close,
+    runs = function() close() return runs end,
+  }
+end
+
 local PACKED_VERTEX = "<" .. string.rep("f", 6 * 6)
 local PACKED_VERTEX_BYTES = 6 * 4
 local PACKED_QUADS_PER_CHUNK = 4096
@@ -200,6 +243,7 @@ local PACKED_QUADS_PER_CHUNK = 4096
 local function newPackedSink()
   local chunks, parts, values = {}, {}, {}
   local quads, n = 0, 0
+  local spans = newSpans(function() return n end)
 
   local function flush()
     if #parts == 0 then return end
@@ -208,6 +252,8 @@ local function newPackedSink()
   end
 
   return {
+    own = spans.own,
+    spans = spans.runs,
     push = function(c, uv, shade)
       local flat = type(shade) ~= "table"
       local at = 1
@@ -225,6 +271,7 @@ local function newPackedSink()
       if quads % PACKED_QUADS_PER_CHUNK == 0 then flush() end
     end,
     finish = function()
+      spans.close()
       if n == 0 then return nil end
       flush()
       local ok, mesh = pcall(function()
@@ -245,7 +292,7 @@ local function newPackedSink()
     end,
     raw = function()
       flush()
-      return { chunks = chunks, n = n }
+      return { chunks = chunks, n = n, spans = spans.runs() }
     end,
   }
 end
@@ -254,8 +301,11 @@ local function newFfiSink()
   local cap = 4096 * 6
   local buf = ffi.new("float[?]", cap * 6)
   local n = 0
+  local spans = newSpans(function() return n end)
   local sink
   sink = {
+    own = spans.own,
+    spans = spans.runs,
     push = function(c, uv, shade)
       if n + 6 > cap then
         local grown = ffi.new("float[?]", cap * 2 * 6)
@@ -278,6 +328,7 @@ local function newFfiSink()
       n = n + 6
     end,
     finish = function()
+      spans.close()
       if n == 0 then return nil end
       -- upload in slices with budget ticks between: a route-sized mesh
       -- is ~10-20MB and one atomic setVertices was the last remaining
@@ -303,7 +354,7 @@ local function newFfiSink()
       return ok and mesh or nil
     end,
     raw = function()
-      return { ptr = buf, n = n }
+      return { ptr = buf, n = n, spans = spans.runs() }
     end,
   }
   return sink
@@ -929,7 +980,61 @@ local function runGeometry(map, bodyOnly, masks, sink, waterSink, visualSinks)
     return scUV
   end
 
-  for _, q in ipairs(S.objectQuads) do
+  -- Ownership for the prop passes (see the span header). A prop's quads
+  -- arrive cell by cell, so consecutive quads landing in the same 16px cell
+  -- share one run -- fine enough to name a felled tree, coarse enough that a
+  -- route's props cost a few hundred runs and not tens of thousands. Quads
+  -- routed to a visual-object sidecar are not the main mesh's to drop, so
+  -- they claim nothing.
+  -- Only the body is worth recording. Runs are selected by block edits,
+  -- block coordinates are body coordinates, so a ring tree's runs could
+  -- never be picked and would just add weight to the cached record.
+  local own = sink.own
+  local ownedCell = nil
+  local function inBodyPx(cx, cz)
+    return cx >= 0 and cx < tw * 8 and cz >= 0 and cz < th * 8
+  end
+  local function ownCell(x0, z0, x1, z1)
+    if not own then return end
+    local ccx = math.floor((x0 + x1) / 32)
+    local ccz = math.floor((z0 + z1) / 32)
+    if not inBodyPx(ccx * 16 + 8, ccz * 16 + 8) then
+      ownedCell = nil
+      return
+    end
+    local cell = ccz * 4096 + ccx
+    if cell == ownedCell then return end
+    ownedCell = cell
+    own(ccx * 16, ccz * 16, ccx * 16 + 16, ccz * 16 + 16)
+  end
+
+  -- Emit the object quads cell by cell instead of in the order the producers
+  -- appended them.
+  --
+  -- The producers interleave, so consecutive quads kept changing cell and a
+  -- run opened for nearly every one: 18596 runs for a body of 1440 cells on
+  -- Cerulean, about 300KB of record per slot, and a cut that needed hundreds
+  -- of small uploads. Grouped, that is 449 runs and one or two uploads.
+  --
+  -- Reordering is safe here. These are opaque triangles drawn against a
+  -- depth buffer, and water and the visual sidecars have their own sinks.
+  local objectOrder = {}
+  for i = 1, #S.objectQuads do objectOrder[i] = i end
+  do
+    local keys = {}
+    for i, q in ipairs(S.objectQuads) do
+      local cx = math.floor((q[1][1] + q[3][1]) / 32)
+      local cz = math.floor((q[1][3] + q[3][3]) / 32)
+      keys[i] = cz * 4096 + cx
+    end
+    table.sort(objectOrder, function(a, b)
+      if keys[a] ~= keys[b] then return keys[a] < keys[b] end
+      return a < b            -- stable: producers' own order inside a cell
+    end)
+  end
+
+  for _, qi in ipairs(objectOrder) do
+    local q = S.objectQuads[qi]
     Budget.tick()
     local x0 = math.min(q[1][1], q[2][1], q[3][1], q[4][1])
     local x1 = math.max(q[1][1], q[2][1], q[3][1], q[4][1])
@@ -951,6 +1056,7 @@ local function runGeometry(map, bodyOnly, masks, sink, waterSink, visualSinks)
         end
         target = visualSink.push
       end
+      if target == push then ownCell(x0, z0, x1, z1) end
       target({ q[1], q[2], q[3], q[4] }, quadUV(q),
         groundShades(q, q.shade))
     end
@@ -991,6 +1097,13 @@ local function runGeometry(map, bodyOnly, masks, sink, waterSink, visualSinks)
       skipAll = not overBody and containedInMask(sx0, sz0, sx1, sz1)
     end
     if not skipAll then
+      -- a stamp is one prop whatever it spans, so it owns its whole
+      -- footprint in one run: the 2x2-cell canopy groups are exactly a
+      -- block, which is exactly what Cut swaps
+      if own and inBodyPx(mx, mz) then
+        own(sx0, sz0, sx1, sz1)
+        ownedCell = nil
+      end
       for _, q in ipairs(st.quads) do
         Budget.tick()
         for i = 1, 4 do
@@ -1057,8 +1170,42 @@ function ChunkMesher.build(map, bodyOnly, masks, split, separateVisuals)
   return sink.finish(), waterSink and waterSink.finish() or nil, visuals
 end
 
+-- Prop runs for a quad list. Cut swaps tall grass as well as trees, so the
+-- grass and flower records carry runs too.
+-- `perQuad` is how many vertices the consumer writes per quad: the raw
+-- records are unindexed triangles (six), quadsMesh indexes four corners.
+local function quadListSpans(quads, perQuad)
+  local spans, first, cellKey, cellX, cellZ = {}, nil, nil, 0, 0
+  local at = 0
+  perQuad = perQuad or 6
+  for _, q in ipairs(quads or {}) do
+    local qx = math.floor((q[1][1] + q[3][1]) / 32)
+    local qz = math.floor((q[1][3] + q[3][3]) / 32)
+    local key = qz * 4096 + qx
+    if key ~= cellKey then
+      if first and at > first then
+        spans[#spans + 1] = first
+        spans[#spans + 1] = at - first
+        spans[#spans + 1] = cellX
+        spans[#spans + 1] = cellZ
+      end
+      cellKey, cellX, cellZ = key, qx * 16 + 8, qz * 16 + 8
+      first = at
+    end
+    at = at + perQuad
+  end
+  if first and at > first then
+    spans[#spans + 1] = first
+    spans[#spans + 1] = at - first
+    spans[#spans + 1] = cellX
+    spans[#spans + 1] = cellZ
+  end
+  return spans
+end
+
 local function quadsMesh(quads)
   if #quads == 0 then return nil end
+  local spans = quadListSpans(quads, 4)
   local verts, indices, n = {}, {}, 0
   for _, q in ipairs(quads) do
     for i = 1, 4 do
@@ -1069,7 +1216,7 @@ local function quadsMesh(quads)
     Voxel3D.pushQuad(indices, n)
     n = n + 1
   end
-  return Voxel3D.newMesh(verts, indices)
+  return Voxel3D.newMesh(verts, indices), spans
 end
 
 -- Flatten auxiliary quads into the same unindexed six-float stream terrain
@@ -1091,7 +1238,7 @@ local function rawQuads(quads)
       end
       Budget.tick()
     end
-    return { ptr = buf, n = n }
+    return { ptr = buf, n = n, spans = quadListSpans(quads) }
   end
   local chunks, parts, values = {}, {}, {}
   for _, q in ipairs(quads) do
@@ -1112,7 +1259,7 @@ local function rawQuads(quads)
     Budget.tick()
   end
   if #parts > 0 then chunks[#chunks + 1] = table.concat(parts) end
-  return { chunks = chunks, n = n }
+  return { chunks = chunks, n = n, spans = quadListSpans(quads) }
 end
 
 local function buildRawAux(map)
@@ -1149,7 +1296,9 @@ local function meshesFromRawAux(aux)
       }
     end
   end
-  return meshFromRaw(aux.grass), meshFromRaw(aux.flowers), figures
+  return meshFromRaw(aux.grass), meshFromRaw(aux.flowers), figures,
+         aux.grass and aux.grass.spans or nil,
+         aux.flowers and aux.flowers.spans or nil
 end
 
 -- The tall-grass rows as their own mesh: VoxelScene draws it AFTER the
@@ -1269,6 +1418,7 @@ local function releaseEntry(c)
     local mesh = c[slot]
     if mesh and mesh.release then pcall(mesh.release, mesh) end
     c[slot] = nil
+    c[slot .. "Spans"] = nil
   end
   releaseVisualMeshes(c.fullVisuals)
   releaseVisualMeshes(c.bodyVisuals)
@@ -1323,7 +1473,7 @@ local function runJob(job)
   end
   if c.grass == nil or c.flowers == nil or c.figures == nil
      or (c.stale and c.stale.aux) then
-    local grass, flowers, figures
+    local grass, flowers, figures, grassSpans, flowerSpans
     if MeshDisk.available() then
       local aux = MeshDisk.loadAux(map)
       if not aux then
@@ -1338,14 +1488,16 @@ local function runJob(job)
           return
         end
       end
-      grass, flowers, figures = meshesFromRawAux(aux)
+      grass, flowers, figures, grassSpans, flowerSpans = meshesFromRawAux(aux)
     else
-      local okG, builtGrass = pcall(buildGrassMesh, map)
-      local okF, builtFlowers = pcall(buildFlowerMesh, map)
+      local okG, builtGrass, builtGrassSpans = pcall(buildGrassMesh, map)
+      local okF, builtFlowers, builtFlowerSpans = pcall(buildFlowerMesh, map)
       local okX, builtFigures = pcall(buildFigureMeshes, map)
       grass = (okG and builtGrass) or false
       flowers = (okF and builtFlowers) or false
       figures = (okX and builtFigures) or false
+      grassSpans = (okG and builtGrass) and builtGrassSpans or nil
+      flowerSpans = (okF and builtFlowers) and builtFlowerSpans or nil
     end
     if not current() then
       if grass and grass.release then pcall(grass.release, grass) end
@@ -1355,12 +1507,14 @@ local function runJob(job)
     end
     swapSlot(c, "grass", grass or false)
     swapSlot(c, "flowers", flowers or false)
+    c.grassSpans = grass and grassSpans or nil
+    c.flowersSpans = flowers and flowerSpans or nil
     releaseFigures(c.figures)
     c.figures = figures or false
     if c.stale then c.stale.aux = nil end
   end
 
-  local mesh, water, visualMeshes
+  local mesh, water, visualMeshes, spans
   -- Annotated originals are small session meshes beside the canonical terrain.
   -- Older persistent terrain records contain those quads, so annotated maps do
   -- not read those records. New records contain only the canonical terrain;
@@ -1372,6 +1526,9 @@ local function runJob(job)
   if cached then
     mesh = meshFromRaw(cached.terrain)
     water = meshFromRaw(cached.water)
+    -- the prop runs were written with the record: a precached map can drop a
+    -- felled tree without ever having run the geometry pass this session
+    spans = cached.spans
   else
     local sink, waterSink = newSink(), newSink()
     local visualSinks = annotatedVisuals and {} or nil
@@ -1380,6 +1537,8 @@ local function runJob(job)
     local terrainRaw = sink.raw and sink.raw() or nil
     local waterRaw = waterSink.raw and waterSink.raw() or nil
     mesh, water = sink.finish(), waterSink.finish()
+    spans = (terrainRaw and terrainRaw.spans)
+            or (sink.spans and sink.spans()) or nil
     if visualSinks then
       visualMeshes = {}
       for id, visualSink in pairs(visualSinks) do
@@ -1411,6 +1570,8 @@ local function runJob(job)
   swapSlot(c, job.slot, mesh or false)
   swapSlot(c, waterSlot(job.slot), water or false)
   swapVisualSlot(c, job.slot, visualMeshes)
+  -- the runs describe THIS mesh, so they land and die with it
+  c[job.slot .. "Spans"] = mesh and spans or nil
   if c.stale then
     c.stale[job.slot] = nil
     if not (c.stale.full or c.stale.body or c.stale.aux) then
@@ -1647,12 +1808,140 @@ function ChunkMesher.figures(map)
   return (type(list) == "table") and list or nil
 end
 
+-- ------- taking one prop out of a mesh that is already on screen
+--
+-- Zeroing a run's vertices leaves degenerate triangles, which draw nothing.
+-- The ground stays, because it comes from the tile loop and owns no runs.
+-- The spans ride the disk cache too, so a precached map can do this without
+-- having run the geometry pass this session.
+--
+-- This only removes what a build already placed. Anything an edit adds, and
+-- the shading corrections around it, still wait for the rebuild.
+
+-- position/uv/shade, six floats (Voxel3D.FORMAT)
+local BLANK_VERTEX_BYTES = 6 * 4
+
+-- The vertex ranges owned by props inside a world-pixel rect, merged where
+-- they are adjacent so one tree costs one upload.
+--
+-- A run belongs to the rect when the center of its footprint does. Testing
+-- for overlap instead pulled in the neighbouring tree every time, because
+-- the 2x2-cell canopy groups are a whole block wide.
+function ChunkMesher.blockRanges(spans, px0, pz0, px1, pz1)
+  local out = {}
+  if type(spans) ~= "table" then return out end
+  local i, n = 1, #spans
+  local function inRect(k)
+    local cx, cz = spans[k + 2], spans[k + 3]
+    return cx >= px0 and cx < px1 and cz >= pz0 and cz < pz1
+  end
+  while i <= n do
+    if inRect(i) then
+      local first = spans[i]
+      local last = first + spans[i + 1]
+      local j = i + 4
+      while j <= n and spans[j] == last and inRect(j) do
+        last = spans[j] + spans[j + 1]
+        j = j + 4
+      end
+      out[#out + 1] = { first, last - first }
+      i = j
+    else
+      i = i + 4
+    end
+  end
+  return out
+end
+
+local zeroCache = ""
+local function zeroBytes(n)
+  if #zeroCache < n then zeroCache = string.rep(string.char(0), n) end
+  return zeroCache:sub(1, n)
+end
+
+local function blankMesh(mesh, spans, px0, pz0, px1, pz1)
+  if not (mesh and mesh.setVertices and spans
+          and love and love.data and love.data.newByteData) then
+    return 0
+  end
+  local dropped = 0
+  for _, r in ipairs(ChunkMesher.blockRanges(spans, px0, pz0, px1, pz1)) do
+    local ok, data = pcall(love.data.newByteData,
+                           zeroBytes(r[2] * BLANK_VERTEX_BYTES))
+    if ok and data then
+      -- setVertices takes a 1-based start vertex; runs are recorded 0-based
+      if pcall(mesh.setVertices, mesh, data, r[1] + 1) then
+        dropped = dropped + r[2]
+      end
+      pcall(data.release, data)
+    end
+  end
+  return dropped
+end
+
+-- The part of a block a swap actually changed, in world pixels, rounded out
+-- to whole 16px cells because that is what a prop is owned by.
+--
+-- Cut swaps a whole block id but the two ids usually differ in one cell.
+-- Cerulean's cuttable block is a single tree in the middle of a hedge, and
+-- dropping the block's props wholesale took the hedge down with it.
+--
+-- nil when nothing changed. The whole block when the tileset cannot answer,
+-- which leaves the caller with the old behaviour.
+function ChunkMesher.changedRect(map, bx, by, before)
+  local px0, pz0 = bx * 32, by * 32
+  local blocks = map and map.tileset and map.tileset.blocks
+  local a = before and blocks and blocks[before + 1]
+  local b = blocks and map.blockAt and blocks[map:blockAt(bx, by) + 1]
+  if not (a and b) then return px0, pz0, px0 + 32, pz0 + 32 end
+  local x0, z0, x1, z1 = math.huge, math.huge, -math.huge, -math.huge
+  for i = 1, 16 do
+    if a[i] ~= b[i] then
+      local tx, tz = (i - 1) % 4, math.floor((i - 1) / 4)
+      x0 = math.min(x0, px0 + tx * 8)
+      x1 = math.max(x1, px0 + tx * 8 + 8)
+      z0 = math.min(z0, pz0 + tz * 8)
+      z1 = math.max(z1, pz0 + tz * 8 + 8)
+    end
+  end
+  if x1 < x0 then return nil end
+  -- out to cell boundaries: a prop is owned by the 16px cell it stands in,
+  -- and a rect cutting a cell in half excludes that cell's own center
+  return math.floor(x0 / 16) * 16, math.floor(z0 / 16) * 16,
+         math.ceil(x1 / 16) * 16, math.ceil(z1 / 16) * 16
+end
+
+-- Drop the props on the changed part of a block from whatever this map is
+-- drawing now. Returns how many vertices were zeroed, which is 0 when the
+-- block held nothing the prop passes owned. Walls and ledges come from the
+-- tile loop, so those still wait for the rebuild.
+--
+-- `before` is the block id that was there. Without it the whole block goes.
+function ChunkMesher.dropBlock(mapId, bx, by, map, before)
+  local c = mapId and cache[mapId]
+  if not (c and bx and by) then return 0 end
+  local px0, pz0, px1, pz1 = ChunkMesher.changedRect(map, bx, by, before)
+  if not px0 then return 0 end
+  local n = 0
+  for _, slot in ipairs({ "full", "body" }) do
+    n = n + blankMesh(c[slot], c[slot .. "Spans"], px0, pz0, px1, pz1)
+  end
+  -- tufts and billboards are meshes of their own, so a cut through tall
+  -- grass has to reach them as well
+  n = n + blankMesh(c.grass, c.grassSpans, px0, pz0, px1, pz1)
+  n = n + blankMesh(c.flowers, c.flowersSpans, px0, pz0, px1, pz1)
+  return n
+end
+
 -- Rebuild a map's meshes IN PLACE: the stale meshes keep drawing while
 -- replacements cook, and each slot swaps as its build lands. This is
 -- the block-edit path (a cut tree, a door stamp) -- invalidate() drops
 -- the mesh outright, and until the async rebuild landed the scene fell
 -- to the flat 2D path, a whole-world blink for a one-block edit.
-function ChunkMesher.refresh(mapId)
+-- `bx, by` name the block that changed and `map`/`before` narrow the drop to
+-- the part of it that moved, so a felled tree goes on the frame it was cut
+-- rather than waiting out the rebuild. Called without them, nothing changes.
+function ChunkMesher.refresh(mapId, bx, by, map, before)
   if not mapId then return ChunkMesher.invalidate() end
   -- Never erase the immutable persistent record. Some engine/mod paths emit a
   -- conservative block notification while loading an area even when its final
@@ -1663,6 +1952,7 @@ function ChunkMesher.refresh(mapId)
   if not (c and (c.full or c.body)) then
     return ChunkMesher.invalidate(mapId)
   end
+  ChunkMesher.dropBlock(mapId, bx, by, map, before)
   Structures.invalidate(mapId)
   gen[mapId] = (gen[mapId] or 0) + 1
   for i = #jobs, 1, -1 do

--- a/lib/VoxelMeshDisk.lua
+++ b/lib/VoxelMeshDisk.lua
@@ -62,7 +62,9 @@ local STATIC_PLAYTHROUGH = "bavc_static_mesh_v2"
 -- ordinary cached terrain when no extension can replace them. Revision 5
 -- stripped signposts unconditionally, then bypassed its own cache on Continue
 -- to reconstruct their sidecars.
-Disk.CACHE_REVISION = 7
+-- Revision 8 stores prop runs alongside the vertices so a precached map can
+-- drop a cut tree from the mesh it is already drawing.
+Disk.CACHE_REVISION = 8
 -- Patch releases which do not change emitted vertices must keep the existing
 -- world cache usable. This token matches the first static-mesh-cache-v2 build;
 -- CACHE_REVISION, not the public mod version, owns geometry compatibility.
@@ -866,6 +868,26 @@ local function readValidated(path, fp, map)
   return blob, pos
 end
 
+-- Prop runs stored with a record: a u32 count, then four floats per run.
+-- A precached map never runs the geometry pass, so without these the cut
+-- fast path in ChunkMesher would never fire on one.
+local function readSpans(blob, pos)
+  local count = readU32(blob, pos)
+  if not count or count > 1048576 then return nil end
+  pos = pos + 4
+  local spans = {}
+  for _ = 1, count do
+    if pos + 15 > #blob then return nil end
+    local a, b, c, d, nextPos = love.data.unpack("<ffff", blob, pos)
+    spans[#spans + 1] = a
+    spans[#spans + 1] = b
+    spans[#spans + 1] = c
+    spans[#spans + 1] = d
+    pos = nextPos
+  end
+  return spans, pos
+end
+
 function Disk.loadTerrain(map, slot, masks)
   if not Disk.staticEligible(map) then return nil end
   local path = pathFor(map, slot, "terrain")
@@ -873,13 +895,15 @@ function Disk.loadTerrain(map, slot, masks)
   local blob, pos = readValidated(path, fp, map)
   if not blob then return nil end
   local terrain, nextPos = streamRecord(blob, pos)
-  local water, finalPos
-  if nextPos then water, finalPos = streamRecord(blob, nextPos) end
-  if not terrain or not water or finalPos ~= #blob + 1 then
+  local water, afterWater
+  if nextPos then water, afterWater = streamRecord(blob, nextPos) end
+  local spans, finalPos
+  if afterWater then spans, finalPos = readSpans(blob, afterWater) end
+  if not terrain or not water or not spans or finalPos ~= #blob + 1 then
     discard(path, true)
     return nil
   end
-  return { terrain = terrain, water = water }
+  return { terrain = terrain, water = water, spans = spans }
 end
 
 local function float4(blob, pos)
@@ -912,7 +936,14 @@ function Disk.loadAux(map)
     figures[#figures + 1] = stream
     pos = finalPos
   end
-  if pos ~= #blob + 1 then discard(path, true); return nil end
+  -- tuft and billboard runs, after the figures
+  local grassSpans, afterGrass = readSpans(blob, pos)
+  local flowerSpans, finalPos
+  if afterGrass then flowerSpans, finalPos = readSpans(blob, afterGrass) end
+  if not grassSpans or not flowerSpans or finalPos ~= #blob + 1 then
+    discard(path, true); return nil
+  end
+  grass.spans, flowers.spans = grassSpans, flowerSpans
   return { grass = grass, flowers = flowers, figures = figures }
 end
 
@@ -1080,6 +1111,16 @@ function Disk.saveRamToDisk()
   return failures == 0, saved, failures, errors
 end
 
+local function writeSpans(file, spans)
+  local count = math.floor(#(spans or {}) / 4)
+  write(file, u32(count))
+  for i = 1, count * 4, 4 do
+    write(file, love.data.pack("string", "<ffff",
+                               spans[i], spans[i + 1],
+                               spans[i + 2], spans[i + 3]))
+  end
+end
+
 function Disk.saveTerrain(map, slot, masks, terrain, water)
   if not Disk.staticEligible(map) then return false end
   local path = pathFor(map, slot, "terrain")
@@ -1087,6 +1128,7 @@ function Disk.saveTerrain(map, slot, masks, terrain, water)
   return writeFile(path, fp, function(file)
     writeChunked(file, terrain)
     writeChunked(file, water)
+    writeSpans(file, terrain and terrain.spans)
   end)
 end
 
@@ -1107,6 +1149,8 @@ function Disk.saveAux(map, aux)
       write(file, f32x4(figure.wx, figure.wz, figure.y, figure.w))
       Budget.check()
     end
+    writeSpans(file, aux.grass and aux.grass.spans)
+    writeSpans(file, aux.flowers and aux.flowers.spans)
   end)
 end
 

--- a/main.lua
+++ b/main.lua
@@ -1285,7 +1285,9 @@ do
       local before = self:blockAt(bx, by)
       setBlock(self, bx, by, block)
       if self.id and self:blockAt(bx, by) ~= before then
-        ChunkMesher.refresh(self.id)
+        -- naming the block lets the mesher drop what stood there from the
+        -- mesh on screen, so a cut tree goes on this frame
+        ChunkMesher.refresh(self.id, bx, by, self, before)
         Companion:worldChanged("map.setBlock")
       end
     end

--- a/tests/cut_drop_test.lua
+++ b/tests/cut_drop_test.lua
@@ -1,0 +1,128 @@
+-- A cut tree goes on the frame it was cut.
+--
+-- A block edit makes the whole map's mesh stale, and refresh() keeps the old
+-- mesh drawing while the rebuild runs, so the tree stayed up for about a
+-- third of a second here and longer on a phone. The prop passes now record
+-- where each thing they emit lands in the vertex stream, so those vertices
+-- can be zeroed in the mesh already on screen.
+--
+-- Picking the right runs is the part worth pinning and it is pure, so it is
+-- driven here. The zeroing itself needs a real mesh and was checked in game.
+--
+--   luajit mods/BattleArtVoxelFork/tests/cut_drop_test.lua
+
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.harness")
+local MOD_PATH = os.getenv("DS_MOD_PATH") or "mods/BattleArtVoxelFork"
+local ROOT = os.getenv("DS_REPO_ROOT") or "."
+local base = ROOT .. "/" .. MOD_PATH
+local modules, dataFiles = {}, {}
+local V = {}
+function V.require(name)
+  if modules[name] ~= nil then return modules[name] end
+  local value = assert(loadfile(base .. "/lib/" .. name .. ".lua"))(V)
+  modules[name] = value
+  return value
+end
+function V.data(name)
+  if dataFiles[name] ~= nil then return dataFiles[name] end
+  local value = assert(loadfile(base .. "/data/" .. name .. ".lua"))(V)
+  dataFiles[name] = value
+  return value
+end
+
+local ChunkMesher = V.require("ChunkMesher")
+
+-- ------- which vertices belong to the thing standing on a block
+
+-- four numbers per run: first vertex, vertex count, footprint center x, z.
+-- Block (1,0) is world pixels x 32..64, z 0..32.
+local spans = {
+  0,  6,   16, 16,   -- a prop in block (0,0)
+  6,  12,  40, 8,    -- two runs inside block (1,0), adjacent in the buffer
+  18, 6,   56, 24,
+  24, 6,   40, 40,   -- same column, the block to the SOUTH
+  30, 9,   48, 16,   -- back inside (1,0), but not adjacent to run 3
+}
+
+T.eq(#ChunkMesher.blockRanges(spans, 320, 320, 352, 352), 0,
+  "a block nothing stands in selects no vertices at all")
+
+local got = ChunkMesher.blockRanges(spans, 32, 0, 64, 32)
+T.eq(#got, 2, "the runs standing in the block are selected, and only those")
+T.eq(got[1][1], 6, "the first range starts where the block's first run does")
+T.eq(got[1][2], 18,
+  "and runs ADJACENT in the vertex buffer merge into it -- one tree comes "
+  .. "out of several stamps, and each upload is a separate GPU call")
+T.eq(got[2][1], 30, "a run separated by other geometry stays its own range")
+T.eq(got[2][2], 9, "carrying its own length")
+
+-- The rule is the run's CENTER, not overlap. The canopy groups are 2x2 cells
+-- -- exactly one block -- so an overlap test would take the neighbouring
+-- tree's canopy down with every cut.
+local edge = ChunkMesher.blockRanges({ 0, 6, 31.9, 16, 6, 6, 32.1, 16 },
+                                     32, 0, 64, 32)
+T.eq(#edge, 1, "a run whose center sits outside the block is not selected")
+T.eq(edge[1][1], 6, "and the one whose center is inside it is")
+
+T.eq(#ChunkMesher.blockRanges(nil, 0, 0, 32, 32), 0,
+  "a mesh built before spans existed selects nothing rather than throwing")
+
+-- ------- and only the part of the block that moved
+--
+-- A block is 4x4 tiles and Cut swaps the whole id, but Cerulean's cuttable
+-- block is one tree in the middle of a hedge: the two ids differ in a single
+-- cell. Dropping the block's props wholesale took the hedge down with the
+-- tree -- four times the geometry the cut actually removes.
+local blocks = {}
+-- tile slots are row-major, 1-based: slots 3,4,7,8 are the NE 16px cell
+blocks[51] = { 1, 1, 9, 9,
+               1, 1, 9, 9,
+               1, 1, 1, 1,
+               1, 1, 1, 1 }
+blocks[110] = { 1, 1, 2, 2,
+                1, 1, 2, 2,
+                1, 1, 1, 1,
+                1, 1, 1, 1 }
+local hedge = {
+  tileset = { blocks = blocks },
+  blockAt = function() return 109 end,   -- blocks[] is id + 1
+}
+
+local x0, z0, x1, z1 = ChunkMesher.changedRect(hedge, 2, 3, 50)
+T.eq(x0, 2 * 32 + 16, "the changed rect starts at the cell that moved")
+T.eq(z0, 3 * 32, "on the row it moved in")
+T.eq(x1, 2 * 32 + 32, "and ends with it")
+T.eq(z1, 3 * 32 + 16,
+  "-- one 16px cell of the four, not the whole block the id names")
+
+-- a swap that changes nothing is not an edit: the door code rewrites a block
+-- with the value it already holds, and that must not blank anything
+T.eq(ChunkMesher.changedRect(hedge, 2, 3, 109), nil,
+  "a block rewritten with the value it already held changes no rect")
+
+-- with nothing to compare against, the whole block goes -- the behaviour
+-- every caller had before the narrowing existed
+local wx0, wz0, wx1, wz1 = ChunkMesher.changedRect(hedge, 2, 3, nil)
+T.eq(wx0, 64, "with no previous id the rect is the whole block")
+T.eq(wx1, 96, "all four tiles wide")
+T.eq(wz0, 96, "from its own corner")
+T.eq(wz1, 128, "and four tiles deep")
+T.eq(select(1, ChunkMesher.changedRect(nil, 2, 3, 50)), 64,
+  "and a map that cannot answer for its tileset falls back the same way")
+
+-- ------- and it is inert where there is nothing to drop
+--
+-- the regrowth rewrites blocks on maps that are not on screen, and a warp
+-- can land an edit on a map whose mesh was evicted
+T.eq(ChunkMesher.dropBlock("BA_NOT_A_MAP", 3, 4), 0,
+  "dropping a block from a map with no cached mesh is a no-op")
+T.eq(ChunkMesher.dropBlock(nil, 3, 4), 0, "so is dropping one from no map")
+T.eq(ChunkMesher.dropBlock("BA_NOT_A_MAP"), 0,
+  "and so is an edit that never said which block it changed")
+
+if T.failures > 0 then
+  error(("cut drop: %d failure(s)"):format(T.failures))
+end
+print(("PASS cut drop (%d checks)"):format(T.checks))


### PR DESCRIPTION
## What this fixes

Cut a tree with voxel mode on and it stays standing for a moment before it
goes. On the flat renderer it disappears immediately.

## Why

A block edit marks the whole map's mesh stale, and `ChunkMesher.refresh` keeps
the old mesh drawing while the replacement builds. That part is deliberate,
since dropping it outright flashes the scene down to the 2D path. But the
rebuild is the whole map: 270 to 690 ms of work here, delivered 12 ms a frame,
so the tree stands for about 20 frames while the cut animation only covers 8.

## What changed

The prop passes (object quads, round stamps, grass, flowers) now record which
vertices each prop owns and where it stands. A block edit zeroes those in the
mesh already on screen, leaving degenerate triangles that draw nothing. The
ground underneath is untouched because it comes from the tile loop, so there is
no hole, and the rebuild still lands behind it with the real shading.

Three things worth calling out:

- Only the cells the swap actually changed are dropped. Cerulean's cuttable
  block is a single tree in a hedge, and dropping the block's props wholesale
  took the hedge with it (11820 vertices instead of 2784).
- The runs are written into the cached record, so `CACHE_REVISION` goes to 8.
  A precached map never runs the geometry pass, so without this the fast path
  would never fire on one. Caches rebuild once.
- Object quads are emitted cell by cell now. The producers interleave, so a run
  was opening for nearly every quad: 18596 runs for a body of 1440 cells on
  Cerulean. Grouped it is 449, which keeps the record around 7 KB a slot and
  makes a cut one or two uploads instead of hundreds. Reordering is safe for
  opaque geometry drawn against a depth buffer.

## Testing

`tests/cut_drop_test.lua` covers the selection rules, 22 checks.

In game at Cerulean's cut tree, one frame after the swap the affected region is
pixel identical to the fully rebuilt frame. Checked with the FFI sink and with
the packed sink that sandboxed mobile builds use, and with the mesh loaded from
the disk cache as well as built in session.

## Limits

This only removes what a build already placed. An edit that adds geometry, and
walls or ledges that come from the tile loop, still wait for the rebuild as
before.
