### PR TITLE
Add draft companion atmosphere effects API

### DIFF
--- a/PROJECT_HANDOFF.md
+++ b/PROJECT_HANDOFF.md
@@ -1,3 +1,11 @@
+# Companion atmosphere extension — 2026-09-07
+
+Optional draft effects API: owner-scoped resources, per-eye queues, bounded
+atmosphere state, desktop camera facts and native celestial fallback.
+See docs/COMPANION_ATMOSPHERE.md for contract and validation limits.
+The official 1.10.4 tree-lift flag no longer falsely blocks registration.
+No manifest/cache bump, companion art/runtime, or gameplay changes.
+
 # Requested world-feature restoration — 2026-09-06
 
 Audited the active `DramaticShapeVoxelMod` checkout on local `master` at

--- a/docs/COMPANION_ATMOSPHERE.md
+++ b/docs/COMPANION_ATMOSPHERE.md
@@ -1,0 +1,74 @@
+# Companion atmosphere effects (draft)
+
+Optional capability: atmosphere_effects_draft = 1.
+Register through exports.voxel_companion, require this capability, and call
+handle:effects(). Reacquire after invalidation. Revoked resources cannot be reused.
+This is a trusted installed-mod API, not an execution sandbox for untrusted GLSL.
+
+## Ownership
+
+Battle Art owns scene order, per-eye matrices, depth, camera and fallback.
+Extensions own their GLSL, geometry, pixels, simulation and audio.
+No Weather or Horizons assets/runtimes are included.
+Queue commands during companion update: simulate once, draw for each eye.
+Queues clear each update. Graphics state is restored after each effect.
+
+## Facade (colon methods)
+
+- material{source, uniforms={}, skyDepth=false}: GLSL up to 64 KiB. Defaults
+  support booleans, finite numbers and flat vectors. vp/eye are reserved host
+  uniforms, rebound each draw. Sky depth clamps far depth without changing terrain.
+- mesh{format, vertices}: float triangle attributes including VertexPosition.
+- updateMesh(token, vertices): same vertex count; recreate when the count changes.
+- image{width,height,rgba,wrap}: RGBA8, nearest filtering, repeat (default) or
+  clamp; maximum 2048 per dimension.
+- enqueue{phase,material,mesh,image,uniforms,blend,tint}: phases
+  celestial_before_clouds, sky_deck, translucent_after_actors.
+  Blend alpha/add uses alphamultiply; tint is RGBA. Uniform overrides must have
+  defaults. Sky materials cannot use the late phase. Depth lequal, no writes.
+- submitAtmosphere{sky,tint,haze}: bounded sky dim/flash, world
+  multiplier/additive tint and haze density/color. sky.replaceCelestials defers
+  the native body only with a valid owned draw. Failed replacement draws the
+  native body behind foreground terrain. Water suppresses its native body only
+  after successful replacement.
+- camera(): copied last-completed desktop center camera with frame age, map/mode,
+  eye/focus/basis, near/far/FOV. Stale or changed identity returns unavailable.
+  Raw stereo/external eyes are not treated as center-camera facts.
+- release(token), clear(): release resources or clear queued/state contributions.
+
+Per-owner budgets: 24 materials, 24 meshes, 8 images, 131072 vertices,
+16 MiB resources, 8 MiB uploads/update, 128 draws.
+Aggregate: 32 materials, 262144 vertices, 32 MiB.
+Faults revoke the failing owner only.
+
+No-provider values stay neutral. Stock sky behavior remains unchanged without a
+provider, including its legacy-uniform fallback. With a provider, optimized-out
+legacy uniforms no longer prevent dim/flash uploads. The reference
+VoxelCompanionAPI dispatcher is unchanged.
+
+## Integrity correction
+
+Official 1.10.4 Structures.lua contains __ds_tree_lift, so that flag alone is
+no longer evidence of a legacy KFP splice. Other marker checks remain.
+The compared source was byte-identical to the release, SHA256
+7f4c602651b298783ca5800314e770591e2d6f424534d4caedf619b9c5c43192.
+
+## Verification and limits
+
+Portable LuaJIT tests (run from mod root):
+- tests/atmosphere_camera_test.lua
+- tests/atmosphere_camera_projection_test.lua
+- tests/atmosphere_companion_integration_test.lua
+
+Separate private integration evidence: engine 0.2.24, 1200 frames through clear,
+rain, night, snow and storm, including NightSky runtime, no companion errors.
+Eight original effect paths had zero RGBA differences in native GPU comparisons.
+Cloud source compiled/rendered; full cloud reference parity was not established.
+The companion adapter/artwork are intentionally separate from this PR.
+Native tests also covered per-eye VP rebinding, owner isolation, celestial
+fallback/occlusion, stock-sky parity, and blend/tint/wrap state restoration.
+
+The API remains draft. Quest/GLES, stereo center-camera acquisition, ray/axis
+sky replacement and exact engine 0.2.53 gameplay remain unverified.
+The broad existing voxel_companion_api_v1_test suite fails on the baseline
+(observedAfterMutation nil); it is not counted as passing.

--- a/lib/AtmosphereCamera.lua
+++ b/lib/AtmosphereCamera.lua
@@ -1,0 +1,37 @@
+local M={}
+local function finite(n,lo,hi)return type(n)=='number' and n==n and n>=lo and n<=hi end
+local function vec(v)
+ if type(v)~='table' then return nil end
+ local r={};for i=1,3 do if not finite(v[i],-1048576,1048576)then return nil end;r[i]=v[i]end
+ return r
+end
+local function normal(v)
+ local l=math.sqrt(v[1]^2+v[2]^2+v[3]^2);if l<1e-8 then return nil end
+ return {v[1]/l,v[2]/l,v[3]/l}
+end
+local function cross(a,b)return {a[2]*b[3]-a[3]*b[2],a[3]*b[1]-a[1]*b[3],a[1]*b[2]-a[2]*b[1]}end
+local function copy(v)if type(v)~='table'then return v end;local r={};for k,x in pairs(v)do r[k]=copy(x)end;return r end
+function M.build(eye,focus,up,near,far,fov,mode)
+ eye,focus,up=vec(eye),vec(focus),vec(up)
+ if not eye or not focus or not up or not finite(near,.001,1048576)or not finite(far,near+.001,1048576)or not finite(fov,.001,math.pi-.001)then return nil end
+ if mode~='first_person' and mode~='third_person' and mode~='diorama'then return nil end
+ local forward=normal({focus[1]-eye[1],focus[2]-eye[2],focus[3]-eye[3]});if not forward then return nil end
+ local right=normal(cross(forward,up));if not right then return nil end
+ local vertical=normal(cross(right,forward));if not vertical then return nil end
+ return {eye=eye,focus=focus,forward=forward,right=right,up=vertical,near=near,far=far,fov=fov,mode=mode,overhead=mode~='diorama'}
+end
+function M.complete(facts,frame,mapId)
+ if not facts or not finite(frame,0,9007199254740991)or frame%1~=0 or type(mapId)~='string'or #mapId>128 then return nil end
+ local clean=M.build(facts.eye,facts.focus,facts.up,facts.near,facts.far,facts.fov,facts.mode);if not clean then return nil end
+ clean.sampledFrame=frame;clean.mapId=mapId;return clean
+end
+function M.snapshot(facts,frame,mapId,mode)
+ local function unavailable(reason)return {available=false,reason=reason,currentFrame=frame,source='last_completed_desktop_center'}end
+ if not facts then return unavailable('no_completed_center_camera')end
+ if facts.mapId~=mapId then return unavailable('map_changed')end
+ if facts.mode~=mode then return unavailable('camera_mode_changed')end
+ local age=frame-facts.sampledFrame
+ if age<0 or age>2 then return unavailable('stale_camera')end
+ local r=copy(facts);r.available=true;r.currentFrame=frame;r.ageFrames=age;r.source='last_completed_desktop_center';return r
+end
+return M

--- a/lib/AtmosphereEffects.lua
+++ b/lib/AtmosphereEffects.lua
@@ -1,0 +1,205 @@
+-- Generic private effect service. Authored GLSL/geometry stays in the extension.
+local V=...
+local Atmosphere=V.require('AtmosphereState')
+local M={}
+local PHASE={celestial_before_clouds=true,sky_deck=true,translucent_after_actors=true}
+local RESERVED={vp=true,eye=true}
+local LIMIT={materials=24,meshes=24,images=8,vertices=131072,bytes=16*1024*1024,uploads=8*1024*1024,draws=128}
+local function plain(v)return type(v)=='table' and getmetatable(v)==nil end
+local function finite(v,lo,hi)return type(v)=='number' and v==v and v>=lo and v<=hi end
+local function copy(v)if type(v)~='table'then return v end;local r={};for k,x in pairs(v)do r[k]=copy(x)end;return r end
+local function uniform(v)
+ if type(v)=='boolean' or finite(v,-1048576,1048576)then return v end
+ if not plain(v)then return nil,'invalid uniform' end
+ local out,n={},0
+ for k,x in pairs(v)do n=n+1;if n>16 or not finite(k,1,16)or k%1~=0 or not finite(x,-1048576,1048576)then return nil,'invalid uniform vector' end;out[k]=x end
+ if n==0 or n~=#out then return nil,'invalid uniform vector length' end
+ for i=1,n do if out[i]==nil then return nil,'uniform holes' end end
+ return out
+end
+local function uniformMap(values)
+ if not plain(values)then return nil,'uniforms must be plain data' end
+ local out,n={},0
+ for k,v in pairs(values)do
+  n=n+1;if n>48 or type(k)~='string'or #k>64 or not k:match('^[%a_][%w_]*$')or RESERVED[k]then return nil,'invalid or reserved uniform' end
+  local x,e=uniform(v);if e then return nil,e end;out[k]=x
+ end
+ return out
+end
+local function format(spec)
+ if not plain(spec)or #spec<1 or #spec>8 then return nil,'invalid vertex format' end
+ local out,seen,stride={}, {},0
+ for i,attr in ipairs(spec)do
+  if not plain(attr)or #attr~=3 or type(attr[1])~='string' or not attr[1]:match('^[%a_][%w_]*$') or #attr[1]>64 or seen[attr[1]] or attr[2]~='float' or not finite(attr[3],1,4)or attr[3]%1~=0 then return nil,'invalid vertex attribute' end
+  seen[attr[1]]=true;stride=stride+attr[3];out[i]={attr[1],attr[2],attr[3]}
+ end
+ if not seen.VertexPosition or stride>32 then return nil,'position required / excessive stride' end
+ return out,stride
+end
+local function vertices(data,stride)
+ if not plain(data)or #data<3 or #data%3~=0 or #data>LIMIT.vertices then return nil,'triangles must contain 3..131072 vertices' end
+ local out={}
+ for i,row in ipairs(data)do
+  if not plain(row)or #row~=stride then return nil,'vertex stride mismatch' end
+  out[i]={};for j=1,stride do if not finite(row[j],-1048576,1048576)then return nil,'invalid vertex' end;out[i][j]=row[j]end
+  for k in pairs(row)do if not finite(k,1,stride)or k%1~=0 then return nil,'extra vertex attribute' end end
+ end
+ for k in pairs(data)do if not finite(k,1,#data)or k%1~=0 then return nil,'invalid vertex index' end end
+ return out
+end
+function M.new()
+ local service={};local records={};local totalBytes,totalVerts,totalMaterials=0,0,0;local frame,eligible=0,false;local atmosphere=Atmosphere.new();local centerCamera={available=false,reason="no_completed_center_camera"}
+ local function drop(r)
+  if not r.live then return end;r.live=false
+  if r.lease then r.lease.dispose()end
+  for _,res in pairs(r.resources)do if res.gpu and res.gpu.release then pcall(res.gpu.release,res.gpu)end end
+  totalBytes=totalBytes-r.bytes;totalVerts=totalVerts-r.verts;totalMaterials=totalMaterials-r.counts.material
+  r.resources={};r.queue={};records[r.owner]=nil
+ end
+ function service.owner(owner)
+  if records[owner]then return records[owner].api end
+  local r={owner=owner,live=true,resources={},queue={},bytes=0,uploads=0,verts=0,counts={material=0,mesh=0,image=0}}
+  records[owner]=r;local api={};r.api=api
+  local function valid()return r.live and records[owner]==r end
+  local function resource(key,kind)local v=r.resources[key];return v and v.kind==kind and v or nil end
+  local function add(kind,gpu,extra)
+   local key={};extra=extra or {};extra.kind,extra.gpu=kind,gpu;r.resources[key]=extra;r.counts[kind]=r.counts[kind]+1;return key
+  end
+  function api:camera()if not valid()then return nil,"revoked owner" end;return copy(centerCamera)end
+  function api:material(spec)
+   if not valid()then return nil,'revoked owner' end
+   if not plain(spec)or type(spec.source)~='string'or #spec.source>65536 or #spec.source==0 or (r.counts.material>=LIMIT.materials or totalMaterials>=32) then return nil,'invalid material or budget' end
+   local defaults,e=uniformMap(spec.uniforms or {});if not defaults then return nil,e end
+   local source=spec.source
+   if spec.skyDepth==true then
+    source='#define position extension_position\n'..source..'\n#undef position\n#ifdef VERTEX\nvec4 position(mat4 m, vec4 v){vec4 c=extension_position(m,v);if(c.w>0.0)c.z=min(c.z,c.w*0.99999);return c;}\n#endif\n'
+   end
+   local ok,sh=pcall(love.graphics.newShader,source);if not ok then return nil,tostring(sh)end
+   for name,value in pairs(defaults)do
+    if not sh:hasUniform(name)then sh:release();return nil,'unused or missing uniform: '..name end
+    local sent,err=pcall(sh.send,sh,name,value);if not sent then sh:release();return nil,tostring(err)end
+   end
+   if not sh:hasUniform('vp')then sh:release();return nil,'material must consume host vp' end
+   totalMaterials=totalMaterials+1
+   return add('material',sh,{defaults=defaults,skyDepth=spec.skyDepth==true})
+  end
+  function api:mesh(spec)
+   if not valid()then return nil,'revoked owner'end
+   if not plain(spec)or r.counts.mesh>=LIMIT.meshes then return nil,'mesh budget'end
+   local fmt,stride=format(spec.format);if not fmt then return nil,stride end
+   local data,e=vertices(spec.vertices,stride);if not data then return nil,e end
+   local bytes=#data*stride*4
+   if r.bytes+bytes>LIMIT.bytes or r.uploads+bytes>LIMIT.uploads or r.verts+#data>LIMIT.vertices or totalBytes+bytes>32*1024*1024 or totalVerts+#data>262144 then return nil,'vertex budget'end
+   local ok,gpu=pcall(love.graphics.newMesh,fmt,data,'triangles','stream');if not ok then return nil,tostring(gpu)end
+   totalBytes,totalVerts=totalBytes+bytes,totalVerts+#data
+   r.bytes,r.uploads,r.verts=r.bytes+bytes,r.uploads+bytes,r.verts+#data
+   return add('mesh',gpu,{format=fmt,stride=stride,count=#data,bytes=bytes})
+  end
+  function api:updateMesh(key,data)
+   if not valid()then return nil,'revoked owner'end
+   local res=resource(key,'mesh');if not res then return nil,'foreign or missing mesh'end
+   local v,e=vertices(data,res.stride);if not v then return nil,e end
+   if #v~=res.count then return nil,'update must preserve vertex count'end
+   if r.uploads+res.bytes>LIMIT.uploads then return nil,'upload budget'end
+   local ok,err=pcall(res.gpu.setVertices,res.gpu,v);if not ok then return nil,tostring(err)end
+   r.uploads=r.uploads+res.bytes;return true
+  end
+  function api:image(spec)
+   if not valid()then return nil,'revoked owner'end
+   if plain(spec) and spec.wrap~=nil and spec.wrap~='clamp' and spec.wrap~='repeat' then return nil,'invalid image wrap' end
+   if not plain(spec)or not finite(spec.width,1,2048)or not finite(spec.height,1,2048)or spec.width%1~=0 or spec.height%1~=0 or type(spec.rgba)~='string'or #spec.rgba~=spec.width*spec.height*4 then return nil,'invalid rgba image'end
+   local bytes=#spec.rgba;if r.counts.image>=LIMIT.images or r.bytes+bytes>LIMIT.bytes or r.uploads+bytes>LIMIT.uploads or totalBytes+bytes>32*1024*1024 then return nil,'image budget'end
+   local ok,data=pcall(love.image.newImageData,spec.width,spec.height,'rgba8',spec.rgba);if not ok then return nil,tostring(data)end
+   local made,gpu=pcall(love.graphics.newImage,data);data:release();if not made then return nil,tostring(gpu)end
+   gpu:setFilter('nearest','nearest');gpu:setWrap(spec.wrap or 'repeat',spec.wrap or 'repeat')
+   totalBytes=totalBytes+bytes
+   r.bytes,r.uploads=r.bytes+bytes,r.uploads+bytes;return add('image',gpu,{bytes=bytes})
+  end
+  function api:release(key)
+   if not valid()then return nil,'revoked owner'end
+   local res=r.resources[key];if not res then return nil,'foreign resource'end
+   totalBytes=totalBytes-(res.bytes or 0);totalVerts=totalVerts-(res.count or 0);if res.kind=='material'then totalMaterials=totalMaterials-1 end
+   res.gpu:release();r.resources[key]=nil;r.counts[res.kind]=r.counts[res.kind]-1;r.bytes=r.bytes-(res.bytes or 0);r.verts=r.verts-(res.count or 0);return true
+  end
+  function api:enqueue(packet)
+   if not valid()then return nil,'revoked owner'end
+   if not eligible then return nil,'ineligible world frame'end
+   if not plain(packet)or not PHASE[packet.phase] or #r.queue>=LIMIT.draws then return nil,'phase or draw budget'end
+   if packet.blend~=nil and packet.blend~='alpha' and packet.blend~='add' then return nil,'invalid blend mode' end
+   local tint={1,1,1,1}
+   if packet.tint~=nil then
+    if not plain(packet.tint)then return nil,'invalid tint' end
+    local count=0
+    for k,v in pairs(packet.tint)do
+     count=count+1
+     if count>4 or not finite(k,1,4)or k%1~=0 or not finite(v,0,1)then return nil,'invalid tint component' end
+     tint[k]=v
+    end
+    if count~=4 then return nil,'tint requires four components' end
+   end
+   local mat,mesh=resource(packet.material,'material'),resource(packet.mesh,'mesh')
+   if not mat or mat.kind~='material' or not mesh or mesh.kind~='mesh' then return nil,'foreign or missing material/mesh'end
+   if mat.skyDepth and packet.phase=='translucent_after_actors' then return nil,'sky-depth material requires sky phase'end
+   local image=packet.image and resource(packet.image,'image');if packet.image and not image then return nil,'foreign image'end
+   local uniforms,e=uniformMap(packet.uniforms or {});if not uniforms then return nil,e end
+   for k in pairs(uniforms)do if mat.defaults[k]==nil then return nil,'undeclared uniform: '..k end end
+   r.queue[#r.queue+1]={phase=packet.phase,material=packet.material,mesh=packet.mesh,image=packet.image,uniforms=uniforms,blend=packet.blend or 'alpha',tint=tint};return true
+  end
+  function api:submitAtmosphere(packet)
+   if not valid()then return nil,'revoked owner'end
+   r.wantsCelestials=false
+   if type(packet)=='table' and type(packet.sky)=='table' and (packet.sky.dither~=nil or packet.sky.smooth~=nil) then if r.lease then r.lease.clear()end;return nil,'draft does not yet support celestial replacement/style overrides' end
+   if type(packet)=='table' and (packet.cloud~=nil or packet.front~=nil or packet.lightning~=nil)then if r.lease then r.lease.clear()end;return nil,'submit cloud/front/lightning through owned material uniforms' end
+   if not r.lease then local lease,err=atmosphere.acquire(owner);if not lease then return nil,err end;r.lease=lease end
+   local ok,err=r.lease.submit(packet,frame);r.wantsCelestials=ok and packet.sky and packet.sky.replaceCelestials==true or false;return ok,err
+  end
+  function api:clear()r.wantsCelestials=false;if not valid()then return nil,'revoked owner'end;r.queue={};if r.lease then r.lease.clear()end;return true end
+  return api
+ end
+ function service.beginFrame(id,allowed,camera)
+  frame,eligible=id,allowed==true;atmosphere.beginFrame(id,eligible)
+  centerCamera=eligible and copy(camera or {available=false,reason="no_completed_center_camera",currentFrame=id}) or {available=false,reason="ineligible_world_frame",currentFrame=id}
+  for _,r in pairs(records)do r.queue={};r.uploads=0;r.wantsCelestials=false;r.celestialDrawn=false end
+ end
+ function service.revoke(owner)local r=records[owner];if r then drop(r)end end
+ function service.reset()centerCamera={available=false,reason="host_reset"};local list={};for _,r in pairs(records)do list[#list+1]=r end;for _,r in ipairs(list)do drop(r)end;atmosphere.reset()end
+ function service.wantsCelestials()
+  if not eligible then return false end
+  for _,r in pairs(records)do if r.wantsCelestials then
+   for _,q in ipairs(r.queue)do if q.phase=='celestial_before_clouds' and r.resources[q.material] and r.resources[q.mesh] and(not q.image or r.resources[q.image])then return true end end
+  end end
+  return false
+ end
+ function service.celestialsDrawn()
+  for _,r in pairs(records)do if r.wantsCelestials and r.celestialDrawn then return true end end
+  return false
+ end
+ function service.snapshot()return atmosphere.snapshot()end
+ function service.clearState(owner)local r=records[owner];if r and r.lease then r.lease.clear()end end
+ function service.draw(phase,vp,eye,allowed)
+  if not eligible or not allowed or not PHASE[phase]then return true end
+  local g=love.graphics;local problems={}
+  if phase=='celestial_before_clouds'then for _,r in pairs(records)do r.celestialDrawn=false end end
+  local owners={};for owner in pairs(records)do owners[#owners+1]=owner end;table.sort(owners)
+  for _,owner in ipairs(owners)do local r=records[owner];local drew=false;local startErrors=#problems
+   for _,q in ipairs(r.queue)do if q.phase==phase then
+    local mat,mesh,img=r.resources[q.material],r.resources[q.mesh],q.image and r.resources[q.image]
+    if not mat or not mesh or(q.image and not img)then problems[#problems+1]='released queued resource';break end
+    g.push('all')
+    local ok,err=pcall(function()
+     g.setShader(mat.gpu);mat.gpu:send('vp','row',vp)
+     if mat.gpu:hasUniform('eye')then mat.gpu:send('eye',eye)end
+     for k,v in pairs(mat.defaults)do local value=q.uniforms[k];if value==nil then value=v end;mat.gpu:send(k,value)end
+     mesh.gpu:setTexture(img and img.gpu or nil)
+     g.setDepthMode('lequal',false);g.setMeshCullMode('none');g.setBlendMode(q.blend,'alphamultiply');g.setColor(q.tint[1],q.tint[2],q.tint[3],q.tint[4]);g.draw(mesh.gpu)
+    end)
+    g.pop()
+    if not ok then problems[#problems+1]=tostring(err);break end;drew=true
+   end end
+   if #problems>startErrors then drop(r)elseif phase=='celestial_before_clouds'then r.celestialDrawn=drew;atmosphere.celestialStatus(owner,drew)end
+  end
+  if #problems>0 then return nil,table.concat(problems,'\n')end;return true
+ end
+ return service
+end
+return M

--- a/lib/AtmosphereState.lua
+++ b/lib/AtmosphereState.lua
@@ -1,0 +1,76 @@
+-- Private contract prototype; no advertised renderer capabilities.
+local M={}
+local function num(a,b)return {kind='number',lo=a,hi=b}end
+local function vec(n,a,b)return {kind='vector',n=n,lo=a,hi=b}end
+local u,b,rgb=num(0,1),{kind='boolean'},vec(3,0,1)
+local schema={sky={dim=u,flash=u,smooth=b,dither=b,replaceCelestials=b},
+ tint={multiplier=vec(3,0,2),additive=rgb},haze={density=num(0,.00010),color=rgb},
+ cloud={coverage=u,opacity=u,overcast=u,color=rgb,light=vec(3,0,2),phase=u,warp=u,density=u,drift=num(-1048576,1048576)},
+ front={x=num(-1048576,1048576),z=num(-1048576,1048576),radius=num(1,262144),axis=vec(2,-1,1),strength=u,canopy=u,fill=u,ready=u},
+ lightning={x=num(-1048576,1048576),z=num(-1048576,1048576),radius=num(1,262144),strength=u}}
+local function finite(v,a,b)return type(v)=='number' and v==v and v>=a and v<=b end
+local function plain(t)return type(t)=='table' and getmetatable(t)==nil end
+local function copy(t)local r={};for k,v in pairs(t)do r[k]=type(v)=='table' and copy(v) or v end;return r end
+local function parse(v,s,path)
+ if s.kind=='number'then if not finite(v,s.lo,s.hi)then return nil,path..': invalid number' end;return v end
+ if s.kind=='boolean'then if type(v)~='boolean'then return nil,path..': invalid boolean' end;return v end
+ if not plain(v)then return nil,path..': expected plain table' end
+ local out,n={},0
+ for k,x in pairs(v)do
+  n=n+1
+  if s.kind=='vector'then
+   if n>s.n or not finite(k,1,s.n) or k%1~=0 or not finite(x,s.lo,s.hi)then return nil,path..': invalid vector' end
+   out[k]=x
+  else
+   if n>16 or type(k)~='string' or not s[k]then return nil,path..': unknown field' end
+   local value,err=parse(x,s[k],path..'.'..k);if err then return nil,err end;out[k]=value
+  end
+ end
+ if s.kind=='vector' and n~=s.n then return nil,path..': vector missing component' end
+ return out
+end
+function M.validate(packet)
+ local r,err=parse(packet,schema,'atmosphere');if not r then return nil,err end
+ for _,name in ipairs({'front','lightning'})do
+  local f=r[name];if f then for _,key in ipairs({'x','z','radius','strength'})do if f[key]==nil then return nil,name..': missing '..key end end end
+ end
+ if r.front then
+  local a=r.front.axis;if not a then return nil,'front: missing axis' end
+  local length=math.sqrt(a[1]^2+a[2]^2);if length<1e-9 then return nil,'front: zero axis' end
+  a[1],a[2]=a[1]/length,a[2]/length
+ end
+ if r.haze and (r.haze.density or 0)>0 and not r.haze.color then return nil,'haze: missing color' end
+ return r
+end
+function M.new()
+ local R={};local token,owner,frame,eligible,state,ready=nil,nil,nil,false,nil,false
+ local function clear()state=nil;ready=false end
+ function R.beginFrame(id,allowed)
+  assert(finite(id,0,9007199254740991) and id%1==0,'invalid frame')
+  if frame and id<frame then return nil,'decreasing frame' end
+  if frame==id then if not allowed then eligible=false;clear()end;return true end
+  frame,eligible=id,allowed==true;clear();return true
+ end
+ function R.acquire(id)
+  if type(id)~='string' or #id==0 or #id>128 then return nil,'invalid owner' end
+  if token then return nil,'atmosphere already owned' end
+  local key={};token,owner=key,id;local L={}
+  function L.submit(packet,id)
+   if token~=key then return nil,'revoked lease' end
+   if id~=frame or not eligible then clear();return nil,'ineligible or stale frame' end
+   local value,err=M.validate(packet);if not value then clear();return nil,err end
+   state=value;return true
+  end
+  function L.clear()if token~=key then return nil,'revoked lease' end;clear();return true end
+  function L.dispose()if token~=key then return nil,'revoked lease' end;token,owner=nil,nil;clear();return true end
+  return L
+ end
+ function R.celestialStatus(id,ok)ready=id==owner and ok==true and eligible end
+ function R.snapshot()
+  if not state or not eligible then return {} end
+  local r=copy(state);if r.sky and r.sky.replaceCelestials and not ready then r.sky.replaceCelestials=false end;return r
+ end
+ function R.reset()token,owner,frame,eligible=nil,nil,nil,false;clear()end
+ return R
+end
+return M

--- a/lib/Sky.lua
+++ b/lib/Sky.lua
@@ -217,6 +217,7 @@ uniform float glowAmt;  // twilight warmth around the low sun; 0 = none
 uniform vec2 glowPos;   // the sun disc, in canvas pixels (flat path)
 uniform float glowInvR; // 1 / the glow's reach in pixels (flat path)
 uniform vec3 glowDir;   // the sun's world direction (ray path)
+uniform vec2 weatherAtmosphere;
 uniform float glowInvA; // 1 / the glow's reach in radians (ray path)
 uniform vec3 glowColor;
 
@@ -270,6 +271,7 @@ vec4 effect(vec4 color, Image tex, vec2 tc, vec2 sc) {
     float g = glowAmt * pow(clamp(1.0 - glowD, 0.0, 1.0), 2.0);
     c = mix(c, glowColor, clamp(g, 0.0, 1.0) * 0.65);
   }
+  c = clamp(c * (1.0-weatherAtmosphere.x) + vec3(0.70,0.80,1.0)*weatherAtmosphere.y, 0.0, 1.0);
   return vec4(c, alpha);
 }
 ]]
@@ -528,6 +530,45 @@ local function paintDisc(body, edge, cell, w, h)
   g.setColor(1, 1, 1, 1)
 end
 
+-- Private draft: postpone only the native flat-camera disc until the owned
+-- celestial queue succeeds. On failure the same native pixels draw at sky depth.
+local deferredBody, fallbackDiscShader
+local function celestialTarget() local c=love.graphics.getCanvas();while type(c)=='table' do c=c[1] or c.canvas end;return c end
+Sky.nativeCelestialReplaced = false
+function Sky.resetDeferredBody()
+  deferredBody=nil;Sky.nativeCelestialReplaced=false;Sky.allowDeferredBody=false
+end
+local function deferBody(body,edge,cell,w,h)
+  if not body or not Sky.allowDeferredBody or not(V.companion and V.companion.canReplaceCelestials and V.companion:canReplaceCelestials())then return false end
+  if not fallbackDiscShader then
+    local ok,sh=pcall(love.graphics.newShader,[[
+#ifdef VERTEX
+vec4 position(mat4 m,vec4 v){vec4 c=m*v;c.z=c.w*0.99999;return c;}
+#endif
+#ifdef PIXEL
+vec4 effect(vec4 c,Image t,vec2 uv,vec2 px){return c*Texel(t,uv);}
+#endif
+]])
+    if not ok then return false end;fallbackDiscShader=sh
+  end
+  local b={};for k,v in pairs(body)do b[k]=v end
+  deferredBody={body=b,edge=edge,cell=cell,w=w,h=h,canvas=celestialTarget()};return true
+end
+function Sky.flushDeferredBody(replaced)
+  local p=deferredBody;deferredBody=nil
+  if not p then return true end
+  Sky.nativeCelestialReplaced=replaced==true
+  if replaced then return true end
+  local g=love.graphics
+  if celestialTarget()~=p.canvas then return nil,'native celestial target changed' end
+  g.push('all')
+  local ok,err=pcall(function()
+    g.origin();g.setShader(fallbackDiscShader);g.setDepthMode('lequal',false);g.setBlendMode('alpha','alphamultiply')
+    paintDisc(p.body,p.edge,p.cell,p.w,p.h)
+  end)
+  g.pop();return ok,err
+end
+
 -- ------- the disc as a TEXTURE, for the VR eyes
 --
 -- A VR eye must not paint the disc in screen space at all: a canvas-grid
@@ -674,37 +715,46 @@ function Sky.paint(w, h, sky, horizonY, cell, body, top, axis, ray)
     local d = ax * bx + ay * by + az * bz
     return math.acos(math.max(-1, math.min(1, d)))
   end
+  local weather = V.companion and V.companion.atmosphereSnapshot and V.companion:atmosphereSnapshot() or {}
   local sh = getShader()
+  local function send(name,...)
+    -- Release shaders optimized out legacy dither uniforms. Preserve the stock
+    -- no-provider path; an active atmosphere must not silently fall back before
+    -- its live uniforms are sent.
+    if weather.sky and sh.hasUniform and not sh:hasUniform(name)then return end
+    return sh:send(name,...)
+  end
   local ramp = sh and rampFor(bands)
   if not ramp then sh = nil end       -- no ramp, no gradient: paint it flat
   if sh then
     local sent = pcall(function()
       -- the bands arrive as a texture, one texel each, and `count` is that
       -- texture's width -- see rampFor for why they are not a uniform array
-      sh:send("ramp", ramp)
-      sh:send("count", #bands)
-      sh:send("edge", edge)
-      sh:send("top", math.min(top or 0, edge - 1))
-      sh:send("axisX", axis and axis[1] or 0)
-      sh:send("axisY", axis and axis[2] or 1)
-      sh:send("useRay", ray and 1 or 0)
+      send("ramp", ramp)
+      send("count", #bands)
+      send("edge", edge)
+      send("top", math.min(top or 0, edge - 1))
+      send("axisX", axis and axis[1] or 0)
+      send("axisY", axis and axis[2] or 1)
+      send("useRay", ray and 1 or 0)
       if ray then
-        sh:send("rayBase", ray.base)
-        sh:send("rayDu", ray.du)
-        sh:send("rayDv", ray.dv)
-        sh:send("raySpan", Sky.ELEV_SPAN)
-        sh:send("invSize", { 1 / w, 1 / h })
+        send("rayBase", ray.base)
+        send("rayDu", ray.du)
+        send("rayDv", ray.dv)
+        send("raySpan", Sky.ELEV_SPAN)
+        send("invSize", { 1 / w, 1 / h })
         -- the angular checker's cell: the angle one dither cell spans at
         -- the frame's centre, so the sky-glued grid comes out the same
         -- size on screen as the diorama's own pixel grid
-        sh:send("cellAng",
+        send("cellAng",
                 math.max(1e-4, rayAngle(0.5, 0, 0.5, 1) * skyCell / h))
       end
-      sh:send("cell", skyCell)
-      sh:send("start", Sky.DITHER and Sky.DITHER_START or 2)
-      sh:send("ditherBlend", Sky.DITHER_BLEND)
-      sh:send("alpha", alpha)
-      sh:send("glowAmt", glowAmt)
+      send("cell", skyCell)
+      send("start", Sky.DITHER and Sky.DITHER_START or 2)
+      send("ditherBlend", Sky.DITHER_BLEND)
+      send("alpha", alpha)
+      send("weatherAtmosphere", {weather.sky and weather.sky.dim or 0, weather.sky and weather.sky.flash or 0})
+      send("glowAmt", glowAmt)
       if glowAmt > 0 then
         local gc = body.glowColor or { 248, 224, 168 }
         if ray then
@@ -713,14 +763,14 @@ function Sky.paint(w, h, sky, horizonY, cell, body, top, axis, ray)
           -- of the frame, so the two paths agree on how wide it looks
           local dx, dy, dz = body.dx, body.dy, body.dz
           local l = math.sqrt(dx * dx + dy * dy + dz * dz)
-          sh:send("glowDir", { dx / l, dy / l, dz / l })
-          sh:send("glowInvA", 1 / math.max(
+          send("glowDir", { dx / l, dy / l, dz / l })
+          send("glowInvA", 1 / math.max(
             1e-3, rayAngle(0, 0.5, 1, 0.5) * Sky.GLOW_REACH))
         else
-          sh:send("glowPos", { body.x, body.y })
-          sh:send("glowInvR", 1 / math.max(1, w * Sky.GLOW_REACH))
+          send("glowPos", { body.x, body.y })
+          send("glowInvR", 1 / math.max(1, w * Sky.GLOW_REACH))
         end
-        sh:send("glowColor", { gc[1] / 255, gc[2] / 255, gc[3] / 255 })
+        send("glowColor", { gc[1] / 255, gc[2] / 255, gc[3] / 255 })
       end
     end)
     if sent then
@@ -736,6 +786,14 @@ function Sky.paint(w, h, sky, horizonY, cell, body, top, axis, ray)
     end
   end
   if not sh then
+    if weather.sky then
+      local adjusted={}
+      for i,c in ipairs(bands)do
+        adjusted[i]={}
+        for k,f in ipairs({.70,.80,1})do adjusted[i][k]=math.max(0,math.min(1,c[k]*(1-(weather.sky.dim or 0))+f*(weather.sky.flash or 0)))end
+      end
+      bands=adjusted
+    end
     paintFlat(w, h, bands, (axis or ray) and math.min(h, edge) or edge,
               alpha, cell, math.min(top or 0, edge - 1))
   end
@@ -744,7 +802,7 @@ function Sky.paint(w, h, sky, horizonY, cell, body, top, axis, ray)
   -- those cameras hang the baked disc in the world instead (drawWorldDisc,
   -- with Sky.discImage)
   if not (axis or ray) then
-    paintDisc(body, math.min(h, edge), cell, w, h)
+    if not deferBody(body, math.min(h, edge), cell, w, h) then paintDisc(body, math.min(h, edge), cell, w, h) end
   end
   g.setColor(1, 1, 1, 1)
 
@@ -758,6 +816,8 @@ end
 -- context builds a new one instead of drawing with a handle from the old. The
 -- ramp is a GPU object on the same context and goes with it.
 function Sky.invalidate()
+  Sky.resetDeferredBody()
+  if fallbackDiscShader then fallbackDiscShader:release();fallbackDiscShader=nil end
   shader = nil
   if cache.ramp and cache.ramp.release then pcall(cache.ramp.release, cache.ramp) end
   cache.ramp, cache.rampFor = nil, nil

--- a/lib/Voxel3D.lua
+++ b/lib/Voxel3D.lua
@@ -36,6 +36,7 @@ local DayNight = V.require("DayNight")
 local GlassMask = V.require("GlassMask")
 local PixelCanvas = V.require("PixelCanvas")
 
+local AtmosphereCamera = V.require("AtmosphereCamera")
 local Voxel3D = {}
 
 -- Vertex format shared by terrain chunks and character models: a position,
@@ -71,6 +72,7 @@ Voxel3D.FACE_SHADE = {
 }
 
 local SHADER = [[
+  varying float weatherDistance;
   varying float vShade;
   varying float vFacadeBack;
   varying vec3 vSun;          // this fragment's place in the sun's view
@@ -102,6 +104,7 @@ local SHADER = [[
     vGrid = vertex_position.xyz;
 #endif
     vec4 w = model * vertex_position;
+    weatherDistance = max(0.0, length(w.xyz-eye)-300.0);
     // All four vertices of a marked facade lie on one Z plane, so this is
     // constant across its fragments. Work it out here where `eye` belongs;
     // the pixel stage only needs the yes/no result.
@@ -241,6 +244,10 @@ local SHADER = [[
   uniform vec3 ghostColor;    // the flat silhouette colour
   uniform float ghost;        // 0 = shade normally, 1 = flatten to it
   uniform float lightOn;      // 1 = scene lighting, 0 = texture true-colour
+  uniform float weatherHaze;
+  uniform vec3 weatherHazeColor;
+  uniform vec3 weatherMul;
+  uniform vec3 weatherAdd;
   uniform vec3 dayTint;       // the hour's light on the world; 1,1,1 = noon
   uniform Image glassMask;    // opaque where the atlas texel is window glass
   uniform vec2 glassSize;     // the mask's dimensions: tc -> atlas texels
@@ -322,6 +329,8 @@ local SHADER = [[
     // detail; replacing the colour outright is what makes it read as one
     // solid silhouette. Last in the chain, so neither the sun nor a voxel
     // seam can mottle it.
+    rgb = clamp(rgb * weatherMul + weatherAdd, 0.0, 1.0);
+    rgb = mix(rgb, weatherHazeColor, min(0.28, 1.0-exp(-weatherHaze*weatherDistance)));
     rgb = mix(rgb, ghostColor, ghost);
     return vec4(rgb, 1.0) * color;
   }
@@ -719,7 +728,10 @@ end
 -- View and projection for a `vw` x `vh` world-pixel view centred on
 -- (cx, cy) in world pixels. Returns the combined matrix.
 function Voxel3D.viewProjection(cx, cy, vw, vh)
+  Voxel3D.atmosphereCameraCandidate=nil
   local cam = Voxel3D.camera
+  local externalEye=cam and (cam.view or cam.proj or cam.eyeIndex~=nil or cam.stereo==true)
+  local cameraMode=Voxel.isFirstPerson() and 'first_person' or (Voxel.isThirdPerson() and 'third_person' or 'diorama')
   if cam then
     cam = cameraWithDelta(cam)
     local eye, focus = cam.eye, cam.focus
@@ -746,6 +758,7 @@ function Voxel3D.viewProjection(cx, cy, vw, vh)
     -- may hand its own up: the first-person BLEND does, because its far
     -- end is the orbit, whose up leans with the pitch -- world up at the
     -- orbit's steep end degenerates against a straight-down view.
+    if not externalEye then Voxel3D.atmosphereCameraCandidate=AtmosphereCamera.build(eye,focus,cam.up or {0,1,0},math.max(1,dist*.05),dist*4+4096,cam.fov,cameraMode) end
     return Mat4.mul(proj, Mat4.lookAt(eye, focus, cam.up or { 0, 1, 0 }))
   end
 
@@ -777,6 +790,7 @@ function Voxel3D.viewProjection(cx, cy, vw, vh)
   -- downward. Winding flips with it, which is free here because the pass
   -- draws with culling off.
   proj = Mat4.mul(Mat4.scale(1, -1, 1), proj)
+  Voxel3D.atmosphereCameraCandidate=AtmosphereCamera.build(eye,focus,up,math.max(1,dist*.05),dist*4+4096,fov,cameraMode)
   return Mat4.mul(proj, Mat4.lookAt(eye, focus, up))
 end
 
@@ -877,6 +891,9 @@ end
 -- `slot` names which cached canvas to render into (see `slots` above);
 -- omitted is the free-roam world pass.
 function Voxel3D.beginScene(w, h, cx, cy, vw, vh, sky, slot, modelShadow, borrowed)
+  Voxel3D.atmosphereCameraCandidate=nil
+  Sky.resetDeferredBody()
+  Sky.allowDeferredBody = not borrowed and sky and sky.bands ~= nil
   -- the wireframe variant when the player has it on AND it built; either
   -- answer falls through to the plain scene rather than to no scene
   local grid = VoxelGrid.enabled()
@@ -1002,6 +1019,12 @@ function Voxel3D.beginScene(w, h, cx, cy, vw, vh, sky, slot, modelShadow, borrow
   pcall(sh.send, sh, "lightOn", 1)
   -- the hour's light, as the caller last set it (see Voxel3D.tint)
   pcall(sh.send, sh, "dayTint", Voxel3D.tint or { 1, 1, 1 })
+  local weather = (not borrowed and sky and V.companion and V.companion.atmosphereSnapshot)
+    and V.companion:atmosphereSnapshot() or {}
+  pcall(sh.send, sh, "weatherHaze", weather.haze and weather.haze.density or 0)
+  pcall(sh.send, sh, "weatherHazeColor", weather.haze and weather.haze.color or {0,0,0})
+  pcall(sh.send, sh, "weatherMul", weather.tint and weather.tint.multiplier or {1,1,1})
+  pcall(sh.send, sh, "weatherAdd", weather.tint and weather.tint.additive or {0,0,0})
   -- the window glass: the tileset's mask (or the blank -- the sampler is
   -- declared either way, and unbound is a driver-dependent crash), how lit
   -- the panes are, and the movement-fed glint as the caller last set it

--- a/lib/VoxelCompanion.lua
+++ b/lib/VoxelCompanion.lua
@@ -17,6 +17,8 @@ local Voxel3D = V.require("Voxel3D")
 local DayNight = V.require("DayNight")
 local Map = require("src.world.Map")
 
+local AtmosphereEffects = V.require("AtmosphereEffects")
+local AtmosphereCamera = V.require("AtmosphereCamera")
 local VoxelCompanion = {}
 VoxelCompanion.__index = VoxelCompanion
 
@@ -123,7 +125,8 @@ local LEGACY_MARKERS = {
     "Jump.swayZ(me)",
   },
   ["lib/Structures.lua"] = {
-    "__ds_tree_lift",
+    -- __ds_tree_lift is also in the official 1.10.4 Structures source;
+    -- that single flag is not sufficient evidence of a legacy splice.
     "__ds_round_key",
     "__ds_round_tomb",
     'rawget(_G, "__ds_ceiling_config")',
@@ -1810,6 +1813,7 @@ function VoxelCompanion.new(options)
     status = function() return copyIntegrity(self.integrity) end,
   }
 
+  self.atmosphereEffects = AtmosphereEffects.new()
   self.dispatcher = API.new({
     host_id = "BATTLE_ART_VOXEL_FORK",
     host_version = "1.9.7",
@@ -1826,6 +1830,8 @@ function VoxelCompanion.new(options)
   local raw = self.dispatcher:provider()
   self.provider = raw
   raw.capabilities.visual_object_overrides = 2
+  -- Draft service: full weather renderer readiness is deliberately not advertised.
+  raw.capabilities.atmosphere_effects_draft = 1
   local register = raw.register
   raw.register = function(spec)
     self.integrity = scanIntegrity(mod)
@@ -1906,6 +1912,7 @@ function VoxelCompanion:_observeState(state)
   local changed = mapIdentity ~= self.mapIdentity
     or timeIdentity ~= self.timeIdentity
   if changed then
+    if mapIdentity ~= self.mapIdentity and self.atmosphereEffects then self.atmosphereEffects.reset();self.completedAtmosphereCamera=nil end
     self.mapIdentity, self.timeIdentity = mapIdentity, timeIdentity
     self:worldChanged("observed_world_identity")
   end
@@ -1931,6 +1938,12 @@ function VoxelCompanion:update(dt, state)
   local changed = self:_observeState(state)
   self.frame = updateFrame(self, dt)
   self.frameDraws = 0
+  local def = self.state and self.state.map and self.state.map.def
+  local okOutdoor, outdoor = pcall(Map.isOutdoor, def)
+  local mode=Voxel.isFirstPerson() and 'first_person' or (Voxel.isThirdPerson() and 'third_person' or 'diorama')
+  local centerCamera=AtmosphereCamera.snapshot(self.completedAtmosphereCamera,self.frameIndex,self.frame.mapId,mode)
+  self.atmosphereEffects.beginFrame(self.frameIndex, (okOutdoor and outdoor == true)
+    or (self.state and self.state.map and self.state.map.id == "SAFARI_ZONE_CENTER"),centerCamera)
   if not self.started then return false end
   if (changed or self.worldPending) and self.state and self.state.map
       and self.clock >= self.nextSnapshotAttempt then
@@ -1998,7 +2011,7 @@ local function callExtension(self, record, stage, handler, ...)
   end, function(problem) return problem end)
   self.callbackRecord, self.callbackStage = previousRecord, previousStage
   self.callbackDepth = previousDepth
-  if not ok then error(result, 0) end
+  if not ok then self.atmosphereEffects.revoke(record.id); error(result, 0) end
   return unpackValues(result, 1, result.n)
 end
 
@@ -2025,7 +2038,7 @@ local function filterVisualCapability(source)
   if type(source) ~= "table" then return source end
   local out, write = {}, 0
   for index = 1, #source do
-    if source[index] ~= "visual_object_overrides" then
+    if source[index] ~= "visual_object_overrides" and source[index] ~= "atmosphere_effects_draft" then
       write = write + 1
       out[write] = source[index]
     end
@@ -2088,7 +2101,7 @@ wrapSpec = function(self, spec, record)
       local callbackName, callback = name, handler
       out[callbackName] = function(...)
         if callbackName == "invalidate" or callbackName == "dispose" then
-          self.visuals:clear(record)
+          self.visuals:clear(record); self.atmosphereEffects.revoke(record.id)
         end
         return callExtension(self, record, callbackName, callback, ...)
       end
@@ -2121,13 +2134,13 @@ wrapSpec = function(self, spec, record)
   if not hasDispose then
     out.lifecycle = out.lifecycle or {}
     out.lifecycle.dispose = function()
-      self.visuals:clear(record)
+      self.visuals:clear(record); self.atmosphereEffects.revoke(record.id)
     end
   elseif type(spec.lifecycle) == "table"
       and type(spec.lifecycle.dispose) == "function" then
     local handler = spec.lifecycle.dispose
     out.lifecycle.dispose = function(...)
-      self.visuals:clear(record)
+      self.visuals:clear(record); self.atmosphereEffects.revoke(record.id)
       return callExtension(self, record, "lifecycle.dispose", handler, ...)
     end
   end
@@ -2159,6 +2172,39 @@ function VisualHandle:status()
   return status
 end
 
+function VisualHandle:effects()
+  local state = visualHandleState(self)
+  if not state.raw:is_active() then return nil, "extension is not active" end
+  return state.host.atmosphereEffects.owner(state.raw:id())
+end
+
+function VoxelCompanion:completeAtmosphereCamera(state)
+  self.completedAtmosphereCamera=AtmosphereCamera.complete(Voxel3D.atmosphereCameraCandidate,
+    self.frameIndex,state and state.map and state.map.id)
+end
+
+function VoxelCompanion:atmosphereSnapshot()
+  return self.atmosphereEffects.snapshot()
+end
+
+function VoxelCompanion:canReplaceCelestials()
+  return self.started and self.atmosphereEffects.wantsCelestials()
+end
+function VoxelCompanion:celestialWasReplaced()
+  return V.require('Sky').nativeCelestialReplaced == true
+end
+function VoxelCompanion:renderAtmosphere(phase, state)
+  local def = state and state.map and state.map.def
+  local ok, outdoor = pcall(Map.isOutdoor, def)
+  local result,err=self.atmosphereEffects.draw(phase, Voxel3D.vp, Voxel3D.eye,
+    (ok and outdoor == true) or (state and state.map and state.map.id == "SAFARI_ZONE_CENTER"))
+  if phase=='celestial_before_clouds' then
+    local restored,restoreError=V.require('Sky').flushDeferredBody(self.atmosphereEffects.celestialsDrawn())
+    if not restored then return nil,restoreError end
+  end
+  return result,err
+end
+
 function VisualHandle:claim_visual_objects(ids)
   local state = visualHandleState(self)
   return state.host.visuals:claim(state.record, ids)
@@ -2167,14 +2213,14 @@ end
 function VisualHandle:invalidate(context, reason)
   local state = visualHandleState(self)
   local ok, err = state.raw:invalidate(context, reason)
-  if ok then state.host.visuals:clear(state.record) end
+  if ok then state.host.visuals:clear(state.record); state.host.atmosphereEffects.revoke(state.raw:id()) end
   return ok, err
 end
 
 function VisualHandle:dispose(context, reason)
   local state = visualHandleState(self)
   local ok, err = state.raw:dispose(context, reason)
-  if ok then state.host.visuals:remove(state.record) end
+  if ok then state.host.visuals:remove(state.record); state.host.atmosphereEffects.revoke(state.raw:id()) end
   return ok, err
 end
 
@@ -2209,6 +2255,8 @@ function VoxelCompanion:render(phase, state)
 end
 
 function VoxelCompanion:invalidate(reason)
+  self.completedAtmosphereCamera=nil
+  self.atmosphereEffects.reset()
   self:worldChanged(reason or "host_invalidated")
   self.visuals:clearAll()
   for key, mesh in pairs(self.meshes) do

--- a/lib/VoxelScene.lua
+++ b/lib/VoxelScene.lua
@@ -1442,6 +1442,12 @@ function VoxelScene.render(state, w, h, vw, vh, paletteFor)
     Voxel3D.endShadows()
   end
 
+  -- Draft effects: queued extension celestials and sky geometry retain per-eye depth.
+  if companion and companion.renderAtmosphere then
+    companion:renderAtmosphere("celestial_before_clouds", state)
+    companion:renderAtmosphere("sky_deck", state)
+  end
+
   -- and the water over the top of it, reflecting everything just drawn plus
   -- the sky the frame opened with (see drawWater).
   --
@@ -1566,8 +1572,12 @@ function VoxelScene.render(state, w, h, vw, vh, paletteFor)
     pcall(companion.render, companion, "translucent_after_actors", state)
   end
 
+  if companion and companion.renderAtmosphere then
+    companion:renderAtmosphere("translucent_after_actors", state)
+  end
   if state.map.id == "MUSEUM_1F" then V.require("MuseumFossils").drawGlass(state.map) end
   local finished = Voxel3D.endScene()
+  if finished and companion and companion.completeAtmosphereCamera then companion:completeAtmosphereCamera(state) end
   -- The delta belongs only to this overworld render. Do not let it reach a
   -- later battle or another owner of Voxel3D's placed-camera seam.
   Voxel3D.setCompanionCameraDelta(nil)

--- a/lib/Water.lua
+++ b/lib/Water.lua
@@ -1417,7 +1417,8 @@ function Water.sendSky(sh, ctx)
   send("skyStart", Sky.DITHER and Sky.DITHER_START or 2)
   send("skyOn", 1)
 
-  local body = DayNight.body()
+  local replaced = V.companion and V.companion.celestialWasReplaced and V.companion:celestialWasReplaced()
+  local body = not replaced and DayNight.body() or nil
   if not body then
     send("bodyOn", 0)
     send("glowAmt", 0)

--- a/tests/atmosphere_camera_projection_test.lua
+++ b/tests/atmosphere_camera_projection_test.lua
@@ -1,0 +1,18 @@
+local state={angle=0,FOCAL=1,isFirstPerson=function()return true end,isThirdPerson=function()return false end}
+local V={require=function(name)
+ if name=='VoxelState'then return state end
+ if name=='Mat4' or name=='AtmosphereCamera'then return assert(loadfile('lib/'..name..'.lua'))()end
+ return {}
+end}
+local R=assert(loadfile('lib/Voxel3D.lua'))(V)
+R.camera={eye={0,5,10},focus={0,5,0},up={0,1,0},fov=1}
+R.viewProjection(0,0,100,100)
+assert(R.atmosphereCameraCandidate.far==4136 and R.atmosphereCameraCandidate.near==1)
+assert(R.atmosphereCameraCandidate.mode=='first_person' and R.atmosphereCameraCandidate.overhead)
+R.camera.eye[1]=2;assert(R.atmosphereCameraCandidate.eye[1]==0)
+R.camera.view={};R.viewProjection(0,0,100,100);assert(R.atmosphereCameraCandidate==nil,'external eye published as center')
+R.camera=nil;state.isFirstPerson=function()return false end
+R.viewProjection(0,0,100,100)
+assert(R.atmosphereCameraCandidate.far==4496 and not R.atmosphereCameraCandidate.overhead)
+assert(R.atmosphereCameraCandidate.up[3]==-1)
+print('PASS actual Voxel3D placed/orbit projection facts and external-eye exclusion')

--- a/tests/atmosphere_camera_test.lua
+++ b/tests/atmosphere_camera_test.lua
@@ -1,0 +1,20 @@
+local C=assert(loadfile('lib/AtmosphereCamera.lua'))()
+local n=0;local function check(v,m)n=n+1;assert(v,m)end
+local eye={10,20,30};local f=assert(C.build(eye,{10,20,20},{0,1,0},1,4136,1,'first_person'));eye[1]=99
+check(f.eye[1]==10,'input alias');check(f.right[1]==1 and f.up[2]==1 and f.forward[3]==-1,'axes')
+local completed=assert(C.complete(f,4,'MAP'));f.eye[1]=77
+local a=C.snapshot(completed,5,'MAP','first_person');check(a.available and a.ageFrames==1 and a.far==4136 and a.overhead,'facts')
+a.eye[1]=66;check(C.snapshot(completed,5,'MAP','first_person').eye[1]==10,'output alias')
+for _,args in ipairs({{8,'MAP','first_person'},{5,'OTHER','first_person'},{5,'MAP','diorama'},{3,'MAP','first_person'}})do check(not C.snapshot(completed,unpack(args)).available,'stale facts accepted')end
+check(not C.snapshot(nil,1,'MAP','first_person').available,'invented camera')
+check(not C.build({0/0,0,0},{0,0,-1},{0,1,0},1,100,1,'first_person'),'NaN')
+check(not C.build({0,0,0},{0,0,0},{0,1,0},1,100,1,'first_person'),'zero direction')
+check(not C.build({0,0,0},{0,1,0},{0,1,0},1,100,1,'first_person'),'degenerate up')
+check(not C.build({0,0,0},{0,0,-1},{0,1,0},1,math.huge,1,'first_person'),'infinite far')
+local d=assert(C.build({0,10,0},{0,0,0},{0,0,-1},1,4496,1,'diorama'));check(not d.overhead and d.up[3]==-1,'diorama')
+local V={require=function(name)return assert(loadfile('lib/'..name..'.lua'))()end}
+local S=assert(loadfile('lib/AtmosphereEffects.lua'))(V).new();S.beginFrame(5,true,C.snapshot(completed,5,'MAP','first_person'))
+local api=S.owner('test');local c=api:camera();check(c.eye[1]==10,'facade source');c.eye[1]=0;check(api:camera().eye[1]==10,'facade alias')
+S.beginFrame(6,false);check(not api:camera().available and api:camera().eye==nil,'indoor facts leaked')
+S.revoke('test');check(api:camera()==nil,'revoked camera')
+print('PASS '..n..' camera facts checks')

--- a/tests/atmosphere_companion_integration_test.lua
+++ b/tests/atmosphere_companion_integration_test.lua
@@ -1,0 +1,329 @@
+-- Focused standalone contract tests for the Voxel Companion API v1 host.
+
+local checks = 0
+
+local function check(value, message)
+  checks = checks + 1
+  if not value then error("FAIL: " .. message, 0) end
+end
+
+local function equal(actual, expected, message)
+  checks = checks + 1
+  if actual ~= expected then
+    error(("FAIL: %s (expected %s, got %s)")
+      :format(message, tostring(expected), tostring(actual)), 0)
+  end
+end
+
+local function contains(text, fragment, message)
+  check(type(text) == "string" and text:find(fragment, 1, true) ~= nil, message)
+end
+
+local function treeSignature(value)
+  if type(value) ~= "table" then
+    if type(value) == "number" then return string.format("%.12g", value) end
+    return tostring(value)
+  end
+  local out = { "[" }
+  for index = 1, #value do out[#out + 1] = treeSignature(value[index]) end
+  out[#out + 1] = "]"
+  return table.concat(out, ",")
+end
+
+local function findTagged(value, tag, out)
+  out = out or {}
+  if type(value) ~= "table" then return out end
+  if value[1] == tag then out[#out + 1] = value end
+  for index = 1, #value do findTagged(value[index], tag, out) end
+  return out
+end
+
+local API = assert(loadfile("lib/VoxelCompanionAPI.lua"))()
+equal(API.VERSION, 1, "vendored dispatcher reports API v1")
+local VisualObjects = assert(loadfile("lib/VoxelVisualObjects.lua"))()
+local DrawFixture = assert(loadfile("tests/fixtures/voxel_companion_draw_v1.lua"))()
+
+local function newRunningDispatcher()
+  local dispatcher = API.new({ capabilities = {} })
+  check(dispatcher:attach({}), "fault-cleanup dispatcher attaches")
+  check(dispatcher:start({}), "fault-cleanup dispatcher starts")
+  return dispatcher
+end
+
+local function attemptCleanupReentry(dispatcher, id)
+  local attempts = {}
+  attempts.dispatch, attempts.dispatchError = dispatcher:dispatch("update", {})
+  attempts.register, attempts.registerError = dispatcher:register({
+    api = 1,
+    id = "cleanup.reentry." .. id,
+    lifecycle = { start = function() end },
+  }, {})
+  attempts.dispose, attempts.disposeError = dispatcher:dispose({}, "cleanup-reentry")
+  return attempts
+end
+
+local function expectCleanupReentryBlocked(attempts)
+  equal(attempts.dispatch, nil, "fault cleanup cannot reenter dispatch")
+  contains(attempts.dispatchError, "reentrant dispatch",
+    "fault cleanup reports blocked dispatch reentry")
+  equal(attempts.register, nil, "fault cleanup cannot register an extension")
+  contains(attempts.registerError, "register during dispatch",
+    "fault cleanup reports blocked registration")
+  equal(attempts.dispose, nil, "fault cleanup cannot dispose the dispatcher")
+  contains(attempts.disposeError, "dispose during dispatch",
+    "fault cleanup reports blocked dispatcher disposal")
+end
+
+local graphicsState = { color = "host", depth = "host", blend = "host" }
+local graphicsStack = {}
+local pushCount, popCount = 0, 0
+local sentinelUpdate = function() end
+
+love = {
+  update = sentinelUpdate,
+  system = { getOS = function() return "Windows" end },
+  image = {},
+  graphics = {},
+}
+
+function love.image.newImageData()
+  return { setPixel = function() end }
+end
+
+function love.graphics.newImage()
+  return {
+    setFilter = function() end,
+    release = function(self) self.released = true end,
+  }
+end
+
+function love.graphics.push(kind)
+  equal(kind, "all", "render isolation uses the full graphics state")
+  pushCount = pushCount + 1
+  graphicsStack[#graphicsStack + 1] = {
+    color = graphicsState.color,
+    depth = graphicsState.depth,
+    blend = graphicsState.blend,
+  }
+end
+
+function love.graphics.pop()
+  popCount = popCount + 1
+  local previous = table.remove(graphicsStack)
+  assert(previous, "unbalanced graphics pop")
+  graphicsState = previous
+end
+
+function love.graphics.setColor(r, g, b, a)
+  graphicsState.color = table.concat({ r, g, b, a }, ":")
+end
+
+function love.graphics.setDepthMode(mode, write)
+  graphicsState.depth = tostring(mode) .. ":" .. tostring(write)
+end
+
+function love.graphics.setBlendMode(mode, alpha)
+  graphicsState.blend = tostring(mode) .. ":" .. tostring(alpha)
+end
+
+local fakeVoxel3D = { metalRenderer=function() return false end,
+  FACE_CORNERS = {},
+  FACE_SHADE = {},
+  eye = { 0, 16, 32 },
+  camera = {
+    eye = { 8, 12, 24 },
+    focus = { 8, 8, 8 },
+    up = { 0, 1, 0 },
+    fov = math.rad(65),
+  },
+  draws = 0,
+  drawLog = {},
+  glassState = true,
+  failNextDraw = false,
+}
+
+for direction = 1, 6 do
+  fakeVoxel3D.FACE_CORNERS[direction] = {
+    { 0, 0, 0 }, { 1, 0, 0 }, { 1, 1, 0 }, { 0, 1, 0 },
+  }
+  fakeVoxel3D.FACE_SHADE[direction] = 1
+end
+
+function fakeVoxel3D.pushQuad(indices, offset)
+  indices[#indices + 1] = offset
+end
+
+function fakeVoxel3D.newMesh(vertices, indices)
+  return {
+    vertices = vertices,
+    indices = indices,
+    releaseCount = 0,
+    setTexture = function(self, texture)
+      if texture == nil and self.failDetach then
+        error("synthetic borrowed texture detach failure", 0)
+      end
+      self.texture = texture
+    end,
+    release = function(self)
+      self.releaseCount = self.releaseCount + 1
+      self.released = true
+    end,
+  }
+end
+
+function fakeVoxel3D.glass(enabled)
+  fakeVoxel3D.glassState = enabled
+end
+
+function fakeVoxel3D.draw(mesh, texture, model)
+  fakeVoxel3D.draws = fakeVoxel3D.draws + 1
+  if texture then mesh:setTexture(texture) end
+  fakeVoxel3D.drawLog[#fakeVoxel3D.drawLog + 1] = {
+    mesh = mesh,
+    texture = texture,
+    model = model,
+    color = graphicsState.color,
+    depth = graphicsState.depth,
+  }
+  if fakeVoxel3D.failNextDraw then
+    fakeVoxel3D.failNextDraw = false
+    error("synthetic GPU draw failure", 0)
+  end
+end
+
+local fakeMat4 = {
+  mul = function(a, b) return { a, b } end,
+  translate = function(x, y, z) return { "translate", x, y, z } end,
+  scale = function(x, y, z) return { "scale", x, y, z } end,
+  rotateY = function(value) return { "rotateY", value } end,
+  rotateX = function(value) return { "rotateX", value } end,
+  rotateZ = function(value) return { "rotateZ", value } end,
+}
+
+local fakeCameraMode = "first_person"
+local fakeVoxelState = {
+  isFirstPerson = function() return fakeCameraMode == "first_person" end,
+  isThirdPerson = function() return fakeCameraMode == "third_person" end,
+}
+
+local fakeDayNight
+fakeDayNight = {
+  period = "DAY",
+  isCanopy = function() return false end,
+  tod = function() return fakeDayNight.period end,
+  time = function() return 12.5 end,
+}
+
+local fakeShapes = {
+  [0] = { class = "grass", h = 0 },
+  [1] = { class = "wall", h = 8 },
+  [2] = { class = "tree", h = 12 },
+  [3] = { class = "water", h = 0 },
+  [4] = { class = "signpost", h = 16 },
+}
+
+local fakeTileShape = {
+  forMap = function() return fakeShapes end,
+}
+
+local fakeMapModule = {
+  isOutdoor = function() return true end,
+}
+
+local fakeChunkMesher = {}
+function fakeChunkMesher.visualObjectAnnotated(map, id)
+  for z = 0, (map.heightCells or 0) - 1 do
+    for x = 0, (map.widthCells or 0) - 1 do
+      if map:cellTile(x, z) == 4
+          and VisualObjects.id("BATTLE_ART_VOXEL_FORK", "signpost",
+            map.id, x, z) == id then
+        return true
+      end
+    end
+  end
+  return false
+end
+
+local fakeGame = { save = { version = "red" } }
+package.loaded["src.world.Map"] = fakeMapModule
+package.loaded["src.core.Game"] = fakeGame
+
+local function cleanMod()
+  local mod = { writes = 0, messages = {} }
+  function mod:read() return "-- clean upstream host\n" end
+  function mod:write()
+    self.writes = self.writes + 1
+    error("integrity scan must never write", 0)
+  end
+  mod.log = {
+    error = function(_, format, value)
+      mod.messages[#mod.messages + 1] = tostring(format):format(value)
+    end,
+  }
+  return mod
+end
+
+local function namespace(mod)
+  local modules = {
+    AtmosphereCamera = assert(loadfile("lib/AtmosphereCamera.lua"))(),
+    AtmosphereEffects = assert(loadfile('lib/AtmosphereEffects.lua'))({require=function(name) return assert(loadfile('lib/'..name..'.lua'))() end}),
+    VoxelCompanionAPI = API,
+    VoxelVisualObjects = VisualObjects,
+    Mat4 = fakeMat4,
+    TileShape = fakeTileShape,
+    ChunkMesher = fakeChunkMesher,
+    VoxelState = fakeVoxelState,
+    Voxel3D = fakeVoxel3D,
+    DayNight = fakeDayNight,
+  }
+  return {
+    mod = mod,
+    require = function(name)
+      local value = modules[name]
+      assert(value, "unexpected module " .. tostring(name))
+      return value
+    end,
+  }
+end
+
+local function worldState()
+  local map = {
+    id = "PALLET_TOWN",
+    widthCells = 2,
+    heightCells = 2,
+    def = { width = 1, height = 1, tileset = "OVERWORLD" },
+    tileset = { id = "OVERWORLD", image = "overworld-atlas" },
+  }
+  function map:cellTile(x, z) return z * 2 + x end
+  function map:isWalkableCell(x, z) return not (x == 1 and z == 0) end
+  function map:isWaterCell(x, z) return x == 1 and z == 1 end
+  function map:isGrassCell(x, z) return x == 0 and z == 0 end
+  function map:warpAtCell(x, z)
+    return x == 0 and z == 1 and { target = "HOUSE" } or nil
+  end
+  function map:isWarpTileCell() return false end
+  local player = { id = "player", px = 0, py = 0, cellX = 0, cellY = 0,
+    facing = "down", gh = 0 }
+  return {
+    map = map,
+    player = player,
+    entities = {
+      player,
+      { id = "npc-1", kind = "npc", px = 16, py = 16,
+        cellX = 1, cellY = 1, facing = "up" },
+    },
+    neighbors = {},
+  }
+end
+
+
+local C=assert(loadfile('lib/VoxelCompanion.lua'))(namespace(cleanMod()))
+local host=C.new{mod=cleanMod()};local h
+h=assert(host.provider.register{api=1,id='weather',requires={'atmosphere_effects_draft'},update=function()
+ local api=assert(h:effects());assert(api:submitAtmosphere{sky={dim=.3}})
+end})
+assert(host:start());host:update(.016,worldState())
+assert(host:atmosphereSnapshot().sky.dim==.3,'owner update did not publish')
+local api=assert(h:effects());assert(h:dispose());assert(not api:submitAtmosphere{sky={dim=.2}},'disposed handle live')
+assert(next(host:atmosphereSnapshot())==nil,'disposed state retained')
+print('PASS companion draft registration, update publication and disposal')


### PR DESCRIPTION
## Changes
Adds an optional draft companion atmosphere API so installed companion mods can submit their own sky/effect geometry through Battle Art's scene instead of patching its renderer.

- Owner-scoped materials, meshes and images with budgets, disposal and fault isolation.
- Per-eye draw queues, bounded sky/tint/haze contributions, and last-completed desktop camera facts.
- Native celestial fallback and water coordination; neutral behavior without a provider.
- Removes the official 1.10.4 __ds_tree_lift flag from legacy-splice detection. That flag alone was falsely blocking companion registration; other checks remain.

No Weather or Horizons runtime/artwork, desktop compatibility shim, or gameplay changes are included. Safari leaf detail remains in #49.

## Validation
Three included LuaJIT regressions pass: camera snapshots, actual placed/orbit projection and external-eye exclusion, and companion registration/publication/disposal.

Separate private integration testing completed 1200 frames on desktop engine 0.2.24 through clear/rain/night/snow/storm without companion errors. Native GPU checks covered state restoration, isolation, celestial fallback and stock-sky parity; eight effect paths matched their reference RGBA output.

The capability is explicitly draft. Quest/GLES, stereo center-camera acquisition, ray/axis sky replacement, and exact engine 0.2.53 gameplay are not verified. Full cloud reference parity is not claimed. The existing broad companion API suite has a baseline observedAfterMutation nil failure and is not counted as passing.

The API contract and validation limits are in docs/COMPANION_ATMOSPHERE.md.
