### PR TITLE
Add fossil display cases and repair cave entrances and cliff corners

### DIFF
--- a/docs/PROJECT_HANDOFF.md
+++ b/docs/PROJECT_HANDOFF.md
@@ -1,3 +1,21 @@
+## Museum cases and exterior cave/cliff repairs (2026-09-06)
+
+Based on current master after merged PR46. MuseumFossils replaces only the two
+exact first-floor fossil displays with Kabutops/Aerodactyl skeletons in framed
+glass cases. Solid geometry uses the existing atlas and chunk mesh; glass uses
+10 low-alpha panes with graphics state restored. Two exhibits add 12,576 solid
+vertices. Cache revision32 invalidates prior geometry. No map or collision edits.
+
+Exterior retaining cave mouths use a six-pixel recess and stepped stone crown.
+The exact 55,19/19,39 upright cliff-corner pattern uses stone rather than the raw
+blue diagonal sprite. A local shade helper handles scalar and corner AO shading.
+
+Validation: portable museum placement/bounds/fallback tests; private real Route4
+geometry regression (88 recessed mouth vertices, stepped heights9/12/13,70
+corner faces without tile19 UV). Desktop native captures verified museum views
+with engine0.2.27. Exact0.2.53 and Quest performance remain unverified. Desktop
+Astra19 backport installed separately with backups; PR preserves current upstream.
+
 ## Absol follow-up: building backs, entrances, cave exits and scrolls (2026-09-05)
 
 Separate follow-up to merged PR #45, integrated with master38e389c (1.10.3).

--- a/lib/ChunkMesher.lua
+++ b/lib/ChunkMesher.lua
@@ -1,3 +1,10 @@
+local function shadeTimes(shade, factor)
+  if type(shade) == "table" then
+    return {shade[1]*factor, shade[2]*factor, shade[3]*factor, shade[4]*factor}
+  end
+  return shade * factor
+end
+
 -- Voxel world mode: turn a map's tile layer into one static 3D mesh.
 --
 -- The scene description comes from Structures.lua, which -- 3dSen-style --
@@ -742,10 +749,18 @@ local function runGeometry(map, bodyOnly, masks, sink, waterSink, visualSinks)
     return false
   end
 
-  local function isKantoRetainingWall(s, tile, run)
+  local function isKantoRetainingWall(s, tile, run, tx, ty)
+    -- The southeast cliff corner is a shared ledge/wall cell, so it does
+    -- not inherit a volume run. Match the exact original 2x2 footprint.
+    local corner = false
+    if tile == 19 and tx and ty then
+      local x, z = math.floor(tx / 2) * 2, math.floor(ty / 2) * 2
+      corner = map:tileAt(x,z)==55 and map:tileAt(x+1,z)==19
+        and map:tileAt(x,z+1)==19 and map:tileAt(x+1,z+1)==39
+    end
     return CommunityVisuals.customWalls() and tileset.id == "OVERWORLD" and (
       (run and run.kantoRetaining == true)
-      or (s and s.class == "wall" and KANTO_RETAINING_TILE[tile] == true)
+      or (s and s.class == "wall" and (KANTO_RETAINING_TILE[tile] == true or corner))
     )
   end
 
@@ -1732,81 +1747,45 @@ local function runGeometry(map, bodyOnly, masks, sink, waterSink, visualSinks)
   -- through as a blue-white hairline below the black recess.
   -- Other compass faces remain ordinary retaining wall, preventing the source
   -- door art from wrapping around the mound.
-  local function retainingCaveMouthSide(d, tx, ty, x0, z0,
-                                         y0, y1, h, shade)
-    if d ~= 5 then
-      retainingRockSide(d, x0, z0, y0, y1, shade)
-      return
+  local function retainingCaveMouthSide(d, tx, ty, x0, z0, y0, y1, h, shade)
+    if d ~= 5 then retainingRockSide(d,x0,z0,y0,y1,shade);return end
+    local first,last=tx,tx
+    while S.runs[keyOf(first-1,ty)] and S.runs[keyOf(first-1,ty)].door do first=first-1 end
+    while S.runs[keyOf(last+1,ty)] and S.runs[keyOf(last+1,ty)].door do last=last+1 end
+    local left=x0-(tx-first)*8;local width=(last-first+1)*8
+    local crown=math.max(4,math.min(h-3,24));local depth=-6
+    local dark=rockUV(RETAINING_SWATCH_TILE,ROCK_TEXEL.dark)
+    local stone=rockUV(RETAINING_SWATCH_TILE,ROCK_TEXEL.body)
+    local function put(a,b,c,e,uv,tone) pushSolid({a,b,c,e},uv,shadeTimes(shade,tone)) end
+    local function point(x,y,r)return faceAxisPoint(d,x0,z0,x,y,r)end
+    local function opening(x)
+      local edge=math.min(x-left,left+width-x)
+      if edge<2 then return 0 end
+      if edge<4 then return math.max(2,crown-4) end
+      if edge<6 then return math.max(3,crown-1) end
+      return crown
     end
-
-    local openTop = math.max(4, math.min(h - 3, 24))
-    local mouthTop = math.min(y1, openTop)
-    if mouthTop > y0 then
-      local leftRun = S.runs[keyOf(tx - 1, ty)]
-      local rightRun = S.runs[keyOf(tx + 1, ty)]
-      local leftEdge = not (leftRun and leftRun.door)
-      local rightEdge = not (rightRun and rightRun.door)
-      local axis0, axis1 = x0, x0 + 8
-      local recess = -1.65
-      local uvDark = rockUV(RETAINING_SWATCH_TILE, ROCK_TEXEL.dark)
-
-      -- Passage subfaces sample the same side-light field as the masonry.
-      -- This also handles both scalar and per-corner ambient shades.
-      -- A dark back wall, far enough behind the facade for camera movement to
-      -- reveal a real passage instead of a black card laid on the masonry.
-      sideSolid({ faceAxisPoint(d, x0, z0, axis0, y0, recess),
-                  faceAxisPoint(d, x0, z0, axis1, y0, recess),
-                  faceAxisPoint(d, x0, z0, axis1, mouthTop, recess),
-                  faceAxisPoint(d, x0, z0, axis0, mouthTop, recess) },
-                uvDark, shade, 0.34, d, x0, z0, y0, y1)
-
-      -- Dark passage floor from the facade plane to the recessed back wall.
-      -- Emit it only for the ground-touching band so stacked wall courses do
-      -- not produce overlapping coplanar quads. This is visual geometry only:
-      -- the ROM threshold, collision and warp trigger remain unchanged.
-      if y0 <= 0 and y1 > 0 then
-        sideSolid({ faceAxisPoint(d, x0, z0, axis0, 0, recess),
-                    faceAxisPoint(d, x0, z0, axis1, 0, recess),
-                    faceAxisPoint(d, x0, z0, axis1, 0, 0),
-                    faceAxisPoint(d, x0, z0, axis0, 0, 0) },
-                  uvDark, shade, 0.30, d, x0, z0, y0, y1)
+    for x=x0,x0+6,2 do
+      local top=opening(x+1);local upper=math.min(y1,top)
+      if top<=y0 then
+        -- Same stone donor as surrounding masonry, bounded to this strip.
+        put(point(x,y0,0),point(x+2,y0,0),point(x+2,y1,0),point(x,y1,0),stone,.78)
+      else
+        put(point(x,y0,depth),point(x+2,y0,depth),point(x+2,upper,depth),point(x,upper,depth),dark,.22)
+        if y0==0 then put(point(x,0,depth),point(x+2,0,depth),point(x+2,0,0),point(x,0,0),stone,.40) end
+        if y1>=top then
+          put(point(x,top,depth),point(x+2,top,depth),point(x+2,top,0),point(x,top,0),stone,.55)
+          if y1>top then put(point(x,top,0),point(x+2,top,0),point(x+2,y1,0),point(x,y1,0),stone,.78) end
+        end
+        for _,side in ipairs({-1,1}) do
+          local neighbor=opening(x+1+side*2)
+          local low=math.max(y0,neighbor)
+          if upper>low then
+            local edge=side==-1 and x or x+2
+            put(point(edge,low,0),point(edge,low,depth),point(edge,upper,depth),point(edge,upper,0),stone,side==-1 and .65 or .48)
+          end
+        end
       end
-
-      -- Only the two outside tiles of a multi-tile door run receive vertical
-      -- returns. Every face uses the darkest masonry texel, eliminating the
-      -- blue/gold sampled edge strips seen in TEST16.
-      if leftEdge then
-        sideSolid({ faceAxisPoint(d, x0, z0, axis0, y0, 0),
-                    faceAxisPoint(d, x0, z0, axis0, y0, recess),
-                    faceAxisPoint(d, x0, z0, axis0, mouthTop, recess),
-                    faceAxisPoint(d, x0, z0, axis0, mouthTop, 0) },
-                  uvDark, shade, 0.54, d, x0, z0, y0, y1)
-      end
-      if rightEdge then
-        sideSolid({ faceAxisPoint(d, x0, z0, axis1, y0, recess),
-                    faceAxisPoint(d, x0, z0, axis1, y0, 0),
-                    faceAxisPoint(d, x0, z0, axis1, mouthTop, 0),
-                    faceAxisPoint(d, x0, z0, axis1, mouthTop, recess) },
-                  uvDark, shade, 0.48, d, x0, z0, y0, y1)
-      end
-
-      -- Emit the ceiling return once, in the band that reaches the opening's
-      -- top. This produces a visible lintel thickness while leaving collision,
-      -- the source door volume and its warp trigger unchanged.
-      if y0 < openTop and y1 >= openTop then
-        sideSolid({ faceAxisPoint(d, x0, z0, axis0, openTop, recess),
-                    faceAxisPoint(d, x0, z0, axis1, openTop, recess),
-                    faceAxisPoint(d, x0, z0, axis1, openTop, 0),
-                    faceAxisPoint(d, x0, z0, axis0, openTop, 0) },
-                  uvDark, shade, 0.44, d, x0, z0, y0, y1)
-      end
-    end
-
-    -- Courses above the opening form a natural lintel and reconnect to the
-    -- unchanged retaining-wall field across the top of the mound.
-    local lintelBottom = math.max(y0, openTop)
-    if y1 > lintelBottom then
-      retainingRockSide(d, x0, z0, lintelBottom, y1, shade)
     end
   end
 
@@ -1963,7 +1942,7 @@ local function runGeometry(map, bodyOnly, masks, sink, waterSink, visualSinks)
           local caveKind = caveSurfaceKind(s, tile)
           if caveKind then
             caveNaturalTop(tx, ty, x0, z0, h, VOLUME_TOP_SHADE, caveKind)
-          elseif isKantoRetainingWall(s, tile, run) then
+          elseif isKantoRetainingWall(s, tile, run, tx, ty) then
             ledgeRockTop(tx, ty, x0, z0, h, RETAINING_SWATCH_TILE,
                          aoShades(tx, ty, h, VOLUME_TOP_SHADE))
           else
@@ -2039,7 +2018,7 @@ local function runGeometry(map, bodyOnly, masks, sink, waterSink, visualSinks)
                  and s.class == "ledge" then
             ledgeRockTop(tx, ty, x0, z0, h, topTile,
                          aoShades(tx, ty, h, 1))
-          elseif isKantoRetainingWall(s, tile, run) then
+          elseif isKantoRetainingWall(s, tile, run, tx, ty) then
             ledgeRockTop(tx, ty, x0, z0, h, RETAINING_SWATCH_TILE,
                          aoShades(tx, ty, h, VOLUME_TOP_SHADE))
           else
@@ -2127,11 +2106,11 @@ local function runGeometry(map, bodyOnly, masks, sink, waterSink, visualSinks)
                 -- mouth on their south face. Their side/back faces stay
                 -- masonry, preventing the raw door sheet from wrapping around
                 -- the mound as blue/gold decoration.
-                elseif isKantoRetainingWall(s, tile, run)
+                elseif isKantoRetainingWall(s, tile, run, tx, ty)
                        and run and run.door then
                   retainingCaveMouthSide(d, tx, ty, x0, z0,
                                          y0, y1, h, faceShade)
-                elseif isKantoRetainingWall(s, tile, run) then
+                elseif isKantoRetainingWall(s, tile, run, tx, ty) then
                   retainingRockSide(d, x0, z0, y0, y1, faceShade)
                 else
                   sideQuad(d, x0, z0, y0, y1, src,

--- a/lib/MuseumFossils.lua
+++ b/lib/MuseumFossils.lua
@@ -1,0 +1,107 @@
+-- Exact first-floor museum exhibits. Render geometry only; no map mutations.
+local V=...
+local M={}
+local pattern={{39,40,40,40,40,40,40,25},{48,70,71,58,58,70,71,44},{49,60,83,63,60,60,60,44},{50,51,50,51,50,51,50,51}}
+function M.placements(map)
+ local out={};if not(map and map.id=='MUSEUM_1F' and map.tileset.id=='MUSEUM')then return out end
+ for _,y in ipairs({4,10})do
+  local match=true
+  for z,row in ipairs(pattern)do for x,t in ipairs(row)do if map:tileAt(x+1,y+z-1)~=t then match=false end end end
+  if match then out[#out+1]={x=16,z=(y+2)*8,kind=y==4 and 'kabutops' or 'aerodactyl',tileY=y} end
+ end
+ return out
+end
+local faces={{1,2,3,4},{5,8,7,6},{1,5,6,2},{4,3,7,8},{1,4,8,5},{2,6,7,3}}
+local shades={.72,.86,.55,1,.78,.88}
+local function box(out,x,y,z,w,h,d,uv,role)
+ local p={{x,y,z},{x+w,y,z},{x+w,y+h,z},{x,y+h,z},{x,y,z+d},{x+w,y,z+d},{x+w,y+h,z+d},{x,y+h,z+d}}
+ for f,ix in ipairs(faces)do out[#out+1]={p[ix[1]],p[ix[2]],p[ix[3]],p[ix[4]],uv={uv,uv,uv,uv},shade=shades[f],fossilRole=role}end
+end
+local function segment(out,a,b,r,uv)
+ local n=math.max(1,math.ceil(math.max(math.abs(b[1]-a[1]),math.abs(b[2]-a[2]),math.abs(b[3]-a[3]))/1.2))
+ for i=0,n do local t=i/n;box(out,a[1]+(b[1]-a[1])*t-r/2,a[2]+(b[2]-a[2])*t-r/2,a[3]+(b[3]-a[3])*t-r/2,r,r,r,uv,'bone')end
+end
+function M.geometry(p,uv)
+ local out={};local x,z=p.x,p.z
+ box(out,x,0,z,64,3,16,uv.dark,'base');box(out,x+1,3,z+1,62,1,14,uv.light,'bed')
+ box(out,x,1,z+15.8,64,.6,.25,uv.middle,'trim');box(out,x+28,1,z+16.1,8,1.7,.3,uv.light,'plaque')
+ for _,xx in ipairs({x,x+63})do for _,zz in ipairs({z,z+15})do box(out,xx,4,zz,1,28,1,uv.dark,'frame')end end
+ for _,yy in ipairs({4,31})do
+  box(out,x,yy,z,64,1,1,uv.dark,'frame');box(out,x,yy,z+15,64,1,1,uv.dark,'frame')
+  box(out,x,yy,z,1,1,16,uv.dark,'frame');box(out,x+63,yy,z,1,1,16,uv.dark,'frame')
+ end
+ local cx,cz=x+32,z+8
+ local function bone(a,b,r)
+  segment(out,{cx+a[1],a[2],cz+a[3]},{cx+b[1],b[2],cz+b[3]},r or 1.1,uv.light)
+ end
+ local function rib(y,w)
+  for _,s in ipairs({-1,1})do bone({0,y,-1},{s*w,y-1,1},.8);bone({s*w,y-1,1},{s*(w-1),y-2,3},.8)end
+ end
+ -- A discreet support keeps each articulated skeleton physically mounted.
+ box(out,cx-.45,4,cz-2,.9,12,.9,uv.dark,'support')
+ if p.kind=='kabutops' then
+  bone({0,12,-1},{0,22,0},1.5)
+  for y=15,21,2 do rib(y,4)end
+  bone({-3,12,0},{3,12,0},1.5)
+  for _,s in ipairs({-1,1})do
+   bone({s*2,12,0},{s*5,8,1},1.6);bone({s*5,8,1},{s*4,5,3},1.3);bone({s*4,5,3},{s*7,5,5},1)
+   bone({s*3,20,0},{s*8,18,1},1.3);bone({s*8,18,1},{s*11,15,2},1.2)
+   -- Long curved scythe, narrowing toward its hooked tip.
+   bone({s*11,15,2},{s*16,12,3},2);bone({s*16,12,3},{s*18,8,4},1.6);bone({s*18,8,4},{s*16,6,5},.8)
+   bone({0,26,0},{s*7,25,0},2);bone({s*7,25,0},{s*10,27,-1},1.8)
+   bone({s*7,25,0},{s*5,22,3},1.5);bone({s*5,22,3},{0,21,4},1.3)
+  end
+  bone({-4,24,3},{4,24,3},1.3);bone({0,23,3},{0,21,4},1.1)
+  bone({0,12,-1},{7,10,-4},1.3);bone({7,10,-4},{13,7,-5},1)
+ else
+  bone({0,11,-1},{0,21,0},1.4)
+  for y=13,19,2 do rib(y,3)end
+  bone({0,21,0},{-2,25,0},1.2)
+  -- Long toothed skull, jaw gap, rear horns.
+  bone({-2,25,0},{-9,24,1},2);bone({-2,22.5,0},{-9,22,1},1)
+  bone({-2,26,0},{-6,25.5,1},1.6)
+  for xx=-8,-3,1.5 do bone({xx,24,1},{xx,23.2,1},.6)end
+  for _,s in ipairs({-1,1})do
+   bone({-1,25,s},{3,28,s*2},1)
+   bone({s*2,19,0},{s*8,24,-1},1.3);bone({s*8,24,-1},{s*17,27,0},1.2);bone({s*17,27,0},{s*26,29,0},.8)
+   for j=1,3 do bone({s*8,24,-1},{s*(12+j*4),19-j*3,1},.85)end
+   bone({s*2,12,0},{s*5,9,1},1.1);bone({s*5,9,1},{s*4,6,3},1)
+   for j=-1,1 do bone({s*4,6,3},{s*4+j*1.3,5,5},.7)end
+  end
+  bone({0,11,-1},{5,8,-4},1);bone({5,8,-4},{10,5,-5},.7)
+ end
+ return out
+end
+local function colors(data,perRow)
+ local w,h=data:getDimensions();local lo,hi,mid=1e9,-1e9,nil;local dark,light
+ for y=0,h-1 do for x=0,w-1 do local a,b,c=data:getPixel(x,y);local v=a+b+c
+  if v<lo then lo=v;dark={(x+.5)/w,(y+.5)/h}end
+  if v>hi then hi=v;light={(x+.5)/w,(y+.5)/h}end
+  if not mid and v>1 and v<2 then mid={(x+.5)/w,(y+.5)/h}end
+ end end
+ return{dark=dark,light=light,middle=mid or light}
+end
+function M.build(S,map,data,perRow)
+ local ps=M.placements(map);if #ps==0 or not data then return 0 end
+ local uv=colors(data,perRow);local n=0
+ for _,p in ipairs(ps)do
+  for y=p.tileY,p.tileY+3 do for x=2,9 do local k=(y+64)*4096+x+64;S.skip[k]=true;S.ground[k]=false;S.shapeAt[k]={class='ground',h=0,art='flat',flat=true,authored=true}end end
+  for _,q in ipairs(M.geometry(p,uv))do S.objectQuads[#S.objectQuads+1]=q;n=n+1 end
+ end
+ return n
+end
+local glassMesh,glassTexture
+function M.drawGlass(map)
+ local ps=M.placements(map);if #ps==0 then return end
+ local g=love.graphics;local D=V.require('Voxel3D')
+ if not glassMesh then
+  local v,ix={},{}
+  for _,p in ipairs(ps)do
+   local x,z=p.x,p.z;local qs={{{x+1,5,z+.5},{x+63,5,z+.5},{x+63,31,z+.5},{x+1,31,z+.5}},{{x+1,5,z+15.5},{x+63,5,z+15.5},{x+63,31,z+15.5},{x+1,31,z+15.5}},{{x+.5,5,z+1},{x+.5,5,z+15},{x+.5,31,z+15},{x+.5,31,z+1}},{{x+63.5,5,z+1},{x+63.5,5,z+15},{x+63.5,31,z+15},{x+63.5,31,z+1}},{{x+1,31.5,z+1},{x+63,31.5,z+1},{x+63,31.5,z+15},{x+1,31.5,z+15}}}
+   for _,q in ipairs(qs)do local b=#v;for _,c in ipairs(q)do v[#v+1]={c[1],c[2],c[3],.5,.5,1}end;for _,j in ipairs({1,2,3,1,3,4})do ix[#ix+1]=b+j end end
+  end
+  glassMesh=D.newMesh(v,ix);local data=love.image.newImageData(1,1);data:setPixel(0,0,1,1,1,1);glassTexture=g.newImage(data);data:release()
+ end
+ g.push('all');g.setBlendMode('alpha','alphamultiply');g.setDepthMode('lequal',false);g.setColor(.7,.85,1,.07);D.draw(glassMesh,glassTexture);g.pop()
+end
+return M

--- a/lib/Structures.lua
+++ b/lib/Structures.lua
@@ -427,6 +427,7 @@ function Structures.forMap(map)
   if map.id == "OAKS_LAB" or map.id == "FIGHTING_DOJO" then
     V.require("HangingScrolls").build(S, map)
   end
+  if map.id == "MUSEUM_1F" then V.require("MuseumFossils").build(S,map,pixels(tileset),perRow) end
   Buildings.build(S, map, pixels(tileset), perRow)
   if tileset.id == "PLATEAU" then
     V.require("FacadeEntrances").build(S, map, pixels(tileset), perRow)

--- a/lib/VoxelMeshDisk.lua
+++ b/lib/VoxelMeshDisk.lua
@@ -67,7 +67,7 @@ local STATIC_PLAYTHROUGH = "bavc_static_mesh_v2"
 -- Jagged TEST38 masonry, ordinary floors and the distant perimeter are locked.
 -- Revision 31 adds explicit rear entrances, clean rear facades, cave exit
 -- portals and hanging scrolls while retaining the current disk-record layout.
-Disk.CACHE_REVISION = 31
+Disk.CACHE_REVISION = 32
 -- Patch releases which do not change emitted vertices must keep the existing
 -- world cache usable. This token matches the first static-mesh-cache-v2 build;
 -- CACHE_REVISION, not the public mod version, owns geometry compatibility.

--- a/lib/VoxelScene.lua
+++ b/lib/VoxelScene.lua
@@ -1488,6 +1488,7 @@ function VoxelScene.render(state, w, h, vw, vh, paletteFor)
     pcall(companion.render, companion, "translucent_after_actors", state)
   end
 
+  if state.map.id == "MUSEUM_1F" then V.require("MuseumFossils").drawGlass(state.map) end
   local finished = Voxel3D.endScene()
   -- The delta belongs only to this overworld render. Do not let it reach a
   -- later battle or another owner of Voxel3D's placed-camera seam.

--- a/tests/museum_fossils_test.lua
+++ b/tests/museum_fossils_test.lua
@@ -1,0 +1,30 @@
+local root=arg[1] or '.'
+local M=assert(loadfile(root..'/lib/MuseumFossils.lua'))({})
+local pattern={{39,40,40,40,40,40,40,25},{48,70,71,58,58,70,71,44},{49,60,83,63,60,60,60,44},{50,51,50,51,50,51,50,51}}
+local map={id='MUSEUM_1F',tileset={id='MUSEUM'}}
+function map:tileAt(x,y)
+ for _,start in ipairs({4,10})do if x>=2 and x<=9 and y>=start and y<start+4 then return pattern[y-start+1][x-1]end end
+ return 0
+end
+local ps=M.placements(map);assert(#ps==2,'two exhibits expected')
+assert(#M.placements({id='OAKS_LAB',tileset={id='LAB'}})==0)
+local uv={dark={0,0},light={1,1},middle={.5,.5}}
+for _,p in ipairs(ps)do
+ local q=M.geometry(p,uv);local roles={}
+ for _,f in ipairs(q)do roles[f.fossilRole]=(roles[f.fossilRole]or 0)+1
+  for i=1,4 do local v=f[i];assert(v[1]>=p.x and v[1]<=p.x+64);assert(v[2]>=0 and v[2]<=32);assert(v[3]>=p.z and v[3]<=p.z+16.5)end
+ end
+ assert(roles.bone>0 and roles.frame>0 and roles.plaque==6)
+ print(p.kind,#q..' quads',roles.bone..' bone quads')
+end
+print('PASS exact museum placements, unrelated map excluded, bounded geometry, case and skeleton present')
+local snap={};for y=0,15 do for x=0,39 do snap[x..','..y]=map:tileAt(x,y)end end
+local S={skip={},ground={},shapeAt={},objectQuads={}}
+local fake={getDimensions=function()return 2,1 end,getPixel=function(_,x)return x,x,x,1 end}
+local count=M.build(S,map,fake,16);assert(count>0)
+local n=0;for k in pairs(S.skip)do n=n+1 end;assert(n==64,'exact 64 source tiles replaced')
+for key,t in pairs(snap)do local x,y=key:match('^(%d+),(%d+)$');assert(map:tileAt(tonumber(x),tonumber(y))==t,'map mutated')end
+print('PASS 64 exhibit tiles replaced; source map unchanged')
+
+
+local original=map.tileAt;map.tileAt=function(self,x,y)if x==2 and y==4 then return 0 end;return original(self,x,y)end;assert(#M.placements(map)==1,'changed source exhibit must fall back');print('PASS modified exhibit fallback')

--- a/tests/retaining_cave_corner_test.lua
+++ b/tests/retaining_cave_corner_test.lua
@@ -1,0 +1,47 @@
+-- Optional real-map regression; callers supply their own engine/imported data.
+local engine=assert(os.getenv('ASTRA_ENGINE'),'ASTRA_ENGINE required');package.path=engine..'/?.lua;'..package.path
+local Map=require('src.world.Map');local gen=assert(os.getenv('ASTRA_GENERATED'),'ASTRA_GENERATED required')
+local maps=dofile(gen..'/maps.lua');local ts=dofile(gen..'/tilesets.lua')
+local root=os.getenv('ASTRA_CANDIDATE') or '.'
+local V={data=function()return dofile(root..'/data/voxel_heights.lua')end};local modules={BuildBudget={tick=function()end},CommunityVisuals=setmetatable({customWalls=function()return true end},{__index=function()return function()return false end end})}
+function V.require(n)if not modules[n]then modules[n]=assert(loadfile(root..'/lib/'..n..'.lua'))(V)end;return modules[n]end
+local m=Map.new(maps.ROUTE_4,ts.OVERWORLD);local S=V.require('Structures').forMap(m)
+for y=8,11 do for x=36,37 do local k=(y+64)*4096+x+64;local r=S.runs[k]or{};print(x,y,'tile',S.tileAt[k],'fold',S.doorFold[k],'skip',S.skip[k],'door',r.door,'front',r.front,'retaining',r.kantoRetaining,'height',S.shapeAt[k]and S.shapeAt[k].h)end end
+local verts,indices,count=V.require('ChunkMesher').geometry(m,true)
+local front,back=0,0
+for _,v in ipairs(verts)do
+ if v[1]>=288 and v[1]<=304 and v[2]>=0 and v[2]<=16 then
+  if math.abs(v[3]-96)<.01 then front=front+1 end
+  if math.abs(v[3]-90)<.01 then back=back+1 end
+ end
+end
+print('GEOMETRY',#verts,'FRONT_VERTICES',front,'RECESSED_MOUTH_VERTICES',back)
+
+assert(back>0,"Mt Moon recessed mouth must be emitted")
+
+local darkBack,ceilings=0,{}
+for i=1,#verts,4 do
+ local q={verts[i],verts[i+1],verts[i+2],verts[i+3]};local cx,cy,cz=0,0,0
+ for _,v in ipairs(q)do cx=cx+v[1]/4;cy=cy+v[2]/4;cz=cz+v[3]/4 end
+ if cx>288 and cx<304 and cz>=90 and cz<=96 then
+  if math.abs(cz-90)<.01 then darkBack=darkBack+1 end
+  if q[1][2]==q[2][2] and q[2][2]==q[3][2] and q[3][2]==q[4][2] and cy>0 then ceilings[cy]=true end
+ end
+end
+assert(darkBack>0,'deep tunnel back emitted');assert(ceilings[9] and ceilings[12] and ceilings[13],'stepped arch roof levels')
+print('PASS deep tunnel and stepped aperture')
+local cornerFaces=0
+local aw=m.tileset.imageWidth or 128;local ah=m.tileset.imageHeight or 48
+for i=1,#verts,4 do
+ local cx,cz=0,0
+ for j=0,3 do cx=cx+verts[i+j][1]/4;cz=cz+verts[i+j][3]/4 end
+ local tx,ty=math.floor(cx/8),math.floor(cz/8)
+ local x,z=math.floor(tx/2)*2,math.floor(ty/2)*2
+ if m:tileAt(x,z)==55 and m:tileAt(x+1,z)==19 and m:tileAt(x,z+1)==19 and m:tileAt(x+1,z+1)==39 and m:tileAt(tx,ty)==19 then
+  for j=0,3 do local v=verts[i+j];local tile=math.floor(v[4]*aw/8)+math.floor(v[5]*ah/8)*16
+   assert(tile~=19,'raw diagonal cliff art still on corner')
+  end
+  cornerFaces=cornerFaces+1
+ end
+end
+assert(cornerFaces>0,'cliff corners covered by regression');print('PASS cliff material '..cornerFaces..' faces')


### PR DESCRIPTION
Replaces the two first-floor museum fossil displays with voxel Kabutops and Aerodactyl skeletons inside framed glass cases. Each has a base, support and plaque; exact source-pattern guards preserve other cabinets and fall back when the exhibit layout differs.

Also fixes the blue diagonal artwork on the upright cliff corners along Routes 3/4 and gives exterior retaining-wall cave mouths a deeper tunnel with a stepped stone arch. Adds the missing local helper for scalar/per-corner shading. Mesh cache revision advances to 32.

No map, collision, warp or gameplay changes. Built on current master after #46.

Validation:
- Portable museum placement, bounds, geometry and changed-layout fallback tests pass.
- Actual Route 4 geometry regression passes: recessed mouth, three arch heights, and 70 cliff-corner faces without tile 19 UVs.
- Existing cave-exit suite: 12,988 checks pass; cache storage suite: 6 checks pass.
- Three native museum capture views pass with the final PR source in an isolated Windows engine 0.2.27 runtime.
- Both cases total 12,576 solid vertices plus 10 glass panes. Quest performance and engine 0.2.53 validation remain pending.

The desktop Astra19 backport was installed separately for testing; this PR preserves current upstream code outside the focused changes. No imported game data or private saves are included.
