### PR TITLE
Add sharper leaf detail to Safari shrubs

### DIFF
--- a/docs/PROJECT_HANDOFF.md
+++ b/docs/PROJECT_HANDOFF.md
@@ -1,3 +1,7 @@
+## Safari leaf material detail (2026-09-06)
+
+Follow-up to merged PR48: replace constant-color foliage swatches with a 48x8 procedural leaf atlas. Preserve nearest filtering, olive palette, mesh positions, topology and draw-call count. Cache revision34 rebuilds UVs. Private desktop native comparisons and all 376 foliage footprint checks passed; geometry/topology were compared exactly against the prior material. Quest testing remains outstanding.
+
 ## Safari and interior texture follow-up (2026-09-06)
 
 Ported the approved desktop candidate onto master after PR47. See SAFARI_INTERIOR_REWORK.md for scope, preserved upstream changes, exact-checkout tests and platform limitations. Mesh cache revision33; no manifest version change. Horizons artwork remains separate.

--- a/lib/SafariFoliage.lua
+++ b/lib/SafariFoliage.lua
@@ -53,7 +53,7 @@ function M.geometry(ps)
    while true do local full=true;for j=0,w-1 do if not g.cells[(u+j)..','..(v+h)]then full=false;break end end;if not full then break end;h=h+1 end
    for y=v,v+h-1 do for x=u,u+w-1 do g.cells[x..','..y]=nil end end
    local ax=axes[g.f];local base,size={0,0,0},{0,0,0};base[ax[1]]=g.plane;base[ax[2]]=u;base[ax[3]]=v;size[ax[2]]=w;size[ax[3]]=h
-   local b=#verts;for _,c in ipairs(D.FACE_CORNERS[g.f])do verts[#verts+1]={(base[1]+c[1]*size[1])*2,(base[2]+c[2]*size[2])*2,(base[3]+c[3]*size[3])*2,(g.color-.5)/6,.5,D.FACE_SHADE[g.f]}end
+   local b=#verts;for _,c in ipairs(D.FACE_CORNERS[g.f])do verts[#verts+1]={(base[1]+c[1]*size[1])*2,(base[2]+c[2]*size[2])*2,(base[3]+c[3]*size[3])*2,((g.color-1)*8+.5+c[ax[2]]*7)/48,(.5+c[ax[3]]*7)/8,D.FACE_SHADE[g.f]}end
    for _,i in ipairs({1,2,3,1,3,4})do indices[#indices+1]=b+i end
   end end
  end
@@ -78,7 +78,21 @@ local function prepare(map)
  local ok,r=pcall(function()
   if not texture then
    local colors={{.12,.18,.065},{.24,.31,.105},{.34,.41,.14},{.43,.48,.20},{.64,.57,.29},{.29,.23,.12}}
-   local data=love.image.newImageData(6,1);for i,c in ipairs(colors)do data:setPixel(i-1,0,c[1],c[2],c[3],1)end
+   -- Two crisp leaf clusters per swatch, with shaded edges and a small ridge.
+   -- Geometry stays unchanged; nearest filtering preserves the pixel details.
+   local leafRows={
+    '00110000','01221000','12221000','01210000',
+    '00000110','00001221','00012221','00001210',
+   }
+   local data=love.image.newImageData(48,8)
+   for i,c in ipairs(colors)do for y=0,7 do for x=0,7 do
+    local shade=1
+    if i>=2 and i<=5 then
+     local d=tonumber(leafRows[y+1]:sub(x+1,x+1))
+     shade=d==0 and .83 or (d==1 and .96 or 1.16)
+    end
+    data:setPixel((i-1)*8+x,y,math.min(1,c[1]*shade),math.min(1,c[2]*shade),math.min(1,c[3]*shade),1)
+   end end end
    texture=love.graphics.newImage(data);data:release();texture:setFilter('nearest','nearest')
   end
   local verts,indices=M.geometry(ps)

--- a/lib/VoxelMeshDisk.lua
+++ b/lib/VoxelMeshDisk.lua
@@ -67,7 +67,7 @@ local STATIC_PLAYTHROUGH = "bavc_static_mesh_v2"
 -- Jagged TEST38 masonry, ordinary floors and the distant perimeter are locked.
 -- Revision 31 adds explicit rear entrances, clean rear facades, cave exit
 -- portals and hanging scrolls while retaining the current disk-record layout.
-Disk.CACHE_REVISION = 33
+Disk.CACHE_REVISION = 34
 -- Patch releases which do not change emitted vertices must keep the existing
 -- world cache usable. This token matches the first static-mesh-cache-v2 build;
 -- CACHE_REVISION, not the public mod version, owns geometry compatibility.


### PR DESCRIPTION
Follow-up to merged PR #48. Safari shrubs previously used flat color swatches on their voxel faces. This adds small procedural leaf clusters, shaded edges and highlights while retaining the approved olive palette and nearest filtering.

- Replace the 6x1 swatch texture with a 48x8 leaf-detail atlas and update face UVs.
- Preserve shrub geometry, footprint, lighting values, index topology and draw-call count.
- Bump mesh cache revision to 34 so prior UVs are rebuilt.

Validation: portable Safari/wall/stair regression passes; git diff --check passes. Earlier native desktop checks covered all 376 foliage placements and compared vertex positions, lighting and indices exactly against the prior material. Five side-by-side native views were reviewed. Quest appearance/performance remains untested. No Horizons changes.
