### PR TITLE
Fix remaining Safari lime tiles and refresh shrub caches

### DIFF
--- a/PROJECT_HANDOFF.md
+++ b/PROJECT_HANDOFF.md
@@ -1,3 +1,12 @@
+# Safari ground coverage and cache refresh — 2026-09-08
+
+Complete olive treatment for flat grass tile94 and hedge/edge variants13,79,84–93.
+Only four outdoor Safari atlases change; non-green detail/alpha retained on edges.
+Native engine0.2.27 captured all four maps: 567 changed atlas pixels, all outside
+new coverage unchanged; tile94 matches tile0 exactly. No Quest validation.
+Map-scoped cache token prevents pre-PR51 shrub vertices from surviving the upgrade;
+non-Safari fingerprints unchanged. No global cache revision bump.
+
 # PR #51 merge verification â€” 2026-09-08
 
 Merged PR head `1e07e7f` into current master `22f5b03` in an isolated worktree.

--- a/lib/TerrainAtlas.lua
+++ b/lib/TerrainAtlas.lua
@@ -979,12 +979,14 @@ local function safariGround(map,base,baked)
   -- The shared FOREST canopy uses the drawing anchored at 4 and edge tile 35.
   -- Recolor its green pixels only in this Safari-owned atlas; retain bark,
   -- source pixel detail and the original tree palette on every other map.
+  -- Hedge/edge variants retain their dark detail; tile 94 is flat grass.
   for _,tile in ipairs({0,48,32,52,55,57,72,73,74,80,81,82,83,95,
-    4,5,6,7,20,21,22,23,35,36,37,38,39,53,54})do
+    4,5,6,7,20,21,22,23,35,36,37,38,39,53,54,
+    13,79,84,85,86,87,88,89,90,91,92,93,94})do
    local sx,sy=tile%perRow*8,math.floor(tile/perRow)*8
    for y=0,7 do for x=0,7 do
     local rr,gg,bb,aa=data:getPixel(sx+x,sy+y)
-    if tile==0 or tile==48 then
+    if tile==0 or tile==48 or tile==94 then
      local hsh=(x*37+y*61+x*y*11)%97
      local c={.48,.50,.265}
      if hsh<12 then c={.53,.46,.29}elseif hsh>88 then c={.61,.57,.34}elseif hsh<23 then c={.40,.44,.235}end

--- a/lib/VoxelMeshDisk.lua
+++ b/lib/VoxelMeshDisk.lua
@@ -469,6 +469,11 @@ function Disk.fingerprint(map, slot, masks, kind)
     "row", tostring(tileset.tilesPerRow),
     "trueColor", tileset.trueColor and "1" or "0",
   }
+  -- PR51 changed shrub vertices/UVs; only Safari needs its meshes rebuilt.
+  if map.id=='SAFARI_ZONE_CENTER' or map.id=='SAFARI_ZONE_EAST'
+      or map.id=='SAFARI_ZONE_NORTH' or map.id=='SAFARI_ZONE_WEST' then
+    parts[#parts + 1] = "safari-canopy-source-shading-v1"
+  end
   -- Community visuals are real geometry/UV inputs. Keep each choice in the
   -- canonical fingerprint so a DEFAULT cache can never be reused for custom
   -- trees/fences/pillars (or vice versa), while every default remains the


### PR DESCRIPTION
Safari still showed lime checkerboard ground and green hedge edges after the olive palette update. This extends the existing Safari-only treatment to the missed variants and makes tile 94 match ordinary olive ground.

It also adds a cache fingerprint token only for the four outdoor Safari maps so pre-#51 shrub geometry cannot survive the update. Other maps keep their existing cache identities.

Validation: native engine 0.2.27 captures in all four Safari maps; 567 atlas pixels corrected, unchanged alpha and all pixels outside the added tile set; tile 94 matches tile 0. No Quest performance claim. No assets or gameplay changes.
