### PR TITLE
fix: avoid false legacy splice detection

### DIFF
--- a/lib/VoxelCompanion.lua
+++ b/lib/VoxelCompanion.lua
@@ -113,8 +113,7 @@ local LEGACY_MARKERS = {
   ["lib/VoxelScene.lua"] = {
     "pcall(Ceiling.draw",
     "pcall(Flora.draw",
-    "pcall(Backdrop.draw",
-    "pcall(SkyLayer.draw",
+    -- Backdrop/SkyLayer draw calls are native host calls as of 1.10.5.
     "local function __dsMod(name, statusKey)",
     "__ds_ceiling_status",
   },
@@ -134,15 +133,17 @@ local LEGACY_MARKERS = {
   ["lib/ChunkMesher.lua"] = {
     "ds_fp_ceilings __ds_round_base",
     "ds_fp_ceilings fastchunks",
-    'rawget(_G, "__ds_round_base")',
+    -- Current Legendary tree-cache code also reads __ds_round_base.
   },
   ["main.lua"] = {
     "Ceiling.setting",
     "__ds_ceiling_config",
   },
   ["lib/Ceiling.lua"] = { "payload-version:", "__ds_ceiling_config" },
-  ["lib/Backdrop.lua"] = { "payload-version:", "__ds_ceiling_config" },
-  ["lib/SkyLayer.lua"] = { "payload-version:", "__ds_ceiling_config" },
+  -- Current Backdrop/SkyLayer modules have payload-version provenance headers.
+  -- A header alone is not a legacy injection; keep the configuration marker.
+  ["lib/Backdrop.lua"] = { "__ds_ceiling_config" },
+  ["lib/SkyLayer.lua"] = { "__ds_ceiling_config" },
   ["lib/Flora.lua"] = { "payload-version:", "__ds_ceiling_config" },
   ["lib/Jump.lua"] = { "payload-version:", "Jump.eyeOffset" },
 }

--- a/tests/atmosphere_companion_integration_test.lua
+++ b/tests/atmosphere_companion_integration_test.lua
@@ -318,6 +318,38 @@ end
 
 
 local C=assert(loadfile('lib/VoxelCompanion.lua'))(namespace(cleanMod()))
+
+local currentMod = cleanMod()
+function currentMod:read(path)
+  local file = assert(io.open(path, "rb"))
+  local source = file:read("*a")
+  file:close()
+  return source
+end
+local currentHost = C.new({mod=currentMod})
+local currentHandle, currentError = currentHost.provider.register({
+  api=1, id='current-host-integrity', update=function() end,
+})
+assert(currentHandle, currentError or 'current built-in host markers were rejected')
+assert(currentHost:status().integrity.clean, 'current built-in markers reported contamination')
+
+local legacyMod = cleanMod()
+local contaminated = false
+function legacyMod:read(path)
+  if contaminated and path == "lib/VoxelScene.lua" then
+    return "local function __dsMod(name, statusKey) end\n"
+  end
+  return "-- clean upstream host\n"
+end
+local legacyHost = C.new({mod=legacyMod})
+contaminated = true
+local refused, legacyError = legacyHost.provider.register({
+  api=1, id='legacy-host-integrity', update=function() end,
+})
+assert(not refused, 'genuine legacy splice was accepted')
+assert(legacyError:find('legacy KFP splice markers detected in lib/VoxelScene.lua', 1, true),
+  'legacy rejection did not name the contaminated target')
+
 local host=C.new{mod=cleanMod()};local h
 h=assert(host.provider.register{api=1,id='weather',requires={'atmosphere_effects_draft'},update=function()
  local api=assert(h:effects());assert(api:submitAtmosphere{sky={dim=.3}})


### PR DESCRIPTION
## Summary

- stop treating native Backdrop/SkyLayer draw calls, their provenance headers, and the Legendary tree-cache read as legacy KFP splice evidence
- retain the actual configuration and host call-site markers so genuine legacy injections are still rejected
- add a regression that scans the current 1.10.8 checkout and separately verifies a real legacy marker is refused

## Why

Since 1.10.5, stock Battle Art contains these literals itself. The existing scanner therefore reports five false findings on an unmodified 1.10.8 host and can refuse Voxel Companion registration, which prevents UI/weather companions from attaching.

## Tests

- `luajit tests/atmosphere_companion_integration_test.lua`
- LuaJIT bytecode parse of `lib/VoxelCompanion.lua`
- LuaJIT bytecode parse of the focused integration test
- `git diff --check`

All pass. The regression confirms the narrowed scanner is clean on stock 1.10.8 while a genuine `local function __dsMod(name, statusKey)` injection is still rejected with the contaminated path.