### PR TITLE
Rework Safari scenery and statues; fix interior wall and stair textures

### DIFF
--- a/docs/PROJECT_HANDOFF.md
+++ b/docs/PROJECT_HANDOFF.md
@@ -1,3 +1,7 @@
+## Safari and interior texture follow-up (2026-09-06)
+
+Ported the approved desktop candidate onto master after PR47. See SAFARI_INTERIOR_REWORK.md for scope, preserved upstream changes, exact-checkout tests and platform limitations. Mesh cache revision33; no manifest version change. Horizons artwork remains separate.
+
 ## Museum cases and exterior cave/cliff repairs (2026-09-06)
 
 Based on current master after merged PR46. MuseumFossils replaces only the two

--- a/docs/SAFARI_INTERIOR_REWORK.md
+++ b/docs/SAFARI_INTERIOR_REWORK.md
@@ -1,0 +1,28 @@
+# Safari scenery, original statues, and interior texture repairs
+
+## Changes
+- Wider Safari Center rear gatehouse with opaque double doors and enclosed roof, guarded by the original pair of exits.
+- Original monster statues rebuilt from their source atlas silhouettes with solid voxel sides/backs and original active-palette colors. Desktop inventory: 94 placements across six tileset families.
+- Beveled feet/caps and recessed panels on 65 tall GYM/PLATEAU statue pedestals.
+- Tall olive scrub, branches and dry grass replacing 376 exact blocked Safari hedge cells.
+- Safari-only muted ground/detail palette and matching distant underlay; Center uses outdoor visual lighting/sky without changing engine map classification.
+- HOUSE maps/windows and school blackboard, Red's room windows, Center high windows, LOBBY notices/pictures, and upstairs route-gate window bands are projected onto vertical faces; plain material covers wall tops/sides.
+- Atlas-safe UV subdivision for legacy rising/descending stair faces in all directions.
+- Mesh cache revision 33. Upstream cave materials, ship rendering and facade entrances retained.
+
+Horizons textures and its olive foreground foliage remain in the separate Horizons mod. No ROM data, generated imported sprite sheets, private saves or native runtime fixtures are included.
+
+## Validation on this PR checkout
+- safari_wall_regression_test.lua: shared wall patterns, source UV isolation, idempotence, gate exit guards, foliage bounds, and legacy north/east/west stair directions.
+- world_underlay_nature_test.lua: 5 checks.
+- museum_fossils_test.lua: bounded skeleton/case geometry, exact placement/fallback and unchanged source maps.
+- astra_hanging_scrolls_test.lua: 9,469 checks including real-map fixtures for Oak and Dojo.
+- building_facade_culling_test.lua: 18 checks.
+- astra_facade_entrances_test.lua: 93,055 checks using local generated map/atlas fixtures.
+- Lua syntax checks and git diff --check pass.
+- building_canopy_regression_test.lua could not run: tests/harness.lua is absent from this repository.
+
+## Earlier desktop candidate evidence
+Native still comparisons cover the gatehouse, statue families/pedestals, Safari foliage/ground, house walls and stairs. The structural audit checked 169 maps, 3,624 stair faces and 626 upright wall-art faces, with unchanged blocks/collision/warp definitions. Separate checks covered the 94 statue placements, 376 foliage footprints, both Safari exits and all five Mansion statue switches.
+
+Those captures and the 169-map audit were made on the desktop candidate before porting onto current upstream. They are not a native walkthrough of every map or an exact-head upstream engine test. Quest performance and native testing of this upstream port remain outstanding. Largest measured foliage mesh: North 122,604 vertices; Center 83,564, East 73,868, West 83,264.

--- a/lib/HouseWallDecor.lua
+++ b/lib/HouseWallDecor.lua
@@ -1,0 +1,62 @@
+-- Shared interior wall artwork belongs on vertical faces, never box lids.
+local M={}
+local function key(x,y)return(y+64)*4096+x+64 end
+local profiles={
+ HOUSE={
+  {w=2,tiles={45,46,61,62},under={0,0,0,0}},
+  {w=2,tiles={36,36,52,52},under={0,0,0,0}},
+  {w=4,tiles={72,73,73,75,88,89,90,91},under={0,0,0,0,0,0,0,0}},
+ },
+ REDS_HOUSE_2={{w=2,tiles={36,37,52,53},under={0,0,0,0}}},
+ POKECENTER={{w=2,tiles={92,93,94,95},under={40,40,40,40}}},
+ LOBBY={
+  {w=1,tiles={6,22},under={1,33}},
+  {w=2,tiles={72,73,88,89},under={1,1,33,33}},
+ },
+}
+local gateGlass={[45]=true,[58]=true,[61]=true,[62]=true}
+function M.build(S,map,x0,x1,y0,y1)
+ local tid=map.tileset.id
+ if not profiles[tid] and tid~='GATE' then return end
+ local aw,ah=map.tileset.imageWidth or 128,map.tileset.imageHeight or 48
+ local perRow=map.tileset.tilesPerRow or 16
+ local function emit(x,y,w,h,tiles,under)
+  for i,t in ipairs(tiles)do
+   local dx,dy=(i-1)%w,math.floor((i-1)/w)
+   -- A gate's deep source band becomes one upright window at the same height.
+   local step=16/h
+   local xx,yy,z=(x+dx)*8,16-dy*step,(y+h)*8+.08
+   local u,v=t%perRow*8,math.floor(t/perRow)*8
+   S.objectQuads[#S.objectQuads+1]={{xx,yy-step,z},{xx+8,yy-step,z},{xx+8,yy,z},{xx,yy,z},
+    uv={{(u+.05)/aw,(v+7.95)/ah},{(u+7.95)/aw,(v+7.95)/ah},{(u+7.95)/aw,(v+.05)/ah},{(u+.05)/aw,(v+.05)/ah}},
+    shade=1,houseWallDecor=true,wallDecorSourceTile=t}
+   S.tileAt[key(x+dx,y+dy)]=under[i]
+  end
+ end
+ for _,p in ipairs(profiles[tid] or {})do
+  local h=#p.tiles/p.w
+  for y=math.max(0,y0),math.min(map.def.height*4-h,y1-h+1)do
+   for x=math.max(0,x0),math.min(map.def.width*4-p.w,x1-p.w+1)do
+    local hit=true
+    for i,t in ipairs(p.tiles)do
+     local k=key(x+(i-1)%p.w,y+math.floor((i-1)/p.w))
+     if S.tileAt[k]~=t or not S.shapeAt[k] or S.shapeAt[k].class~='wall' then hit=false;break end
+    end
+    if hit then emit(x,y,p.w,h,p.tiles,p.under)end
+   end
+  end
+ end
+ -- Only the authored four-row north window band of upstairs route gates.
+ if tid=='GATE' and map.id:match('_GATE_2F$') then
+  for x=0,map.def.width*4-1 do
+   local tiles,under={},{}
+   for y=0,3 do
+    local k=key(x,y);local t=S.tileAt[k]
+    if not gateGlass[t] or not S.shapeAt[k] or S.shapeAt[k].class~='wall' then break end
+    tiles[#tiles+1]=t;under[#under+1]=0
+   end
+   if #tiles==4 then emit(x,0,1,4,tiles,under)end
+  end
+ end
+end
+return M

--- a/lib/InteriorStairs.lua
+++ b/lib/InteriorStairs.lua
@@ -21,17 +21,10 @@ function Stairs.build(S,map,data,cx,cy,s)
   local perRow=map.tileset.tilesPerRow or 16
   local aw,ah=map.tileset.imageWidth or 128,map.tileset.imageHeight or 48
   local quads=S.objectQuads
-  local function uv(x,y)
-    x=math.max(.05,math.min(15.95,x));y=math.max(.05,math.min(15.95,y))
-    local tx,tz=cx*2+math.floor(x/8),cy*2+math.floor(y/8)
-    local tile=S.tileAt[key(tx,tz)]
-    assert(tile~=nil,"interior stair source cell")
-    return{((tile%perRow)*8+x%8)/aw,(math.floor(tile/perRow)*8+y%8)/ah}
-  end
   local function vertex(x,y,z)return{mx+x,y,mz+z}end
   local function put(points,coords,shade,role)
     local q={points[1],points[2],points[3],points[4],uv={},shade=shade}
-    if s.warpStair then
+    do
       -- Shared public drawings need not occupy adjacent atlas tiles.
       -- Select the source tile from this face's center, keeping an edge
       -- at pixel 8/16 inside that same tile instead of jumping to its neighbor.
@@ -39,13 +32,12 @@ function Stairs.build(S,map,data,cx,cy,s)
       for i=1,4 do ax=ax+coords[i][1]/4;ay=ay+coords[i][2]/4 end
       local bx,by=math.floor(ax/8),math.floor(ay/8)
       local tile=S.tileAt[key(cx*2+bx,cy*2+by)]
+      q.stairSourceTile=tile
       for i=1,4 do
         local x=math.max(.05,math.min(7.95,coords[i][1]-bx*8))
         local y=math.max(.05,math.min(7.95,coords[i][2]-by*8))
         q.uv[i]={((tile%perRow)*8+x)/aw,(math.floor(tile/perRow)*8+y)/ah}
       end
-    else
-      for i=1,4 do q.uv[i]=uv(coords[i][1],coords[i][2])end
     end
     -- Diagnostic roles do not participate in batching or material selection.
     q.interiorStairRole=role

--- a/lib/SafariFoliage.lua
+++ b/lib/SafariFoliage.lua
@@ -1,0 +1,107 @@
+-- Dense voxel foliage replacing only the complete Safari hedge block.
+local V=...
+local M={}
+local allowed={SAFARI_ZONE_CENTER=true,SAFARI_ZONE_EAST=true,SAFARI_ZONE_NORTH=true,SAFARI_ZONE_WEST=true}
+local cache={};local texture
+function M.placements(map)
+ local out={}
+ if not(map and allowed[map.id]and map.tileset.id=='FOREST')then return out end
+ for y=0,map.def.height*4-2,2 do for x=0,map.def.width*4-2,2 do
+  if map:tileAt(x,y)==84 and map:tileAt(x+1,y)==85 and map:tileAt(x,y+1)==86 and map:tileAt(x+1,y+1)==87 and not map:isWalkableCell(x/2,y/2)then out[#out+1]={x=x/2,z=y/2,tx=x,ty=y}end
+ end end
+ return out
+end
+local function hash(x,y,z)return (x*197+y*71+z*283+x*z*13)%997 end
+function M.geometry(ps)
+ local vox,owners={},{}
+ local function key(x,y,z)return x..','..y..','..z end
+ for _,p in ipairs(ps)do owners[p.x..','..p.z]=true end
+ for _,p in ipairs(ps)do
+  local ox,oz=p.x*8,p.z*8
+  local shift=(hash(p.x,0,p.z)%3-1)*.4
+  for x=0,7 do for z=0,7 do for y=0,9 do
+   local xx,yy,zz=x+.5,y+.5,z+.5
+   local function lobe(cx,cy,cz,rx,ry,rz)return ((xx-cx)/rx)^2+((yy-cy)/ry)^2+((zz-cz)/rz)^2<=1 end
+   local leaf=lobe(2.6,6.5+shift,3.2,3.0,1.8,3.1)or lobe(5.2,7.8+shift,4.3,2.8,1.7,3.0)or lobe(3.8,4.0,4.8,3.0,1.6,2.6)
+   -- Join neighboring bushes through their interior, preserving a scalloped edge.
+   if y>=5 and y<=7 then
+    if (x==0 and owners[(p.x-1)..','..p.z])or(x==7 and owners[(p.x+1)..','..p.z])then leaf=leaf or(z>=2 and z<=5)end
+    if (z==0 and owners[p.x..','..(p.z-1)])or(z==7 and owners[p.x..','..(p.z+1)])then leaf=leaf or(x>=2 and x<=5)end
+   end
+   if leaf then
+    local c=2+hash(math.floor((ox+x)/2),math.floor(y/2),math.floor((oz+z)/2))%3
+    if y>=7 and hash(ox+x,y,oz+z)%3==0 then c=5 end
+    vox[key(ox+x,y,oz+z)]={ox+x,y,oz+z,c}
+   end
+  end end end
+  -- Rooted woody core, mostly sheltered by the leaf clusters.
+  for y=0,5 do for x=3,4 do for z=3,4 do vox[key(ox+x,y,oz+z)]={ox+x,y,oz+z,6}end end end
+  for x=1,6 do local y=4+math.floor(math.abs(x-3)/2);vox[key(ox+x,y,oz+3)]={ox+x,y,oz+3,6}end
+
+ end
+ local D=V.require('Voxel3D');local dirs={{1,0,0},{-1,0,0},{0,1,0},{0,-1,0},{0,0,1},{0,0,-1}}
+ local axes={{1,2,3},{1,2,3},{2,1,3},{2,1,3},{3,1,2},{3,1,2}};local groups={}
+ for _,v in pairs(vox)do for f,d in ipairs(dirs)do if not vox[key(v[1]+d[1],v[2]+d[2],v[3]+d[3])]then
+  local ax=axes[f];local plane=v[ax[1]]+(f%2==1 and 1 or 0);local k=f..':'..plane..':'..v[4]
+  local g=groups[k]or {f=f,plane=plane,color=v[4],cells={}};groups[k]=g;g.cells[v[ax[2]]..','..v[ax[3]]]={v[ax[2]],v[ax[3]]}
+ end end end
+ local verts,indices={},{};local gkeys={};for k in pairs(groups)do gkeys[#gkeys+1]=k end;table.sort(gkeys)
+ for _,gk in ipairs(gkeys)do local g=groups[gk];local keys={};for k in pairs(g.cells)do keys[#keys+1]=k end;table.sort(keys)
+  for _,k in ipairs(keys)do local cell=g.cells[k];if cell then
+   local u,v=cell[1],cell[2];local w,h=1,1
+   while g.cells[(u+w)..','..v]do w=w+1 end
+   while true do local full=true;for j=0,w-1 do if not g.cells[(u+j)..','..(v+h)]then full=false;break end end;if not full then break end;h=h+1 end
+   for y=v,v+h-1 do for x=u,u+w-1 do g.cells[x..','..y]=nil end end
+   local ax=axes[g.f];local base,size={0,0,0},{0,0,0};base[ax[1]]=g.plane;base[ax[2]]=u;base[ax[3]]=v;size[ax[2]]=w;size[ax[3]]=h
+   local b=#verts;for _,c in ipairs(D.FACE_CORNERS[g.f])do verts[#verts+1]={(base[1]+c[1]*size[1])*2,(base[2]+c[2]*size[2])*2,(base[3]+c[3]*size[3])*2,(g.color-.5)/6,.5,D.FACE_SHADE[g.f]}end
+   for _,i in ipairs({1,2,3,1,3,4})do indices[#indices+1]=b+i end
+  end end
+ end
+ -- Narrow stepped grass blades, rather than trunk-sized blocks.
+ for _,p in ipairs(ps)do for _,a in ipairs({{2,2},{13,4},{4,13}})do
+  for j=0,2 do
+   local x,z=p.x*16+a[1]+j*.55,p.z*16+a[2]
+   local h=2+(hash(p.x,j,p.z)%3)*.7
+   local b=#verts
+   for f,corners in ipairs(D.FACE_CORNERS)do
+    b=#verts;for _,c in ipairs(corners)do verts[#verts+1]={x+c[1]*.4,c[2]*h,z+c[3]*.4,4.5/6,.5,D.FACE_SHADE[f]}end
+    for _,i in ipairs({1,2,3,1,3,4})do indices[#indices+1]=b+i end
+   end
+  end
+ end end
+ return verts,indices
+end
+local function prepare(map)
+ if not(map and allowed[map.id])then return end
+ if cache[map.id]then return cache[map.id]end
+ local ps=M.placements(map);if #ps==0 then return end
+ local ok,r=pcall(function()
+  if not texture then
+   local colors={{.12,.18,.065},{.24,.31,.105},{.34,.41,.14},{.43,.48,.20},{.64,.57,.29},{.29,.23,.12}}
+   local data=love.image.newImageData(6,1);for i,c in ipairs(colors)do data:setPixel(i-1,0,c[1],c[2],c[3],1)end
+   texture=love.graphics.newImage(data);data:release();texture:setFilter('nearest','nearest')
+  end
+  local verts,indices=M.geometry(ps)
+  return {mesh=assert(V.require('Voxel3D').newMesh(verts,indices)),placements=ps,vertices=#verts}
+ end)
+ if ok then cache[map.id]=r;return r end
+end
+function M.build(S,map)
+ local r=prepare(map);if not r then return 0 end
+ for _,p in ipairs(r.placements)do for y=p.ty,p.ty+1 do for x=p.tx,p.tx+1 do
+  local k=(y+64)*4096+x+64;S.skip[k]=true;S.ground[k]=48;S.shapeAt[k]={class='ground',h=0,art='flat',flat=true,authored=true}
+ end end end
+ return #r.placements
+end
+function M.draw(map,ox,oz,shadow)
+ local r=prepare(map);if not r then return end
+ local model=(ox~=0 or oz~=0)and V.require('Mat4').translate(ox,0,oz)or nil
+ if shadow then shadow.draw(r.mesh,texture,model)else V.require('Voxel3D').draw(r.mesh,texture,model)end
+end
+function M.setLive(live)
+ for id,r in pairs(cache)do if not live[id]then r.mesh:release();cache[id]=nil end end
+ if not next(cache)and texture then texture:release();texture=nil end
+end
+function M.invalidate()M.setLive({})end
+function M.diagnostics(map)local r=prepare(map);return r and {count=#r.placements,vertices=r.vertices}or {count=0,vertices=0}end
+return M

--- a/lib/SafariGatehouse.lua
+++ b/lib/SafariGatehouse.lua
@@ -1,0 +1,50 @@
+-- Rear gatehouse shell, owned by the real two-cell Safari exit.
+local V=...
+local M={}
+function M.matches(map)
+ if not(map and map.id=='SAFARI_ZONE_CENTER' and map.tileset.id=='FOREST')then return false end
+ local found={}
+ for _,w in ipairs(map.def.warps or {})do
+  if w.y==25 and w.destMap=='SAFARI_ZONE_GATE' and ((w.x==14 and w.destWarp==3) or (w.x==15 and w.destWarp==4))then found[w.x]=true end
+ end
+ return found[14] and found[15] or false
+end
+local faces={{1,2,3,4},{5,8,7,6},{1,5,6,2},{4,3,7,8},{1,4,8,5},{2,6,7,3}}
+local shades={1,.75,.6,1,.82,.9}
+function M.geometry(uv)
+ local q={}
+ local function box(x,y,z,w,h,d,color,role)
+  y,h=y*.6,h*.6
+  local p={{x,y,z},{x+w,y,z},{x+w,y+h,z},{x,y+h,z},{x,y,z+d},{x+w,y,z+d},{x+w,y+h,z+d},{x,y+h,z+d}}
+  for f,ids in ipairs(faces)do q[#q+1]={p[ids[1]],p[ids[2]],p[ids[3]],p[ids[4]],uv={uv[color],uv[color],uv[color],uv[color]},shade=shades[f],own=true,gateRole=role}end
+ end
+ -- Structural body is beyond the original map edge (z416). No walking cells claimed.
+ box(192,0,416,32,44,32,'wood','wall');box(256,0,416,32,44,32,'wood','wall')
+ box(224,36,416,32,8,32,'wood','lintel');box(192,0,446,96,44,2,'wood','rear')
+ for _,x in ipairs({192,220,256,284})do box(x,0,415.5,4,44,3,'dark','post')end
+ box(188,44,412,104,4,40,'dark','roof')
+ -- Opaque backing and two inset door leaves; no view through the center seam.
+ box(224,0,417,32,36,2,'dark','doorBacking')
+ box(224.75,1,416,14.5,33,1,'wood','door');box(240.75,1,416,14.5,33,1,'wood','door')
+ for y=6,30,6 do
+  box(196,y,415.4,24,.6,.25,'middle','wallSeam');box(260,y,415.4,24,.6,.25,'middle','wallSeam')
+  box(225,y,415.7,14,.35,.35,'middle','doorSeam');box(241,y,415.7,14,.35,.35,'middle','doorSeam')
+ end
+ box(235.5,16,414.8,2,2,1.2,'dark','handle');box(242.5,16,414.8,2,2,1.2,'dark','handle')
+ return q
+end
+function M.build(S,map,data)
+ if not M.matches(map) or not data then return 0 end
+ local w,h=data:getDimensions();local uv,best={},{dark=1e9,wood=1e9,middle=1e9}
+ for y=0,h-1 do for x=0,w-1 do
+  local a,b,c,alpha=data:getPixel(x,y)
+  if (alpha or 1)>.5 then for name,target in pairs({dark=0,wood=2/3,middle=1/3})do
+   local score=math.abs((a+b+c)/3-target)
+   if score<best[name]then best[name]=score;uv[name]={(x+.5)/w,(y+.5)/h}end
+  end end
+ end end
+ if not(uv.dark and uv.wood and uv.middle)then return 0 end
+ local q=M.geometry(uv);for _,face in ipairs(q)do S.objectQuads[#S.objectQuads+1]=face end
+ return #q
+end
+return M

--- a/lib/SafariStatues.lua
+++ b/lib/SafariStatues.lua
@@ -1,0 +1,209 @@
+-- Original Safari monster ornament rebuilt from its own atlas pixels.
+-- Front details stay on the front; shaped body sides and back are solid.
+local V=...
+local M={}
+local configs={
+ FOREST={tiles={10,11,26,27},base={75,76},ownBase=true,maps={SAFARI_ZONE_CENTER=true,SAFARI_ZONE_WEST=true,SAFARI_ZONE_EAST=true,SAFARI_ZONE_NORTH=true}},
+ GATE={tiles={14,15,30,31},base={50,51},ownBase=true,maps={ROUTE_22_GATE=true}},
+ INTERIOR={tiles={17,18,33,34},base={91,92},height=8,tabletop=true,maps={POKEMON_FAN_CLUB=true,SILPH_CO_11F=true}},
+ GYM={tiles={2,56,18,19},base={34,35,50,51},height=0,plinth=true,maps={PEWTER_GYM=true,CERULEAN_GYM=true,VERMILION_GYM=true,CELADON_GYM=true,FUCHSIA_GYM=true,VIRIDIAN_GYM=true,BRUNOS_ROOM=true,LORELEIS_ROOM=true,CHAMPIONS_ROOM=true}},
+ PLATEAU={tiles={16,18,40,41},base={21,22,48,49},height=0,plinth=true,maps={INDIGO_PLATEAU=true,ROUTE_23=true}},
+ FACILITY={tiles={39,47,55,63},base={61,62},ownBase=true,maps={SAFFRON_GYM=true,CINNABAR_GYM=true,POKEMON_MANSION_1F=true,POKEMON_MANSION_2F=true,POKEMON_MANSION_3F=true,POKEMON_MANSION_B1F=true}}
+}
+local cache,templates={},{}
+local sourceData
+local unit=1
+function M.placements(map)
+ local out={};local cfg=map and map.tileset and configs[map.tileset.id]
+ if not(cfg and cfg.maps[map.id])then return out end
+ for y=0,map.def.height*4-2 do for x=0,map.def.width*4-2 do
+  local match=true
+  for i,id in ipairs(cfg.tiles)do if map:tileAt(x+(i-1)%2,y+math.floor((i-1)/2))~=id then match=false;break end end
+  local pedestal=true
+  for i,id in ipairs(cfg.base)do if map:tileAt(x+(i-1)%2,y+2+math.floor((i-1)/2))~=id then pedestal=false;break end end
+  local originalForest=map.tileset.id=='FOREST'and y%2==0
+  if match and (pedestal or originalForest)then
+   local baseTy=cfg.ownBase and (pedestal and y+1 or y)or (cfg.tabletop and y+1 or y+2)
+   if not map:isWalkableCell(math.floor(x/2),math.floor(baseTy/2))then
+    out[#out+1]={x=x*8,z=baseTy*8,tx=x,ty=y,rows=cfg.plinth and 4 or (cfg.ownBase and pedestal and 3 or 2),kind=map.tileset.id,height=cfg.height or 0,tabletop=cfg.tabletop,turn=map.id=='SAFARI_ZONE_CENTER'and baseTy/2>=20}
+   end
+  end
+ end end
+ return out
+end
+-- Occupancy union emits exposed faces only, including real backs and undersides.
+function M.template(kind)
+ if templates[kind]then return templates[kind]end
+ local cfg=assert(configs[kind]);local lift=cfg.plinth and 16 or (cfg.ownBase and 3 or 0)
+ local vox={}
+ local function key(x,y,z)return x..','..y..','..z end
+ local function put(x,y,z,c)
+  assert(x>=-12 and x<12 and z>=-12 and z<12,'statue exceeds original footprint')
+  vox[key(x,y,z)]={x,y,z,c or 2}
+ end
+ local function box(x,y,z,w,h,d,c)
+  for a=x,x+w-1 do for b=y,y+h-1 do for e=z,z+d-1 do put(a,b,e,c)end end end
+ end
+ -- Read existing four tiles; no replacement sprite asset is shipped.
+ local data=assert(sourceData,'original statue atlas unavailable')
+ local iw,ih=data:getDimensions();local perRow=math.floor(iw/8)
+ local colors,air,sourceUV={},{},{}
+ for y=0,15 do for x=0,15 do
+  local tile=cfg.tiles[math.floor(y/8)*2+math.floor(x/8)+1]
+  local rr,gg,bb,aa=data:getPixel((tile%perRow)*8+x%8,math.floor(tile/perRow)*8+y%8)
+  local c=math.floor((rr+gg+bb)/3*3+.5)
+  colors[y*16+x]={c=c,alpha=aa or 1}
+  sourceUV[c]=sourceUV[c]or {((tile%perRow)*8+x%8+.5)/iw,(math.floor(tile/perRow)*8+y%8+.5)/ih}
+ end end
+ local bg=colors[0].c
+ local queue={}
+ local function seed(x,y)
+  if x<0 or y<0 or x>15 or y>15 then return end
+  local k=y*16+x;local c=colors[k]
+  if not air[k]and(c.c==bg or c.alpha<.5)then air[k]=true;queue[#queue+1]={x,y}end
+ end
+ for i=0,15 do seed(i,0);seed(i,15);seed(0,i);seed(15,i)end
+ local i=1;while queue[i]do local a=queue[i];seed(a[1]-1,a[2]);seed(a[1]+1,a[2]);seed(a[1],a[2]-1);seed(a[1],a[2]+1);i=i+1 end
+ if cfg.ownBase then box(-8,0,-8,16,2,16,4);box(-7,2,-7,14,1,14,2)end
+ for y=0,15 do for x=0,15 do
+  if not air[y*16+x]then
+   local edge=math.abs(x-7.5)
+   local front,back=12,4
+   if y<=3 then front,back=11,7 end -- ears and crown
+   if y>=7 and edge>5 then front,back=11,7 end -- separate arms
+   if y>=11 and edge<5 then front,back=13,3 end -- rounded belly
+   if y>=14 then front,back=14,4 end -- planted feet
+   if y>=7 and y<=9 and edge<2 then front=14 end -- raised snout/horn
+   local taper=math.max(0,math.floor((edge-3)/2))
+   front,back=front-taper,back+taper
+   local c=({[0]=1,[1]=2,[2]=3,[3]=5})[colors[y*16+x].c]
+   for z=back,front do put(x-8,15+lift-y,z-8,z==front and c or 2)end
+  end
+ end end
+ -- Connect the crown behind the original face, without a floating top voxel.
+ box(-1,12+lift,-1,2,4,2,2)
+ local paletteUV={sourceUV[0],sourceUV[1],sourceUV[2],sourceUV[0],sourceUV[3],sourceUV[1],sourceUV[1]}
+ local D=V.require('Voxel3D');local out={}
+ local dirs={{1,0,0},{-1,0,0},{0,1,0},{0,-1,0},{0,0,1},{0,0,-1}}
+ local axes={{1,2,3},{1,2,3},{2,1,3},{2,1,3},{3,1,2},{3,1,2}}
+ local groups={}
+ for _,v in pairs(vox)do for f,d in ipairs(dirs)do
+  if not vox[key(v[1]+d[1],v[2]+d[2],v[3]+d[3])]then
+   local c=v[4]
+
+   local ax=axes[f];local plane=v[ax[1]]+(f%2==1 and 1 or 0)
+   local gk=f..':'..plane..':'..c
+   local g=groups[gk]or {f=f,plane=plane,color=c,cells={}};groups[gk]=g
+   g.cells[v[ax[2]]..','..v[ax[3]]]={v[ax[2]],v[ax[3]]}
+  end
+ end end
+ -- Greedy coplanar rectangles preserve the silhouette and remove tiny flat faces.
+ local gkeys={};for k in pairs(groups)do gkeys[#gkeys+1]=k end;table.sort(gkeys)
+ for _,gk in ipairs(gkeys)do local g=groups[gk];local keys={}
+  for k in pairs(g.cells)do keys[#keys+1]=k end;table.sort(keys)
+  for _,k in ipairs(keys)do local cell=g.cells[k]
+   if cell then
+    local u,v=cell[1],cell[2];local w,h=1,1
+    while g.cells[(u+w)..','..v]do w=w+1 end
+    while true do local full=true;for j=0,w-1 do if not g.cells[(u+j)..','..(v+h)]then full=false;break end end;if not full then break end;h=h+1 end
+    for y=v,v+h-1 do for x=u,u+w-1 do g.cells[x..','..y]=nil end end
+    local ax=axes[g.f];local base,size={0,0,0},{0,0,0}
+    base[ax[1]]=g.plane;base[ax[2]]=u;base[ax[3]]=v;size[ax[2]]=w;size[ax[3]]=h
+    local q={};for _,c in ipairs(D.FACE_CORNERS[g.f])do
+     q[#q+1]={(base[1]+c[1]*size[1])*unit+8,(base[2]+c[2]*size[2])*unit,(base[3]+c[3]*size[3])*unit+8,paletteUV[g.color][1],paletteUV[g.color][2],D.FACE_SHADE[g.f]}
+    end
+    out[#out+1]=q
+   end
+  end
+ end
+ if cfg.plinth then
+  -- Keep the original 16px pedestal and front plaque, not a repeated figure.
+  local function uv(tile,px,py)return {(tile%perRow*8+px+.5)/iw,(math.floor(tile/perRow)*8+py+.5)/ih}end
+  local side=sourceUV[1]
+  for _,tile in ipairs(cfg.base)do
+   local found=false
+   for yy=0,7 do for xx=0,7 do
+    local rr,gg,bb=data:getPixel(tile%perRow*8+xx,math.floor(tile/perRow)*8+yy)
+    if math.floor((rr+gg+bb)/3*3+.5)==1 then side=uv(tile,xx,yy);found=true;break end
+   end;if found then break end end
+   if found then break end
+  end
+  local dark=sourceUV[0]
+  local function solid(x,y,z,w,h,d,tex)
+   for f,corners in ipairs(D.FACE_CORNERS)do
+    local q={};for _,c in ipairs(corners)do q[#q+1]={x+c[1]*w,y+c[2]*h,z+c[3]*d,tex[1],tex[2],D.FACE_SHADE[f]}end;out[#out+1]=q
+   end
+  end
+  local function bevel(y0,y1,in0,in1,tex)
+   local low={{in0,y0,in0},{16-in0,y0,in0},{16-in0,y0,16-in0},{in0,y0,16-in0}}
+   local high={{in1,y1,in1},{16-in1,y1,in1},{16-in1,y1,16-in1},{in1,y1,16-in1}}
+   for i=1,4 do local j=i%4+1;local q={};for _,p in ipairs({low[j],low[i],high[i],high[j]})do q[#q+1]={p[1],p[2],p[3],tex[1],tex[2],.82}end;out[#out+1]=q end
+  end
+  -- Full-width foot and cap retain the exact old height and footprint.
+  solid(0,0,0,16,1,16,dark)
+  bevel(1,2,0,1,side)
+  solid(1,2,1,14,.6,14,dark)
+  solid(2,2.6,2,12,10.4,12,side)
+  for _,x in ipairs({1,13})do for _,z in ipairs({1,13})do solid(x,2.6,z,2,10.4,2,side)end end
+  -- Dark recessed panel borders on the two sides and rear, no repeated face art.
+  for _,x in ipairs({1.65,13.95})do
+   solid(x,4,3.5,.4,.45,9,dark);solid(x,11.4,3.5,.4,.45,9,dark)
+   solid(x,4,3.5,.4,7.8,.45,dark);solid(x,4,12,.4,7.8,.45,dark)
+  end
+  solid(3.5,4,1.65,9,.45,.4,dark);solid(3.5,11.4,1.65,9,.45,.4,dark)
+  solid(3.5,4,1.65,.45,7.8,.4,dark);solid(12,4,1.65,.45,7.8,.4,dark)
+  solid(1,13,1,14,.7,14,dark)
+  bevel(13.7,15,1,0,side)
+  solid(0,15,0,16,.55,16,dark)
+  solid(.35,15.55,.35,15.3,.45,15.3,side)
+  -- Original four-tile front is inset as one panel within the stone frame.
+  for i,tile in ipairs(cfg.base)do
+   local x=2+((i-1)%2)*6;local y=3+5-math.floor((i-1)/2)*5
+   local u0=(tile%perRow*8)/iw;local v0=math.floor(tile/perRow)*8/ih
+   local u1=u0+8/iw;local v1=v0+8/ih
+   out[#out+1]={{x,y,14.02,u0,v1,.9},{x+6,y,14.02,u1,v1,.9},{x+6,y+5,14.02,u1,v0,.9},{x,y+5,14.02,u0,v0,.9}}
+  end
+ end
+ templates[kind]=out;return out
+end
+local function prepare(map)
+ if not(map and map.tileset and configs[map.tileset.id]and configs[map.tileset.id].maps[map.id])then return end
+ if cache[map.id]then return cache[map.id]end
+ local ps=M.placements(map);if #ps==0 then return end
+ local ok,record=pcall(function()
+  sourceData=assert(require("src.render.Assets").imageData(map.tileset.image))
+  local verts,indices={},{}
+  for _,p in ipairs(ps)do for _,q in ipairs(M.template(p.kind))do local b=#verts
+   for _,v in ipairs(q)do verts[#verts+1]={(p.turn and 16-v[1]or v[1])+p.x,v[2]+p.height,(p.turn and 16-v[3]or v[3])+p.z,v[4],v[5],v[6]}end
+   for _,i in ipairs({1,2,3,1,3,4})do indices[#indices+1]=b+i end
+  end end
+  local mesh=assert(V.require('Voxel3D').newMesh(verts,indices))
+  return {mesh=mesh,placements=ps,vertices=#verts}
+ end)
+ if ok then cache[map.id]=record;return record end
+ -- Leave the original tile art intact if this platform cannot create the mesh.
+ return nil
+end
+function M.build(S,map)
+ local r=prepare(map);if not r then return 0 end
+ for _,p in ipairs(r.placements)do for y=p.ty,p.ty+p.rows-1 do for x=p.tx,p.tx+1 do
+  local k=(y+64)*4096+x+64
+  if p.tabletop then
+   S.tileAt[k]=64;S.shapeAt[k]={class='counter',h=8,art='upright',authored=true}
+  else S.skip[k]=true;S.ground[k]=false;S.shapeAt[k]={class='ground',h=0,art='flat',flat=true,authored=true}end
+ end end end
+ return #r.placements
+end
+function M.draw(map,ox,oz,shadow,atlas)
+ local r=prepare(map);if not r then return end
+ local model=(ox~=0 or oz~=0)and V.require('Mat4').translate(ox,0,oz)or nil
+ local texture=atlas or (map.renderer and map.renderer.image)
+ if not texture then return end
+ if shadow then shadow.draw(r.mesh,texture,model)else V.require('Voxel3D').draw(r.mesh,texture,model)end
+end
+function M.setLive(live)
+ for id,r in pairs(cache)do if not live[id]then r.mesh:release();cache[id]=nil end end
+end
+function M.invalidate()M.setLive({})end
+function M.diagnostics(map)local r=prepare(map);return r and {count=#r.placements,vertices=r.vertices}or {count=0,vertices=0}end
+return M

--- a/lib/Structures.lua
+++ b/lib/Structures.lua
@@ -428,10 +428,13 @@ function Structures.forMap(map)
     V.require("HangingScrolls").build(S, map)
   end
   if map.id == "MUSEUM_1F" then V.require("MuseumFossils").build(S,map,pixels(tileset),perRow) end
+  V.require("SafariFoliage").build(S,map)
+  V.require("SafariStatues").build(S,map)
   Buildings.build(S, map, pixels(tileset), perRow)
   if tileset.id == "PLATEAU" then
     V.require("FacadeEntrances").build(S, map, pixels(tileset), perRow)
   end
+  if map.id == 'SAFARI_ZONE_CENTER' then V.require('SafariGatehouse').build(S,map,pixels(tileset)) end
 
   -- Fold doors into their buildings. A door cell is WALKABLE (the player
   -- steps onto it to warp), so it resolves to ground and punches a hole in
@@ -521,6 +524,7 @@ function Structures.forMap(map)
   -- says is behind the object, so the wall band it was painted into keeps
   -- resolving as the wall it is -- without a second copy of the drawing
   -- flat on its face.
+  V.require("HouseWallDecor").build(S, map, x0, x1, y0, y1)
   Structures.buildMounted(S, map, x0, x1, y0, y1)
 
   -- ---- flood-fill regions of structural tiles ----
@@ -2300,23 +2304,14 @@ local function stairCell(S, map, data, cx, cy, s)
   local runW = 16 / STAIR_STEPS
   local z0, z1 = mz, mz + 16
 
-  -- cell-space art coords (16x16, row 0 the top) -> atlas uv; callers keep
-  -- a quad's range inside one 8px tile so it never samples across a seam
-  local function uv(px, py)
-    px = math.max(0.05, math.min(15.95, px))
-    py = math.max(0.05, math.min(15.95, py))
-    local tile = S.tileAt[keyOf(cx * 2 + (px >= 8 and 1 or 0),
-                                cy * 2 + (py >= 8 and 1 or 0))]
-    return ((tile % perRow) * 8 + px % 8) / atlasW,
-           (math.floor(tile / perRow) * 8 + py % 8) / atlasH
-  end
   -- corners run bottom-left, bottom-right, top-right, top-left as seen
   -- from outside (the mesher's side convention); art rect in cell space
   local function face(c1, c2, c3, c4, ax0, ay0, ax1, ay1, shade)
-    if s.warpStair then
-      -- Newly authored public stairs use shared/nonadjacent atlas tiles.
+    do
+      -- All stair faces need atlas-safe subdivision, including legacy stairs.
+      -- Source tiles need not be adjacent in the atlas.
       -- Split both source seams and the eight-pixel world-curve lattice;
-      -- the historical Red/Ship path below remains exactly as authored.
+      -- Keep geometry, direction and the original source drawings intact.
       local us, vs = { 0, 1 }, { 0, 1 }
       local function cuts(out, a, b)
         if math.abs(b-a) < .000001 then return end
@@ -2346,15 +2341,11 @@ local function stairCell(S, map, data, cx, cy, s)
           return {((tile%perRow)*8+x)/atlasW,(math.floor(tile/perRow)*8+y)/atlasH}
         end
         quads[#quads+1]={point(a,c),point(b,c),point(b,d),point(a,d),
-          uv={source(a,c),source(b,c),source(b,d),source(a,d)},shade=shade}
+          uv={source(a,c),source(b,c),source(b,d),source(a,d)},shade=shade,stairSourceTile=tile}
       end end
       return
     end
-    local u0, v0 = uv(ax0, ay0)
-    local u1, v1 = uv(ax1, ay1)
-    quads[#quads + 1] = { c1, c2, c3, c4,
-      uv = { { u0, v1 }, { u1, v1 }, { u1, v0 }, { u0, v0 } },
-      shade = shade }
+
   end
   -- a vertical face spanning heights [fy0, fy1] wearing art rows
   -- [ay0, ay1], emitted per 8-row art band so no quad crosses the seam

--- a/lib/TerrainAtlas.lua
+++ b/lib/TerrainAtlas.lua
@@ -916,7 +916,7 @@ function TerrainAtlas.animate(map, colors, base, baked)
   local caveMaterial = map.tileset and map.tileset.id == "CAVERN"
     and "#test36-warm-brick-rough-cap" or ""
   local key = map.tileset.image .. "#a#" .. paletteKey(colors or {})
-    .. "#community#" .. communityKey() .. caveMaterial .. (perMap or "")
+    .. "#community#" .. communityKey() .. caveMaterial .. (perMap or "") .. ((map.id or ""):match("^SAFARI_ZONE_") and ("#safari#"..map.id) or "")
   local entry = animated[key]
   if entry == nil then
     entry = newEntry(map, base, baked)
@@ -949,10 +949,60 @@ function TerrainAtlas.animate(map, colors, base, baked)
   return entry.image
 end
 
+-- Safari owns a local grass/dry-earth treatment, never a global palette swap.
+local safariMaps={SAFARI_ZONE_CENTER=true,SAFARI_ZONE_EAST=true,SAFARI_ZONE_NORTH=true,SAFARI_ZONE_WEST=true}
+-- Shared with the distant floor so it uses this terrain treatment too.
+function TerrainAtlas.safariGroundColor(map)
+ if map and safariMaps[map.id] and map.tileset and map.tileset.id=='FOREST' then
+  return {.48,.50,.265,1}
+ end
+end
+local safariAtlases={}
+local function releaseSafari(entry)
+ if entry then entry.image:release();entry.data:release()end
+end
+local function safariGround(map,base,baked)
+ if not(safariMaps[map.id]and map.tileset.id=='FOREST')then return base,baked end
+ local old=safariAtlases[map.id]
+ if old and old.base==base then return old.image,old.data end
+ local ok,entry=pcall(function()
+  local raw=baked
+  if not raw then
+   love.graphics.push('all');love.graphics.setShader();love.graphics.setDepthMode()
+   raw=readback(base)
+   love.graphics.pop()
+  end
+  if not raw then return nil end
+  local w,h=raw:getDimensions();local data=love.image.newImageData(w,h);data:paste(raw,0,0,0,0,w,h)
+  if not baked then raw:release()end
+  local perRow=map.tileset.tilesPerRow or 16
+  for _,tile in ipairs({0,48,32,52,55,57,72,73,74,80,81,82,83,95})do
+   local sx,sy=tile%perRow*8,math.floor(tile/perRow)*8
+   for y=0,7 do for x=0,7 do
+    local rr,gg,bb,aa=data:getPixel(sx+x,sy+y)
+    if tile==0 or tile==48 then
+     local hsh=(x*37+y*61+x*y*11)%97
+     local c={.48,.50,.265}
+     if hsh<12 then c={.53,.46,.29}elseif hsh>88 then c={.61,.57,.34}elseif hsh<23 then c={.40,.44,.235}end
+     data:setPixel(sx+x,sy+y,c[1],c[2],c[3],aa)
+    elseif gg>rr*1.08 and gg>bb*1.3 then
+     local v=math.max(rr,gg,bb)
+     data:setPixel(sx+x,sy+y,.19+v*.33,.25+v*.31,.095+v*.19,aa)
+    end
+   end end
+  end
+  local image=love.graphics.newImage(data);image:setFilter('nearest','nearest')
+  return {base=base,image=image,data=data}
+ end)
+ if ok and entry then releaseSafari(old);safariAtlases[map.id]=entry;return entry.image,entry.data end
+ return base,baked
+end
+
 function TerrainAtlas.forMap(map, colors)
   local base, baked = staticAtlas(map, colors)
   if not base then return nil end
   base, baked = communityAtlas(map, colors, base, baked)
+  base, baked = safariGround(map, base, baked)
   return TerrainAtlas.animate(map, colors, base, baked) or base
 end
 
@@ -1061,6 +1111,7 @@ end
 -- per map ever entered, and each pins the engine's own baked ImageData
 -- alive behind it.
 function TerrainAtlas.setLive(live)
+  for id,entry in pairs(safariAtlases)do if not live[id]then releaseSafari(entry);safariAtlases[id]=nil end end
   for key, entry in pairs(animated) do
     if entry and entry.mapId and not live[entry.mapId] then
       releaseAnimatedEntry(entry)
@@ -1075,6 +1126,8 @@ function TerrainAtlas.setLive(live)
 end
 
 function TerrainAtlas.invalidate()
+  for _,entry in pairs(safariAtlases)do releaseSafari(entry)end
+  safariAtlases={}
   cache = {}
   cacheData = {}
   community = {}

--- a/lib/VoxelMeshDisk.lua
+++ b/lib/VoxelMeshDisk.lua
@@ -67,7 +67,7 @@ local STATIC_PLAYTHROUGH = "bavc_static_mesh_v2"
 -- Jagged TEST38 masonry, ordinary floors and the distant perimeter are locked.
 -- Revision 31 adds explicit rear entrances, clean rear facades, cave exit
 -- portals and hanging scrolls while retaining the current disk-record layout.
-Disk.CACHE_REVISION = 32
+Disk.CACHE_REVISION = 33
 -- Patch releases which do not change emitted vertices must keep the existing
 -- world cache usable. This token matches the first static-mesh-cache-v2 build;
 -- CACHE_REVISION, not the public mod version, owns geometry compatibility.

--- a/lib/VoxelScene.lua
+++ b/lib/VoxelScene.lua
@@ -30,6 +30,8 @@ local WorldUnderlay = V.require("WorldUnderlay")
 local WorldFillProps = V.require("WorldFillProps")
 local GranitePillars = V.require("GranitePillars")
 local ShipHull = V.require("ShipHull")
+local SafariStatues = V.require("SafariStatues")
+local SafariFoliage = V.require("SafariFoliage")
 local CommunityFlora = V.require("CommunityFlora")
 local CavePerimeter = V.require("CavePerimeter")
 local RenderDistance = V.require("RenderDistance")
@@ -143,7 +145,7 @@ end
 -- void to wants -- the overworld battle's arena shot is one of those. The
 -- gradient is added on top of this by skyFor, for the free-roam camera alone.
 function VoxelScene.skyColor(map, t)
-  if not (map and map.def and Map.isOutdoor(map.def)) then return nil end
+  if not (map and map.def and (Map.isOutdoor(map.def) or map.id == 'SAFARI_ZONE_CENTER')) then return nil end
   if not t or t <= 0 then return nil end
   local sky = VoxelScene.skyShade(SKY_SHADE, t)
   -- outdoors the flat fill follows the CLOCK: it becomes the hour's haze --
@@ -485,6 +487,8 @@ local function rebuildNeighborhood(state)
   cachedMasks = masks
   ChunkMesher.setLive(live)
   TerrainAtlas.setLive(live)
+  SafariFoliage.setLive(live)
+  SafariStatues.setLive(live)
   if GranitePillars.setLive then GranitePillars.setLive(live) end
 end
 
@@ -576,6 +580,8 @@ end
 
 function VoxelScene.invalidate()
   GranitePillars.invalidate()
+  SafariFoliage.invalidate()
+  SafariStatues.invalidate()
   CommunityFlora.invalidate()
   lastCompleteCanvas, lastCompleteW, lastCompleteH = nil, 0, 0
   lastCompleteMapId = nil
@@ -1092,6 +1098,10 @@ local function castShadows(state, terrain, nbMesh, posed, cx, cy, vw, vh,
   -- ShadowMap.sprites) so water can decline them: everything the world casts
   -- still shades a lake, a silhouette of somebody standing beside it does
   -- not. Ground, roofs and the characters themselves take them as before.
+  SafariFoliage.draw(state.map,0,0,ShadowMap)
+  for _,nb in ipairs(state.neighbors or {})do if RenderDistance.neighbor(nb,state.player)then SafariFoliage.draw(nb.map,nb.ox or 0,nb.oy or 0,ShadowMap)end end
+  SafariStatues.draw(state.map,0,0,ShadowMap,atlasFor(state.map))
+  for _,nb in ipairs(state.neighbors or {})do if RenderDistance.neighbor(nb,state.player)then SafariStatues.draw(nb.map,nb.ox or 0,nb.oy or 0,ShadowMap,atlasFor(nb.map))end end
   ShadowMap.sprites(true)
   -- authored figures cast too, for the same reason the flowers do: a
   -- handful of cards per map, and a person with no shadow reads as pasted on
@@ -1175,7 +1185,7 @@ function VoxelScene.render(state, w, h, vw, vh, paletteFor)
   -- every surface by. A CANOPY map (Viridian Forest) is the case between:
   -- the rig stays at noon and no sky is painted, but the hour's tint still
   -- falls through the leaves -- night reaches a forest floor.
-  local outdoor = state.map.def and Map.isOutdoor(state.map.def) or false
+  local outdoor = state.map.def and (Map.isOutdoor(state.map.def) or state.map.id == 'SAFARI_ZONE_CENTER') or false
   DayNight.applyRig(outdoor)
   Voxel3D.tint = DayNight.tint(outdoor or DayNight.isCanopy(state.map))
   -- and the window glass: the tileset's own panes (found in its art --
@@ -1306,6 +1316,10 @@ function VoxelScene.render(state, w, h, vw, vh, paletteFor)
     end
   end
 
+  SafariFoliage.draw(state.map,0,0)
+  for _,nb in ipairs(state.neighbors or {})do if RenderDistance.neighbor(nb,state.player)then SafariFoliage.draw(nb.map,nb.ox or 0,nb.oy or 0)end end
+  SafariStatues.draw(state.map,0,0,nil,atlasFor(state.map))
+  for _,nb in ipairs(state.neighbors or {})do if RenderDistance.neighbor(nb,state.player)then SafariStatues.draw(nb.map,nb.ox or 0,nb.oy or 0,nil,atlasFor(nb.map))end end
   GranitePillars.draw(state.map,0,0)
   for _,nb in ipairs(state.neighbors or {}) do if RenderDistance.neighbor(nb,state.player) then GranitePillars.draw(nb.map,nb.ox or 0,nb.oy or 0) end end
 

--- a/lib/WorldUnderlay.lua
+++ b/lib/WorldUnderlay.lua
@@ -134,6 +134,8 @@ function WorldUnderlay.resolve(state, colors)
       and biomes.black and biomes.black[mapId] then
     return COLORS.black, "nature:black"
   end
+  local safariColor = TerrainAtlas.safariGroundColor(map)
+  if safariColor then return safariColor, "safari:grass" end
   if map and map.def and not Map.isOutdoor(map.def) then
     local borderId = TileRenderer.borderBlockFor(map)
     if borderId == false then return { 0, 0, 0, 1 }, "indoor:black" end

--- a/tests/safari_wall_regression_test.lua
+++ b/tests/safari_wall_regression_test.lua
@@ -1,0 +1,54 @@
+
+local Decor=assert(loadfile('lib/HouseWallDecor.lua'))()
+local function key(x,y)return(y+64)*4096+x+64 end
+local fixtures={
+ {'HOUSE',2,{45,46,61,62}}, {'HOUSE',4,{72,73,73,75,88,89,90,91}},
+ {'REDS_HOUSE_2',2,{36,37,52,53}}, {'POKECENTER',2,{92,93,94,95}},
+ {'LOBBY',1,{6,22}}, {'LOBBY',2,{72,73,88,89}},
+}
+local count=0
+for _,f in ipairs(fixtures)do
+ local map={id='TEST',def={width=2,height=2},tileset={id=f[1],imageWidth=128,imageHeight=48}}
+ local S={tileAt={},shapeAt={},objectQuads={}}
+ for i,t in ipairs(f[3])do local k=key((i-1)%f[2],math.floor((i-1)/f[2]));S.tileAt[k]=t;S.shapeAt[k]={class='wall',h=16} end
+ Decor.build(S,map,0,7,0,7);assert(#S.objectQuads==#f[3])
+ for _,q in ipairs(S.objectQuads)do
+  assert(q[1][3]==q[3][3] and q[1][2]<q[3][2])
+  for _,uv in ipairs(q.uv)do assert(math.floor(uv[1]*128/8)+math.floor(uv[2]*48/8)*16==q.wallDecorSourceTile)end
+ end
+ Decor.build(S,map,0,7,0,7);assert(#S.objectQuads==#f[3],'repeated decoration')
+ count=count+#f[3]
+end
+local Gate=assert(loadfile('lib/SafariGatehouse.lua'))({})
+local map={id='SAFARI_ZONE_CENTER',tileset={id='FOREST'},def={warps={{x=14,y=25,destMap='SAFARI_ZONE_GATE',destWarp=3},{x=15,y=25,destMap='SAFARI_ZONE_GATE',destWarp=4}}}}
+assert(Gate.matches(map));map.def.warps[2].destWarp=9;assert(not Gate.matches(map))
+local F=assert(loadfile('lib/SafariFoliage.lua'))({require=function(n) assert(n=='Voxel3D');return {FACE_SHADE={1,1,1,1,1,1},FACE_CORNERS={{{1,0,0},{1,0,1},{1,1,1},{1,1,0}},{{0,0,1},{0,0,0},{0,1,0},{0,1,1}},{{0,1,0},{1,1,0},{1,1,1},{0,1,1}},{{0,0,1},{1,0,1},{1,0,0},{0,0,0}},{{0,0,1},{1,0,1},{1,1,1},{0,1,1}},{{1,0,0},{0,0,0},{0,1,0},{1,1,0}}},pushQuad=function(t,q)local b=q*4;for _,i in ipairs({1,2,3,1,3,4})do t[#t+1]=b+i end end}end})
+local verts=F.geometry({{x=0,z=0,tx=0,ty=0}})
+assert(#verts>0)
+for _,v in ipairs(verts)do assert(v[1]>=0 and v[1]<=16 and v[2]>=0 and v[2]<=20 and v[3]>=0 and v[3]<=16)end
+assert(#F.placements({id='VIRIDIAN_FOREST',tileset={id='FOREST'}})==0)
+local Stair=assert(loadfile('lib/InteriorStairs.lua'))()
+for _,class in ipairs({'stair_n','stair_down_n'})do
+ local S={tileAt={},objectQuads={}}
+ for i,t in ipairs({3,61,19,78})do S.tileAt[key((i-1)%2,math.floor((i-1)/2))]=t end
+ Stair.build(S,{tileset={imageWidth=128,imageHeight=48}},nil,0,0,{class=class,h=16})
+ for _,q in ipairs(S.objectQuads)do for _,uv in ipairs(q.uv)do
+  assert(math.floor(uv[1]*128/8)+math.floor(uv[2]*48/8)*16==q.stairSourceTile,'legacy stair crossed tile')
+ end end
+end
+print('PASS shared wall patterns, UV isolation, idempotence, gate guards, foliage bounds and legacy north stairs')
+
+local file=assert(io.open('lib/Structures.lua','rb'));local source=file:read('*a');file:close()
+local a=assert(source:find('local STAIR_STEPS =',1,true))
+local b=assert(source:find('function Structures.buildStairs',a,true))
+local fn=assert(loadstring('local function keyOf(x,y)return(y+64)*4096+x+64 end\n'..source:sub(a,b-1)..'\nreturn stairCell'))()
+for _,class in ipairs({'stair_e','stair_w','stair_down_e','stair_down_w'})do
+ local S={tileAt={},objectQuads={}}
+ for i,t in ipairs({3,61,19,78})do S.tileAt[key((i-1)%2,math.floor((i-1)/2))]=t end
+ fn(S,{tileset={imageWidth=128,imageHeight=48}},nil,0,0,{class=class,h=16})
+ assert(#S.objectQuads>0)
+ for _,q in ipairs(S.objectQuads)do for _,uv in ipairs(q.uv)do
+  assert(math.floor(uv[1]*128/8)+math.floor(uv[2]*48/8)*16==q.stairSourceTile,'legacy E/W stair crossed tile')
+ end end
+end
+print('PASS all four legacy east/west stair directions with nonadjacent source tiles')

--- a/tests/world_underlay_nature_test.lua
+++ b/tests/world_underlay_nature_test.lua
@@ -24,7 +24,7 @@ end }
 function namespace.require(name)
   return assert(({
     Voxel3D = { newMesh = function() end },
-    Mat4 = {}, ModSetting = ModSetting, TerrainAtlas = {},
+    Mat4 = {}, ModSetting = ModSetting, TerrainAtlas = { safariGroundColor = function() return nil end },
   })[name], "unexpected WorldUnderlay dependency " .. tostring(name))
 end
 package.loaded["src.world.Map"] = {


### PR DESCRIPTION
Repairs interior artwork wrapping onto wall lids/sides and freestanding stairs sampling unrelated atlas tiles, and adds the reviewed Safari scenery and original-statue rework.

- Keep house maps/windows, school blackboards, Center windows, store notices/pictures and upstairs gatehouse windows on vertical wall faces.
- Split legacy stair UVs at source-tile boundaries for rising and descending flights.
- Add the Safari rear gatehouse with solid doors, 376 voxel scrub placements, and matching grass/earth ground and distant fill.
- Rebuild 94 original statue placements with source colors and proper sides/backs; refine 65 tall pedestals.
- Bump mesh cache to 33. Preserve upstream cave materials, ship and facade behavior. Horizons artwork remains separate.

Validation on this branch: new wall/foliage/stair regressions; underlay, museum, scroll, facade-culling and real-map entrance tests; Lua syntax and whitespace checks. Full scope and test details are in docs/SAFARI_INTERIOR_REWORK.md.

Earlier native desktop candidate checks covered 169 maps, 3,624 stair faces, 626 wall-art faces, statue/foliage bounds, both Safari exits and Mansion switches. Those results precede this upstream port. Quest performance and native testing of the upstream port remain outstanding. The existing canopy test could not run because its tests/harness.lua dependency is absent.
